### PR TITLE
Nathanf Aggregation Implementation

### DIFF
--- a/query/aggregate.go
+++ b/query/aggregate.go
@@ -136,7 +136,7 @@ type meanAggregator struct {
 }
 
 // The mean aggregator returns a meanAggregation pointer with a `sum` and `count` both 0.
-func (aggregator MeanAggregator) beginAggregation() aggregation {
+func (aggregator meanAggregator) beginAggregation() aggregation {
 	return &meanAggregation{
 		sum:   0,
 		count: 0,
@@ -164,7 +164,7 @@ func (aggregation *meanAggregation) result() float64 {
 type minAggregator struct {
 }
 
-func (aggregator MinAggregator) beginAggregation() aggregation {
+func (aggregator minAggregator) beginAggregation() aggregation {
 	return &minAggregation{
 		min: math.Inf(1),
 	}
@@ -204,7 +204,7 @@ func (aggregation *maxAggregation) result() float64 {
 	return aggregation.max
 }
 
-func useAggregator(aggregator Aggregator, values []float64) float64 {
+func useAggregator(aggregator aggregator, values []float64) float64 {
 	aggregation := aggregator.beginAggregation()
 	for _, v := range values {
 		aggregation.accumulate(v)
@@ -214,7 +214,7 @@ func useAggregator(aggregator Aggregator, values []float64) float64 {
 
 // applyAggregation takes an aggregation function ( [float64] => float64 ) and applies it to a given list of Timeseries
 // the list must be non-empty, or an error is returned
-func applyAggregation(group group, aggregator Aggregator) (api.Timeseries, error) {
+func applyAggregation(group group, aggregator aggregator) (api.Timeseries, error) {
 	list := group.List
 	tagSet := group.TagSet
 
@@ -247,7 +247,7 @@ func applyAggregation(group group, aggregator Aggregator) (api.Timeseries, error
 // `aggregateBy` takes a series list, an aggregator, and a set of tags.
 // It produces a SeriesList which is the result of grouping by the tags and then aggregating each group
 // into a single Series.
-func aggregateBy(list api.SeriesList, aggregator Aggregator, tags []string) (api.SeriesList, error) {
+func aggregateBy(list api.SeriesList, aggregator aggregator, tags []string) (api.SeriesList, error) {
 	// Begin by grouping the input:
 	groups := groupBy(list, tags)
 

--- a/query/aggregate.go
+++ b/query/aggregate.go
@@ -34,9 +34,9 @@ type groupResult struct {
 
 // If the given group will accept this given series (since it belongs to this group)
 // then bucketValid will return true.
-func bucketValid(row group, series api.Timeseries, tags []string) bool {
+func bucketValid(left api.TagSet, right api.TagSet, tags []string) bool {
 	for _, tag := range tags {
-		if row.TagSet[tag] != series.TagSet[tag] {
+		if left[tag] != right[tag] {
 			return false
 		}
 	}
@@ -55,18 +55,15 @@ func addToBucket(rows []group, series api.Timeseries, tags []string) []group {
 
 	// Next, find the best bucket for this series:
 	for i, row := range rows {
-		if bucketValid(row, series, tags) {
+		if bucketValid(row.TagSet, series.TagSet, tags) {
 			rows[i].List = append(rows[i].List, series)
 			return rows
 		}
 	}
-	tagSet := api.NewTagSet()
-	for _, tag := range tags {
-		tagSet[tag] = series.TagSet[tag]
-	}
+	// Otherwise, no bucket yet exists
 	return append(rows, group{
 		[]api.Timeseries{series},
-		tagSet,
+		newTags,
 	})
 }
 

--- a/query/aggregate.go
+++ b/query/aggregate.go
@@ -78,9 +78,9 @@ func groupBy(list api.SeriesList, tags []string) []group {
 
 // The aggregator interface is the public-facing way in which values are aggregated.
 // Aggregator objects are required to perform aggregation (max, min, range, mean, sum, etc.)
-// Their only interface method is the `beginAggregation()` method which returns an "aggregation".
+// Their only interface method is the `aggregate()` method which returns an "aggregation".
 type aggregator interface {
-	beginAggregation() aggregation
+	aggregate() aggregation
 }
 
 // An aggregation is a private interface which aggregates values for a particular SeriesList.
@@ -102,9 +102,9 @@ type aggregation interface {
 type sumAggregator struct {
 }
 
-// The `beginAggregation()` for sum returns a pointer to a new sumAggregation,
+// The `aggregate()` for sum returns a pointer to a new sumAggregation,
 // which has a sum set to 0.
-func (aggregator sumAggregator) beginAggregation() aggregation {
+func (aggregator sumAggregator) aggregate() aggregation {
 	return &sumAggregation{
 		sum: 0,
 	}
@@ -133,7 +133,7 @@ type meanAggregator struct {
 }
 
 // The mean aggregator returns a meanAggregation pointer with a `sum` and `count` both 0.
-func (aggregator meanAggregator) beginAggregation() aggregation {
+func (aggregator meanAggregator) aggregate() aggregation {
 	return &meanAggregation{
 		sum:   0,
 		count: 0,
@@ -161,7 +161,7 @@ func (aggregation *meanAggregation) result() float64 {
 type minAggregator struct {
 }
 
-func (aggregator minAggregator) beginAggregation() aggregation {
+func (aggregator minAggregator) aggregate() aggregation {
 	return &minAggregation{
 		min: math.Inf(1),
 	}
@@ -183,7 +183,7 @@ func (aggregation *minAggregation) result() float64 {
 type maxAggregator struct {
 }
 
-func (aggregator maxAggregator) beginAggregation() aggregation {
+func (aggregator maxAggregator) aggregate() aggregation {
 	return &maxAggregation{
 		max: math.Inf(-1),
 	}
@@ -202,7 +202,7 @@ func (aggregation *maxAggregation) result() float64 {
 }
 
 func useAggregator(aggregator aggregator, values []float64) float64 {
-	aggregation := aggregator.beginAggregation()
+	aggregation := aggregator.aggregate()
 	for _, v := range values {
 		aggregation.accumulate(v)
 	}

--- a/query/aggregate.go
+++ b/query/aggregate.go
@@ -79,10 +79,10 @@ func groupBy(list api.SeriesList, tags []string) []group {
 	return result
 }
 
-// The Aggregator interface is the public-facing way in which values are aggregated.
+// The aggregator interface is the public-facing way in which values are aggregated.
 // Aggregator objects are required to perform aggregation (max, min, range, mean, sum, etc.)
 // Their only interface method is the `beginAggregation()` method which returns an "aggregation".
-type Aggregator interface {
+type aggregator interface {
 	beginAggregation() aggregation
 }
 
@@ -102,12 +102,12 @@ type aggregation interface {
 // Aggregators will generally be empty structs (or an equivalent),
 // although they could alternatively store parameters which they can use
 // to which which aggregation to return, or to supply parameters to their aggregations.
-type SumAggregator struct {
+type sumAggregator struct {
 }
 
 // The `beginAggregation()` for sum returns a pointer to a new sumAggregation,
 // which has a sum set to 0.
-func (aggregator SumAggregator) beginAggregation() aggregation {
+func (aggregator sumAggregator) beginAggregation() aggregation {
 	return &sumAggregation{
 		sum: 0,
 	}
@@ -131,7 +131,8 @@ func (aggregation *sumAggregation) result() float64 {
 }
 
 // A mean aggregator is highly similar to a sum aggregator.
-type MeanAggregator struct {
+// It computes the aggregate mean for a seriesList
+type meanAggregator struct {
 }
 
 // The mean aggregator returns a meanAggregation pointer with a `sum` and `count` both 0.
@@ -159,7 +160,8 @@ func (aggregation *meanAggregation) result() float64 {
 	return aggregation.sum / float64(aggregation.count)
 }
 
-type MinAggregator struct {
+// The min aggregator is an aggregator that computes the aggregate minimum for a seriesList
+type minAggregator struct {
 }
 
 func (aggregator MinAggregator) beginAggregation() aggregation {
@@ -168,6 +170,7 @@ func (aggregator MinAggregator) beginAggregation() aggregation {
 	}
 }
 
+// The min aggregation is the aggregation for the min aggregator
 type minAggregation struct {
 	min float64
 }
@@ -179,15 +182,17 @@ func (aggregation *minAggregation) result() float64 {
 	return aggregation.min
 }
 
-type MaxAggregator struct {
+// The maxAggregator is an aggregator that computes the aggregate maximum for a seriesList
+type maxAggregator struct {
 }
 
-func (aggregator MaxAggregator) beginAggregation() aggregation {
+func (aggregator maxAggregator) beginAggregation() aggregation {
 	return &maxAggregation{
 		max: math.Inf(-1),
 	}
 }
 
+// The maxAggregation is an aggregation that computes the aggregate minimum for a seriesList
 type maxAggregation struct {
 	max float64
 }

--- a/query/aggregate.go
+++ b/query/aggregate.go
@@ -1,0 +1,197 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"github.com/square/metrics/api"
+)
+
+type groupRow struct {
+	List   []api.Timeseries
+	TagSet api.TagSet
+}
+
+type groupResult struct {
+	Results []groupRow
+}
+
+// If the given groupRow will accept this given series (since it belongs to this group)
+// then bucketValid will return true.
+func bucketValid(row groupRow, series api.Timeseries, tags []string) bool {
+	for _, tag := range tags {
+		if row.TagSet[tag] != series.TagSet[tag] {
+			return false
+		}
+	}
+	return true
+}
+
+// Adds the series to the corresponding bucket, possibly modifying the input `rows` and returning a new list.
+func addToBucket(rows []groupRow, series api.Timeseries, tags []string) []groupRow {
+	// First we delete all tags with names other than those found in 'tags'
+	newTags := api.NewTagSet()
+	for _, tag := range tags {
+		newTags[tag] = series.TagSet[tag]
+	}
+	// replace series' TagSet with newTags
+	series.TagSet = newTags
+
+	// Next, find the best bucket for this series:
+	for i, row := range rows {
+		if bucketValid(row, series, tags) {
+			rows[i].List = append(rows[i].List, series)
+			return rows
+		}
+	}
+	tagSet := api.NewTagSet()
+	for _, tag := range tags {
+		tagSet[tag] = series.TagSet[tag]
+	}
+	return append(rows, groupRow{
+		[]api.Timeseries{series},
+		tagSet,
+	})
+}
+
+// Groups the given SeriesList by tags, producing a list of lists (of type groupResult)
+func groupBy(list api.SeriesList, tags []string) groupResult {
+	result := []groupRow{}
+	for _, series := range list.Series {
+		result = addToBucket(result, series, tags)
+	}
+	return groupResult{
+		result,
+	}
+}
+
+// The Aggregator interface is the public-facing way in which values are aggregated.
+// Aggregator objects are required to perform aggregation (max, min, range, mean, sum, etc.)
+// Their only interface method is the `beginAggregation()` method which returns an "aggregation".
+type Aggregator interface {
+	beginAggregation() aggregaton
+}
+
+// An aggregation is a private interface which aggregates values for a particular SeriesList.
+// Because this interface is private, there would be no way to create aggregator outside this package.
+// If extension is desirable, this may change.
+// They can `accumulate(...)` value, and they can compute their `result()`.
+// During aggregation, `accumulate(...)` is called with each value corresponding to a given index,
+// with one call for each Timeseries inside the SeriesList.
+// Then, to compute the resulting value, `result()` is invoked exactly once.
+type aggregation interface {
+	accumulate(float64)
+	result() float64
+}
+
+// Here are example aggregators and their aggregation types.
+// Aggregators will generally be empty structs (or an equivalent),
+// although they could alternatively store parameters which they can use
+// to which which aggregation to return, or to supply parameters to their aggregations.
+type SumAggregator struct {
+}
+
+// The `beginAggregation()` for sum returns a pointer to a new sumAggregation,
+// which has a sum set to 0.
+func (aggregator SumAggregator) beginAggregation() aggregation {
+	return &sumAggregation{
+		sum: 0,
+	}
+}
+
+// The sumAggregation struct just contains the sum, which it will accumulate over time.
+type sumAggregation struct {
+	sum float64
+}
+
+// The accumulation for the sumAggregation consists of adding the value to the struct's sum.
+// Note that the interface is on the pointer `*sumAggregation` rather than `sumAggregation`
+// because it must be mutable.
+func (aggregation *sumAggregation) accumulate(value float64) {
+	aggregation.sum += value
+}
+
+// The result just returns this value.
+func (aggregation *sumAggregation) result() {
+	return aggregation.sum
+}
+
+// A mean aggregator is highly similar to a sum aggregator.
+type MeanAggregator struct {
+}
+
+// The mean aggregator returns a meanAggregation pointer with a `sum` and `count` both 0.
+func (aggregator MeanAggregator) beginAggregation() aggregation {
+	return &meanAggregation{
+		sum:   0,
+		count: 0,
+	}
+}
+
+// The `sum` and `count` fields totally define the meanAggregation's state.
+type meanAggregation struct {
+	sum   float64
+	count int
+}
+
+// The accumulaton function adds the value to the mean's running `sum`, and increments its `count`.
+func (aggregation *meanAggregation) accumulate(value float64) {
+	aggregation.sum += value
+	aggregation.count++
+}
+
+// The result returns the quotient of the running `sum` and `count`, computed through `accumulate()`
+func (aggregation *meanAggregation) result() float64 {
+	return aggregation.sum / aggregation.count
+}
+
+func useAggregator(aggregator Aggregator, values []float64) float64 {
+	aggregation := aggregator.beginAggregation()
+	for _, v := range float64 {
+		aggregation.accumulate(v)
+	}
+	return aggregation.result()
+}
+
+// applyAggregation takes an aggregation function ( [float64] => float64 ) and applies it to a given list of Timeseries
+// the list must be non-empty, or an error is returned
+func applyAggregation(list api.SeriesList, aggregator Aggregator, tagSet TagSet) (api.SeriesList, error) {
+	if len(list.Series) == 0 {
+		return api.SeriesList{}, EmptyAggregateError{}
+	}
+
+	series := api.Timeseries{
+		Values: make([]float64, len(list.Series[0].Values)), // The first Series in the given list is used to determine this length
+		TagSet: tagSet,                                      // The tagset is supplied by an argument (it will be the values grouped on)
+	}
+
+	// Make a slice of time to reuse.
+	// Each entry corresponds to a particular Series, all having the same index within their corresponding Series.
+	timeSlice := make([]float64, len(list.Series))
+
+	for i := range series.Values {
+		// We need to determine each value in turn.
+		for j := range timeSlice {
+			timeSlice[j] = list.Series[j].Values[i]
+		}
+		// Find the aggregated value:
+		series.Values[i] = useAggregator(aggregator, timeSlice)
+	}
+
+	return api.SeriesList{
+		Series:    series,
+		Timerange: list.Timerange,
+		Name:      list.Name,
+	}, nil
+}

--- a/query/aggregate.go
+++ b/query/aggregate.go
@@ -18,6 +18,8 @@ package query
 // and produces an aggregated SeriesList with one list per group, each group having been aggregated into it.
 
 import (
+	"math"
+
 	"github.com/square/metrics/api"
 )
 
@@ -155,6 +157,46 @@ func (aggregation *meanAggregation) accumulate(value float64) {
 // The result returns the quotient of the running `sum` and `count`, computed through `accumulate()`
 func (aggregation *meanAggregation) result() float64 {
 	return aggregation.sum / float64(aggregation.count)
+}
+
+type MinAggregator struct {
+}
+
+func (aggregator MinAggregator) beginAggregation() aggregation {
+	return &minAggregation{
+		min: math.Inf(1),
+	}
+}
+
+type minAggregation struct {
+	min float64
+}
+
+func (aggregation *minAggregation) accumulate(value float64) {
+	aggregation.min = math.Min(aggregation.min, value)
+}
+func (aggregation *minAggregation) result() float64 {
+	return aggregation.min
+}
+
+type MaxAggregator struct {
+}
+
+func (aggregator MaxAggregator) beginAggregation() aggregation {
+	return &maxAggregation{
+		max: math.Inf(-1),
+	}
+}
+
+type maxAggregation struct {
+	max float64
+}
+
+func (aggregation *maxAggregation) accumulate(value float64) {
+	aggregation.max = math.Max(aggregation.max, value)
+}
+func (aggregation *maxAggregation) result() float64 {
+	return aggregation.max
 }
 
 func useAggregator(aggregator Aggregator, values []float64) float64 {

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -369,6 +369,16 @@ var aggregatedTests = []struct {
 			},
 		},
 	},
+	{
+		[]string{},
+		sumAggregator{},
+		[]api.Timeseries{
+			api.Timeseries{
+				Values: []float64{5, 6, 9},
+				TagSet: map[string]string{},
+			},
+		},
+	},
 }
 
 func tagSetsEqual(leftSet api.TagSet, rightSet api.TagSet) bool {

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -17,6 +17,7 @@ package query
 import (
 	"github.com/square/metrics/api"
 
+	"math"
 	"testing"
 )
 
@@ -204,17 +205,9 @@ func Test_applyAggregation(t *testing.T) {
 		}
 		// Next, compare the aggregated values:
 		for i, correct := range testCase.Expected {
-			if abs(result.Values[i]-correct) > 1e-10 {
+			if math.Abs(result.Values[i]-correct) > 1e-10 {
 				t.Fatalf("applyAggregation() produces incorrect values on aggregation %+v; should be %+v but is %+v", testCase.Aggregator, testCase.Expected, result.Values)
 			}
 		}
-	}
-}
-
-func abs(x float64) float64 {
-	if x < 0 {
-		return -x
-	} else {
-		return x
 	}
 }

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"github.com/square/metrics/api"
+
+	"testing"
+)
+
+var (
+	listA = api.SeriesList{
+		Series: []api.Timeseries{
+			api.Timeseries{
+				Values: []float64{0, 0, 0},
+				TagSet: map[string]string{
+					"dc":   "A",
+					"env":  "production",
+					"host": "#1",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{1, 1, 1},
+				TagSet: map[string]string{
+					"dc":   "B",
+					"env":  "staging",
+					"host": "#1",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{2, 2, 2},
+				TagSet: map[string]string{
+					"dc":   "C",
+					"env":  "staging",
+					"host": "#1",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{3, 3, 3},
+				TagSet: map[string]string{
+					"dc":   "B",
+					"env":  "production",
+					"host": "#2",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{4, 4, 4},
+				TagSet: map[string]string{
+					"dc":   "C",
+					"env":  "staging",
+					"host": "#2",
+				},
+			},
+		},
+		Timerange: api.Timerange{},
+		Name:      "",
+	}
+)
+
+var aggregateTestCases = []struct {
+	Tags           []string
+	ExpectedGroups int
+}{
+	{
+		[]string{"dc"},
+		3,
+	},
+	{
+		[]string{"host"},
+		2,
+	},
+	{
+		[]string{"env"},
+		2,
+	},
+	{
+		[]string{"dc", "host"},
+		5,
+	},
+	{
+		[]string{"dc", "env"},
+		4,
+	},
+	{
+		[]string{"dc", "env"},
+		4,
+	},
+	{
+		[]string{},
+		1,
+	},
+}
+
+// Checks that groupBy() behaves as expected
+func Test_groupBy(t *testing.T) {
+	for i, testCase := range aggregateTestCases {
+		result := groupBy(listA, testCase.Tags)
+		if len(result.Results) != testCase.ExpectedGroups {
+			t.Errorf("Testcase %d results in %d groups when %d are expected (tags %+v)", i, len(result.Results), testCase.ExpectedGroups, testCase.Tags)
+			continue
+		}
+		for _, row := range result.Results {
+			// Further consistency checks are needed
+			for _, series := range row.List {
+				for _, tag := range testCase.Tags {
+					if series.TagSet[tag] != row.TagSet[tag] {
+						t.Errorf("Series %+v in row %+v has inconsistent tag %s", series, row, tag)
+						continue
+					}
+					if len(series.Values) != 3 {
+						t.Errorf("groupBy changed the number of elements in Values: %+v", series)
+						continue
+					}
+					originalIndex := int(series.Values[0])
+					if originalIndex < 0 || originalIndex >= len(listA.Series) {
+						t.Errorf("groupBy has changed the values in Values: %+v", series)
+						continue
+					}
+					original := listA.Series[originalIndex]
+					if original.TagSet[tag] != series.TagSet[tag] {
+						t.Errorf("groupBy changed a series' tagset[%s]: original %+v; result %+v", tag, original, series)
+						continue
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -150,7 +150,7 @@ var testGroup = group{
 			},
 		},
 		api.Timeseries{
-			Values: []float64{4, 4, 4, 4},
+			Values: []float64{4, 0, 4, 4},
 			TagSet: api.TagSet{
 				"env": "production",
 				"dc":  "A",
@@ -183,15 +183,15 @@ var aggregationTestCases = []struct {
 }{
 	{
 		sumAggregator{},
-		[]float64{3, 6, 8, 11},
+		[]float64{3, 2, 8, 11},
 	},
 	{
 		meanAggregator{},
-		[]float64{3.0 / 4.0, 6.0 / 4.0, 8.0 / 4.0, 11.0 / 4.0},
+		[]float64{3.0 / 4.0, 2.0 / 4.0, 8.0 / 4.0, 11.0 / 4.0},
 	},
 	{
 		maxAggregator{},
-		[]float64{4, 4, 4, 4},
+		[]float64{4, 2, 4, 4},
 	},
 	{
 		minAggregator{},

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -178,15 +178,15 @@ var testGroup = group{
 }
 
 var aggregationTestCases = []struct {
-	Aggregator Aggregator
+	Aggregator aggregator
 	Expected   []float64
 }{
 	{
-		SumAggregator{},
+		sumAggregator{},
 		[]float64{3, 6, 8, 11},
 	},
 	{
-		MeanAggregator{},
+		meanAggregator{},
 		[]float64{3.0 / 4.0, 6.0 / 4.0, 8.0 / 4.0, 11.0 / 4.0},
 	},
 }

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -107,11 +107,11 @@ var aggregateTestCases = []struct {
 func Test_groupBy(t *testing.T) {
 	for i, testCase := range aggregateTestCases {
 		result := groupBy(listA, testCase.Tags)
-		if len(result.Results) != testCase.ExpectedGroups {
-			t.Errorf("Testcase %d results in %d groups when %d are expected (tags %+v)", i, len(result.Results), testCase.ExpectedGroups, testCase.Tags)
+		if len(result) != testCase.ExpectedGroups {
+			t.Errorf("Testcase %d results in %d groups when %d are expected (tags %+v)", i, len(result), testCase.ExpectedGroups, testCase.Tags)
 			continue
 		}
-		for _, row := range result.Results {
+		for _, row := range result {
 			// Further consistency checks are needed
 			for _, series := range row.List {
 				for _, tag := range testCase.Tags {

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -189,6 +189,14 @@ var aggregationTestCases = []struct {
 		meanAggregator{},
 		[]float64{3.0 / 4.0, 6.0 / 4.0, 8.0 / 4.0, 11.0 / 4.0},
 	},
+	{
+		maxAggregator{},
+		[]float64{4, 4, 4, 4},
+	},
+	{
+		minAggregator{},
+		[]float64{-1, -1, 0, 2},
+	},
 }
 
 const epsilon = 1e-10 // epsilon is a constant for the maximum allowable error between correct test case answers and actual results
@@ -425,5 +433,4 @@ func Test_aggregateBy(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -404,6 +404,7 @@ func Test_aggregateBy(t *testing.T) {
 		aggregated, err := aggregateBy(testList, testCase.Aggregator, testCase.Tags)
 		if err != nil {
 			t.Error(err)
+			continue
 		}
 		// Check that aggregated looks correct.
 		// There should be two series

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -191,6 +191,8 @@ var aggregationTestCases = []struct {
 	},
 }
 
+const epsilon = 1e-10 // epsilon is a constant for the maximum allowable error between correct test case answers and actual results
+
 func Test_applyAggregation(t *testing.T) {
 	for _, testCase := range aggregationTestCases {
 		result, err := applyAggregation(testGroup, testCase.Aggregator)
@@ -205,9 +207,223 @@ func Test_applyAggregation(t *testing.T) {
 		}
 		// Next, compare the aggregated values:
 		for i, correct := range testCase.Expected {
-			if math.Abs(result.Values[i]-correct) > 1e-10 {
+			if math.Abs(result.Values[i]-correct) > epsilon {
 				t.Fatalf("applyAggregation() produces incorrect values on aggregation %+v; should be %+v but is %+v", testCase.Aggregator, testCase.Expected, result.Values)
 			}
 		}
 	}
+}
+
+var testList = api.SeriesList{
+	[]api.Timeseries{
+		api.Timeseries{
+			Values: []float64{0, 1, 2},
+			TagSet: api.TagSet{
+				"env":  "staging",
+				"dc":   "A",
+				"host": "q77",
+			},
+		},
+		api.Timeseries{
+			Values: []float64{4, 4, 4},
+			TagSet: api.TagSet{
+				"env":  "staging",
+				"dc":   "B",
+				"host": "r53",
+			},
+		},
+		api.Timeseries{
+			Values: []float64{-1, -1, 2},
+			TagSet: api.TagSet{
+				"env":  "production",
+				"dc":   "A",
+				"host": "y1",
+			},
+		},
+		api.Timeseries{
+			Values: []float64{0, 2, 0},
+			TagSet: api.TagSet{
+				"env":  "production",
+				"dc":   "A",
+				"host": "w20",
+			},
+		},
+		api.Timeseries{
+			Values: []float64{2, 0, 0},
+			TagSet: api.TagSet{
+				"env":  "production",
+				"dc":   "B",
+				"host": "t8",
+			},
+		},
+		api.Timeseries{
+			Values: []float64{0, 0, 1},
+			TagSet: api.TagSet{
+				"env":  "production",
+				"dc":   "C",
+				"host": "b38",
+			},
+		},
+	},
+	api.Timerange{
+		40,
+		280,
+		6,
+	},
+	"Test.List",
+}
+
+var aggregatedTests = []struct {
+	Tags       []string
+	Aggregator aggregator
+	Results    []api.Timeseries
+}{
+	{
+		[]string{"env"},
+		sumAggregator{},
+		[]api.Timeseries{
+			api.Timeseries{
+				Values: []float64{1, 1, 3},
+				TagSet: map[string]string{
+					"env": "production",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{4, 5, 6},
+				TagSet: map[string]string{
+					"env": "staging",
+				},
+			},
+		},
+	},
+	{
+		[]string{"dc"},
+		maxAggregator{},
+		[]api.Timeseries{
+			api.Timeseries{
+				Values: []float64{0, 2, 2},
+				TagSet: map[string]string{
+					"dc": "A",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{4, 4, 4},
+				TagSet: map[string]string{
+					"dc": "B",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{0, 0, 1},
+				TagSet: map[string]string{
+					"dc": "C",
+				},
+			},
+		},
+	},
+	{
+		[]string{"dc", "env"},
+		meanAggregator{},
+		[]api.Timeseries{
+			api.Timeseries{
+				Values: []float64{0, 1, 2},
+				TagSet: map[string]string{
+					"dc":  "A",
+					"env": "staging",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{-1.0 / 2.0, 1.0 / 2.0, 1.0},
+				TagSet: map[string]string{
+					"dc":  "A",
+					"env": "production",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{4, 4, 4},
+				TagSet: map[string]string{
+					"dc":  "B",
+					"env": "staging",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{2, 0, 0},
+				TagSet: map[string]string{
+					"dc":  "B",
+					"env": "production",
+				},
+			},
+			api.Timeseries{
+				Values: []float64{0, 0, 1},
+				TagSet: map[string]string{
+					"dc":  "C",
+					"env": "production",
+				},
+			},
+		},
+	},
+}
+
+func tagSetsEqual(leftSet api.TagSet, rightSet api.TagSet) bool {
+	for key, left := range leftSet {
+		right, ok := rightSet[key]
+		if !ok || left != right {
+			return false
+		}
+	}
+	return true
+}
+
+func Test_aggregateBy(t *testing.T) {
+
+	for _, testCase := range aggregatedTests {
+		aggregated, err := aggregateBy(testList, testCase.Aggregator, testCase.Tags)
+		if err != nil {
+			t.Error(err)
+		}
+		// Check that aggregated looks correct.
+		// There should be two series
+		if aggregated.Timerange != testList.Timerange {
+			t.Errorf("Expected aggregate's Timerange to be %+v but is %+v", testList.Timerange, aggregated.Timerange)
+			continue
+		}
+		if aggregated.Name != testList.Name {
+			t.Errorf("Expected aggregate's Name to be %s but is %s", testList.Name, aggregated.Name)
+			continue
+		}
+		if len(aggregated.Series) != len(testCase.Results) {
+			t.Errorf("Expected %d series in aggregation result but found %d", len(testCase.Results), len(aggregated.Series))
+			continue
+		}
+		// Lastly, we have to check that the values are correct.
+		// First, check that an aggregated series corresponding to each correct tagset:
+		for _, series := range testCase.Results {
+			found := false
+			for _, aggregate := range aggregated.Series {
+				if tagSetsEqual(series.TagSet, aggregate.TagSet) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("Expected to find series corresponding to %+v but could not in %+v", series.TagSet, aggregated)
+			}
+		}
+		// Next, each series will do the reverse-lookup and check that its values match the expected results.
+		// (It is neccesary to check both ways [see above] to ensure that the result doesn't contain just one of the series repeatedly)
+		for _, aggregate := range aggregated.Series {
+			// Any of the testCase results which it matches are candidates
+			for _, correct := range testCase.Results {
+				if tagSetsEqual(aggregate.TagSet, correct.TagSet) {
+					// Compare their values
+					for i := range aggregate.Values {
+						if math.Abs(aggregate.Values[i]-correct.Values[i]) > epsilon {
+							t.Errorf("For tagset %+v, result %+v does not match expected %+v", correct.TagSet, aggregate.Values, correct.Values)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
 }

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -381,10 +381,17 @@ var aggregatedTests = []struct {
 	},
 }
 
+// tagSetsEqual verifies that two tag sets are equal (contain the same keys and have the same values for these)
 func tagSetsEqual(leftSet api.TagSet, rightSet api.TagSet) bool {
 	for key, left := range leftSet {
 		right, ok := rightSet[key]
 		if !ok || left != right {
+			return false
+		}
+	}
+	for key := range rightSet {
+		_, ok := leftSet[key]
+		if !ok {
 			return false
 		}
 	}

--- a/query/aggregate_test.go
+++ b/query/aggregate_test.go
@@ -440,6 +440,10 @@ func Test_aggregateBy(t *testing.T) {
 			// Any of the testCase results which it matches are candidates
 			for _, correct := range testCase.Results {
 				if tagSetsEqual(aggregate.TagSet, correct.TagSet) {
+					if len(aggregate.Values) != len(correct.Values) {
+						t.Errorf("For tagset %+v, result %+v has a different length than expected %+v", correct.TagSet, aggregate.Values, correct.Values)
+						continue
+					}
 					// Compare their values
 					for i := range aggregate.Values {
 						if math.Abs(aggregate.Values[i]-correct.Values[i]) > epsilon {

--- a/query/errors.go
+++ b/query/errors.go
@@ -43,6 +43,7 @@ func (errors SyntaxErrors) Error() string {
 	return strings.Join(errorStrings, "\n")
 }
 
+// EmptyAggregateError is an Error for attempts to aggregate empty SeriesLists.
 type EmptyAggregateError struct {
 }
 
@@ -51,3 +52,4 @@ func (err EmptyAggregateError) Error() string {
 }
 
 var _ error = (*SyntaxError)(nil)
+var _ error = EmptyAggregateError{}

--- a/query/errors.go
+++ b/query/errors.go
@@ -43,4 +43,11 @@ func (errors SyntaxErrors) Error() string {
 	return strings.Join(errorStrings, "\n")
 }
 
+type EmptyAggregateError struct {
+}
+
+func (err EmptyAggregateError) Error() string {
+	return "attempt to aggregate an empty series list"
+}
+
 var _ error = (*SyntaxError)(nil)


### PR DESCRIPTION
This pull request defines functions for performing "groupBy" and "aggregate" operations on time series lists.

The most pertinent outward-facing function is called `aggregateBy` and is located at the bottom of `aggregate.go`. Given any `aggregator`, this function can perform aggregation on a time series list.

`Aggregator`s will be reimplemented in a nicer manner to instead just act as a `func([]float64)float64`.

@jeeyoungk  @achow 