### PR TITLE
Change parser so AND has higher precedence than OR

### DIFF
--- a/query/language.peg
+++ b/query/language.peg
@@ -140,11 +140,11 @@ predicateClause <- "where" __ predicate_1
 # ...
 
 predicate_1 <-
-  predicate_2 OP_AND predicate_1 { p.addAndPredicate() } /
+  predicate_2 OP_OR predicate_1 { p.addOrPredicate() } /
   predicate_2 /
 
 predicate_2 <-
-  predicate_3 OP_OR predicate_2 { p.addOrPredicate() } /
+  predicate_3 OP_AND predicate_2 { p.addAndPredicate() } /
   predicate_3
 
 predicate_3 <-


### PR DESCRIPTION
In almost every language, AND is given greater precedence than OR. It could be potentially confusing to clients who find that this convention is reversed.

SQL:
https://msdn.microsoft.com/en-us/library/ms190276.aspx
https://technet.microsoft.com/en-us/library/ms186992(v=sql.105).aspx
https://dev.mysql.com/doc/refman/5.0/en/operator-precedence.html

Go:
https://golang.org/ref/spec#Operator_precedence
