### PR TITLE
Transformation function implementation

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -36,15 +36,12 @@ func NewTagSet() TagSet {
 }
 
 func (left TagSet) Equals(right TagSet) bool {
+	if len(left) != len(right) {
+		return false
+	}
 	for k := range left {
 		_, ok := right[k]
 		if !ok || left[k] != right[k] {
-			return false
-		}
-	}
-	for k := range right {
-		_, ok := left[k]
-		if !ok {
 			return false
 		}
 	}

--- a/api/types.go
+++ b/api/types.go
@@ -35,6 +35,22 @@ func NewTagSet() TagSet {
 	return make(map[string]string)
 }
 
+func (left TagSet) Equals(right TagSet) bool {
+	for k := range left {
+		_, ok := right[k]
+		if !ok || left[k] != right[k] {
+			return false
+		}
+	}
+	for k := range right {
+		_, ok := left[k]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // Merge two tagsets, and return a new tagset.
 // If keys conflict, the first tag set is preferred.
 func (tagSet TagSet) Merge(other TagSet) TagSet {

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -29,6 +29,63 @@ func TestTagSet_Serialize(t *testing.T) {
 	a.EqString(ts.Serialize(), "dc=sjc1b,env=production")
 }
 
+func TestTagSetEquals(t *testing.T) {
+	sets := []TagSet{
+		TagSet{ // Case 0
+			"A": "x",
+			"B": "y",
+			"C": "z",
+		},
+		TagSet{ // Case 1
+			"A": "x",
+			"B": "y",
+			"C": "z",
+		},
+		TagSet{ // Case 2
+			"A": "q",
+			"B": "y",
+			"C": "z",
+		},
+		TagSet{ // Case 3
+			"A": "x",
+			"C": "z",
+		},
+		TagSet{ // Case 4
+			"A": "x",
+			"C": "z",
+		},
+	}
+	tests := []struct {
+		left     int
+		right    int
+		expected bool
+	}{
+		{0, 0, true}, // Compare to self
+		{1, 1, true},
+		{2, 2, true},
+		{3, 3, true},
+		{4, 4, true},
+		{0, 1, true}, // Compare to identical
+		{3, 4, true},
+		{0, 2, false}, // Compare to different
+		{1, 2, false},
+		{0, 3, false}, // Compare to missing
+		{1, 3, false},
+		{0, 4, false},
+		{1, 4, false},
+	}
+	for i, test := range tests {
+		if sets[test.left].Equals(sets[test.right]) != test.expected {
+			t.Errorf("Test %d on sets %d and %d fails (expected %t)", i, test.left, test.right, test.expected)
+			continue
+		}
+		if sets[test.right].Equals(sets[test.left]) != test.expected {
+			t.Errorf("Test %d on sets %d and %d fails (expected %t)", i, test.right, test.left, test.expected)
+			continue
+		}
+	}
+}
+
 func TestTagSet_Serialize_Escape(t *testing.T) {
 	a := assert.New(t)
 	ts := NewTagSet()

--- a/query/aggregate/aggregate_test.go
+++ b/query/aggregate/aggregate_test.go
@@ -218,25 +218,7 @@ func Test_applyAggregation(t *testing.T) {
 	}
 }
 
-// tagSetsEqual verifies that two tag sets are equal (contain the same keys and have the same values for these)
-func tagSetsEqual(leftSet api.TagSet, rightSet api.TagSet) bool {
-	for key, left := range leftSet {
-		right, ok := rightSet[key]
-		if !ok || left != right {
-			return false
-		}
-	}
-	for key := range rightSet {
-		_, ok := leftSet[key]
-		if !ok {
-			return false
-		}
-	}
-	return true
-}
-
 func Test_AggregateBy(t *testing.T) {
-
 	var testList = api.SeriesList{
 		[]api.Timeseries{
 			api.Timeseries{
@@ -421,7 +403,7 @@ func Test_AggregateBy(t *testing.T) {
 		for _, series := range testCase.Results {
 			found := false
 			for _, aggregate := range aggregated.Series {
-				if tagSetsEqual(series.TagSet, aggregate.TagSet) {
+				if series.TagSet.Equals(aggregate.TagSet) {
 					found = true
 					break
 				}
@@ -435,7 +417,7 @@ func Test_AggregateBy(t *testing.T) {
 		for _, aggregate := range aggregated.Series {
 			// Any of the testCase results which it matches are candidates
 			for _, correct := range testCase.Results {
-				if tagSetsEqual(aggregate.TagSet, correct.TagSet) {
+				if aggregate.TagSet.Equals(correct.TagSet) {
 					if len(aggregate.Values) != len(correct.Values) {
 						t.Errorf("For tagset %+v, result %+v has a different length than expected %+v", correct.TagSet, aggregate.Values, correct.Values)
 						continue

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -68,7 +68,8 @@ func ApplyTransform(list api.SeriesList, transform transform, parameters []value
 func checkParameters(name string, expected int, parameter transformParameter) error {
 	args := parameter.parameters
 	if len(args) != expected {
-		return errors.New(fmt.Sprintf("Expected function %s to be given %d parameters but was given %d: main series and %+v", name, expected+1, len(args)+1, args))
+		printArgs := append([]value{stringValue("(SeriesList)")}, args...)
+		return errors.New(fmt.Sprintf("expected %s to be given %d parameters but was given %d: %+v", name, expected+1, len(args)+1, printArgs))
 	}
 	return nil
 }
@@ -163,10 +164,11 @@ func transformMovingAverage(values []float64, parameter transformParameter) ([]f
 }
 
 // transformMapMaker can be used to use a function as a transform, such as 'math.Abs' (or similar):
-//  `transformMapMaker(math.Abs)` is a transform function which can be used, e.g. with applyTransform
-func transformMapMaker(fun func(float64) float64) func([]float64, transformParameter) ([]float64, error) {
+//  `transformMapMaker(math.Abs)` is a transform function which can be used, e.g. with ApplyTransform
+// The name is used for error-checking purposes.
+func transformMapMaker(name string, fun func(float64) float64) func([]float64, transformParameter) ([]float64, error) {
 	return func(values []float64, parameter transformParameter) ([]float64, error) {
-		if err := checkParameters("transform.map(???)", 0, parameter); err != nil {
+		if err := checkParameters(fmt.Sprintf("transform.%s", name), 0, parameter); err != nil {
 			return nil, err
 		}
 		result := make([]float64, len(values))

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -17,8 +17,6 @@
 package query
 
 import (
-	"math"
-
 	"github.com/square/metrics/api"
 )
 
@@ -136,21 +134,4 @@ func transformMapMaker(fun func(float64) float64) func([]float64, transformation
 		}
 		return result
 	}
-}
-
-func transformTimeOffset(values []float64, parameter transformationParameter) []float64 {
-	result := make([]float64, len(values))
-	// Shifting the time series by the given number of samples (by dividing the parameter by scale)
-	shift := int(parameter.parameter/parameter.scale + math.Copysign(0.5, parameter.parameter)) // The (+ 0.5) causes it to round.
-	// Positive shift means forward in time (so result[shift] = values[0])
-	// Negative shift means backwards in time.
-	// Values outside this range are assigned 0
-	for i := range values {
-		if i-shift < 0 || i-shift >= len(values) {
-			result[i] = 0
-			continue
-		}
-		result[i] = values[i-shift]
-	}
-	return result
 }

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -17,6 +17,8 @@
 package query
 
 import (
+	"math"
+
 	"github.com/square/metrics/api"
 )
 
@@ -139,13 +141,12 @@ func transformMapMaker(fun func(float64) float64) func([]float64, transformation
 func transformTimeOffset(values []float64, parameter transformationParameter) []float64 {
 	result := make([]float64, len(values))
 	// Shifting the time series by the given number of samples (by dividing the parameter by scale)
-	shift := int(parameter.parameter/parameter.scale + 0.5) // The (+ 0.5) causes it to round.
+	shift := int(parameter.parameter/parameter.scale + math.Copysign(0.5, parameter.parameter)) // The (+ 0.5) causes it to round.
 	// Positive shift means forward in time (so result[shift] = values[0])
 	// Negative shift means backwards in time.
 	// Values outside this range are assigned 0
 	for i := range values {
 		if i-shift < 0 || i-shift >= len(values) {
-
 			result[i] = 0
 			continue
 		}

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -1,0 +1,155 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package query contains all the logic to parse
+// and execute queries against the underlying metric system.
+package query
+
+import (
+	"github.com/square/metrics/api"
+)
+
+// A transformation takes the list of values, and a "scale" factor:
+// It is the unitless quotient (sample duration / 1s)
+// So if the resolution is "once every 5 minutes" them we get a scale factor of 5*60 = 300
+type transformation func([]float64, transformationParameter) []float64
+
+type transformationParameter struct {
+	scale     float64
+	parameter float64
+}
+
+func transformTimeseries(series api.Timeseries, transformation transformation, parameter transformationParameter) api.Timeseries {
+	return api.Timeseries{
+		Values: transformation(series.Values, parameter),
+		TagSet: series.TagSet,
+	}
+}
+
+// applyTransformation applies the given transformation to the entire list of series.
+func applyTransformation(list api.SeriesList, transformation transformation, parameter float64) api.SeriesList {
+	result := api.SeriesList{
+		Series:    make([]api.Timeseries, len(list.Series)),
+		Timerange: list.Timerange,
+		Name:      list.Name,
+	}
+	scale := float64(list.Timerange.Resolution)
+	for i, series := range list.Series {
+		result.Series[i] = transformTimeseries(series, transformation, transformationParameter{
+			scale:     scale,
+			parameter: parameter,
+		})
+	}
+	return result
+}
+
+// transformDerivative estimates the "change per second" between the two samples (scaled consecutive difference)
+func transformDerivative(values []float64, parameter transformationParameter) []float64 {
+	result := make([]float64, len(values))
+	for i := range values {
+		if i == 0 {
+			// The first element has 0
+			result[i] = 0
+			continue
+		}
+		// Otherwise, it's the scaled difference
+		result[i] = (values[i] - values[i-1]) / parameter.scale
+	}
+	return result
+}
+
+// transformIntegral integrates a series whose values are "X per second" to estimate "total X so far"
+func transformIntegral(values []float64, parameter transformationParameter) []float64 {
+	result := make([]float64, len(values))
+	integral := 0.0
+	for i := range values {
+		integral += values[i]
+		result[i] = integral * parameter.scale
+	}
+	return result
+}
+
+// transformRate functions exactly like transformDerivative but bounds the result to be positive and does not normalize
+func transformRate(values []float64, parameter transformationParameter) []float64 {
+	result := make([]float64, len(values))
+	for i := range values {
+		if i == 0 {
+			result[i] = 0
+			continue
+		}
+		result[i] = (values[i] - values[i-1]) / parameter.scale
+		if result[i] < 0 {
+			result[i] = 0
+		}
+	}
+	return result
+}
+
+// transformMovingAverage finds the average over the time period given in the parameter.parameter value
+func transformMovingAverage(values []float64, parameter transformationParameter) []float64 {
+	result := make([]float64, len(values))
+	limit := int(parameter.parameter/parameter.scale + 0.5) // Limit is the number of items to include in the average
+	if limit < 1 {
+		// At least one value must be included at all times
+		limit = 1
+	}
+	count := 0
+	sum := 0.0
+	for i := range values {
+		sum += values[i]
+		if count < limit {
+			// Increment the number of participants.
+			count++
+		} else {
+			// Remove the earliest participant
+			// (This is an optimization)
+			sum -= values[i-limit]
+			// For example, if limit = 4, we are suppose to include 4 items (including oneself).
+			// If i = 10, then we want to include 10, 9, 8, 7.
+			// So exclude 6 = 10 - 4 = i - limit
+		}
+		result[i] = sum / float64(count)
+	}
+	return result
+}
+
+// transformMapMaker can be used to use a function as a transformation, such as 'math.Abs' (or similar):
+//  `transformMapMaker(math.Abs)` is a transformation function which can be used, e.g. with applyTransformation
+func transformMapMaker(fun func(float64) float64) func([]float64, transformationParameter) []float64 {
+	return func(values []float64, parameter transformationParameter) []float64 {
+		result := make([]float64, len(values))
+		for i := range values {
+			result[i] = fun(values[i])
+		}
+		return result
+	}
+}
+
+func transformTimeOffset(values []float64, parameter transformationParameter) []float64 {
+	result := make([]float64, len(values))
+	// Shifting the time series by the given number of samples (by dividing the parameter by scale)
+	shift := int(parameter.parameter/parameter.scale + 0.5) // The (+ 0.5) causes it to round.
+	// Positive shift means forward in time (so result[shift] = values[0])
+	// Negative shift means backwards in time.
+	// Values outside this range are assigned 0
+	for i := range values {
+		if i-shift < 0 || i-shift >= len(values) {
+
+			result[i] = 0
+			continue
+		}
+		result[i] = values[i-shift]
+	}
+	return result
+}

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -81,7 +81,7 @@ func TestTransformTimeseries(t *testing.T) {
 			if !transform.useParam {
 				params = []value{}
 			}
-			result, err := transformTimeseries(series, transform.fun, params, api.Timerange{0, int64(test.scale), int64(test.scale)})
+			result, err := transformTimeseries(series, transform.fun, params, test.scale)
 			if err != nil {
 				t.Error(err)
 				continue

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -21,22 +21,6 @@ import (
 	"github.com/square/metrics/api"
 )
 
-func tagSetEquals(a, b api.TagSet) bool {
-	for k, v := range a {
-		w, ok := b[k]
-		if !ok || v != w {
-			return false
-		}
-	}
-	for k := range b {
-		_, ok := a[k]
-		if !ok {
-			return false
-		}
-	}
-	return true
-}
-
 func TestTransformTimeseries(t *testing.T) {
 	testCases := []struct {
 		values     []float64
@@ -102,7 +86,7 @@ func TestTransformTimeseries(t *testing.T) {
 				t.Error(err)
 				continue
 			}
-			if !tagSetEquals(result.TagSet, test.tagSet) {
+			if !result.TagSet.Equals(test.tagSet) {
 				t.Errorf("Expected tagset to be unchanged by transform, changed %+v into %+v", test.tagSet, result.TagSet)
 				continue
 			}

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -260,31 +260,25 @@ func TestApplyTransformFailure(t *testing.T) {
 	testCases := []struct {
 		transform transform
 		parameter []value
-		expected  string
 	}{
 		{
 			transform: transformDerivative,
 			parameter: []value{scalarValue(3)},
-			expected:  "expected transform.derivative to be given 1 parameters but was given 2: [(SeriesList) 3]",
 		},
 		{
 			transform: transformMapMaker("abs", math.Abs),
 			parameter: []value{scalarValue(3)},
-			expected:  "expected transform.abs to be given 1 parameters but was given 2: [(SeriesList) 3]",
 		},
 		{
 			transform: transformMovingAverage,
 			parameter: []value{},
-			expected:  "expected transform.moving_average to be given 2 parameters but was given 1: [(SeriesList)]",
 		},
 	}
 	for _, test := range testCases {
 		_, err := ApplyTransform(list, test.transform, test.parameter)
 		if err == nil {
-			t.Fatalf("expected failure for testcase %+v", test)
-		}
-		if err.Error() != test.expected {
-			t.Fatalf("expected error message `%s` but got `%s`", test.expected, err.Error())
+			t.Errorf("expected failure for testcase %+v", test)
+			continue
 		}
 	}
 }

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -78,10 +78,6 @@ func TestTransformTimeseries(t *testing.T) {
 					fun:      transformMapMaker(func(x float64) float64 { return -x }),
 					expected: []float64{0, -1, -2, -3, -4, -5},
 				},
-				{
-					fun:      transformTimeOffset,
-					expected: []float64{0, 0, 0, 0, 1, 2},
-				},
 			},
 		},
 	}
@@ -172,15 +168,6 @@ func TestApplyTransformation(t *testing.T) {
 				"A": {0, 0.5, 1, 2, 3, 4},
 				"B": {2.0, 2.0, 5.0 / 3, 4.0 / 3, 5.0 / 3, 7.0 / 3},
 				"C": {0, 0.5, 1, 2, 7.0 / 3, 2},
-			},
-		},
-		{
-			transformation: transformTimeOffset,
-			parameter:      -55, // 55 seconds is about 2 samples
-			expected: map[string][]float64{
-				"A": {2, 3, 4, 5, 0, 0},
-				"B": {1, 1, 3, 3, 0, 0},
-				"C": {2, 3, 2, 1, 0, 0},
 			},
 		},
 	}

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -1,0 +1,216 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"math"
+	"testing"
+
+	"github.com/square/metrics/api"
+)
+
+func tagSetEquals(a, b api.TagSet) bool {
+	for k, v := range a {
+		w, ok := b[k]
+		if !ok || v != w {
+			return false
+		}
+	}
+	for k := range b {
+		_, ok := a[k]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func TestTransformTimeseries(t *testing.T) {
+	testCases := []struct {
+		values    []float64
+		tagSet    api.TagSet
+		parameter transformationParameter
+		tests     []struct {
+			fun      transformation
+			expected []float64
+		}
+	}{
+		{
+			values: []float64{0, 1, 2, 3, 4, 5},
+			tagSet: api.TagSet{
+				"dc":   "A",
+				"host": "B",
+				"env":  "C",
+			},
+			parameter: transformationParameter{
+				scale:     30,
+				parameter: 100,
+			},
+			tests: []struct {
+				fun      transformation
+				expected []float64
+			}{
+				{
+					fun:      transformDerivative,
+					expected: []float64{0.0, 1.0 / 30.0, 1.0 / 30.0, 1.0 / 30.0, 1.0 / 30.0, 1.0 / 30.0},
+				},
+				{
+					fun:      transformIntegral,
+					expected: []float64{0.0, 1.0 * 30.0, 3.0 * 30.0, 6.0 * 30.0, 10.0 * 30.0, 15.0 * 30.0},
+				},
+				{
+					fun:      transformMovingAverage,
+					expected: []float64{0.0, 0.5, 1.0, 2.0, 3.0, 4.0},
+				},
+				{
+					fun:      transformMapMaker(func(x float64) float64 { return -x }),
+					expected: []float64{0, -1, -2, -3, -4, -5},
+				},
+				{
+					fun:      transformTimeOffset,
+					expected: []float64{0, 0, 0, 0, 1, 2},
+				},
+			},
+		},
+	}
+	epsilon := 1e-10
+	for _, test := range testCases {
+		series := api.Timeseries{
+			Values: test.values,
+			TagSet: test.tagSet,
+		}
+		for _, transform := range test.tests {
+			result := transformTimeseries(series, transform.fun, test.parameter)
+			if !tagSetEquals(result.TagSet, test.tagSet) {
+				t.Errorf("Expected tagset to be unchanged by transformation, changed %+v into %+v", test.tagSet, result.TagSet)
+				continue
+			}
+			if len(result.Values) != len(transform.expected) {
+				t.Errorf("Expected result to have length %d but has length %d", transform.expected, result.Values)
+				continue
+			}
+			// Now check that the values are approximately equal
+			for i := range result.Values {
+				if math.Abs(result.Values[i]-transform.expected[i]) > epsilon {
+					t.Errorf("Expected %+v but got %+v", transform.expected, result.Values)
+					break
+				}
+			}
+		}
+	}
+}
+
+func TestApplyTransformation(t *testing.T) {
+	epsilon := 1e-10
+	list := api.SeriesList{
+		Series: []api.Timeseries{
+			{
+				Values: []float64{0, 1, 2, 3, 4, 5},
+				TagSet: api.TagSet{
+					"series": "A",
+				},
+			},
+			{
+				Values: []float64{2, 2, 1, 1, 3, 3},
+				TagSet: api.TagSet{
+					"series": "B",
+				},
+			},
+			{
+				Values: []float64{0, 1, 2, 3, 2, 1},
+				TagSet: api.TagSet{
+					"series": "C",
+				},
+			},
+		},
+		Timerange: api.Timerange{
+			Start:      758300,
+			End:        758300 + 30*5,
+			Resolution: 30,
+		},
+		Name: "test",
+	}
+	testCases := []struct {
+		transformation transformation
+		parameter      float64
+		expected       map[string][]float64
+	}{
+		{
+			transformation: transformDerivative,
+			parameter:      17, // parameter is unused by derivative
+			expected: map[string][]float64{
+				"A": {0, 1.0 / 30, 1.0 / 30, 1.0 / 30, 1.0 / 30, 1.0 / 30},
+				"B": {0, 0, -1.0 / 30, 0, 2.0 / 30, 0},
+				"C": {0, 1.0 / 30, 1.0 / 30, 1.0 / 30, -1.0 / 30, -1.0 / 30},
+			},
+		},
+		{
+			transformation: transformIntegral,
+			parameter:      27, // parameter is unused by integral
+			expected: map[string][]float64{
+				"A": {0, 1 * 30, 3 * 30, 6 * 30, 10 * 30, 15 * 30},
+				"B": {2 * 30, 4 * 30, 5 * 30, 6 * 30, 9 * 30, 12 * 30},
+				"C": {0, 1 * 30, 3 * 30, 6 * 30, 8 * 30, 9 * 30},
+			},
+		},
+		{
+			transformation: transformMovingAverage,
+			parameter:      100, // 100 seconds corresponds to roughly 3 samples
+			expected: map[string][]float64{
+				"A": {0, 0.5, 1, 2, 3, 4},
+				"B": {2.0, 2.0, 5.0 / 3, 4.0 / 3, 5.0 / 3, 7.0 / 3},
+				"C": {0, 0.5, 1, 2, 7.0 / 3, 2},
+			},
+		},
+		{
+			transformation: transformTimeOffset,
+			parameter:      -55, // 55 seconds is about 2 samples
+			expected: map[string][]float64{
+				"A": {2, 3, 4, 5, 0, 0},
+				"B": {1, 1, 3, 3, 0, 0},
+				"C": {2, 3, 2, 1, 0, 0},
+			},
+		},
+	}
+	for _, test := range testCases {
+		result := applyTransformation(list, test.transformation, test.parameter)
+		alreadyUsed := make(map[string]bool)
+		for _, series := range result.Series {
+			name := series.TagSet["series"]
+			expected, ok := test.expected[name]
+			if !ok {
+				t.Errorf("Series not present in testcase (A, B, or C). Is instead [%s]", name)
+				continue
+			}
+			if alreadyUsed[name] {
+				t.Errorf("Multiple series posing as %s", name)
+				continue
+			}
+			alreadyUsed[name] = true
+			// Lastly, compare the actual values
+			if len(series.Values) != len(expected) {
+				t.Errorf("Expected result to have %d entries but has %d entries; for series %s", len(expected), len(series.Values), name)
+				continue
+			}
+			// Check that elements are within epsilon
+			for i := range series.Values {
+				if math.Abs(series.Values[i]-expected[i]) > epsilon {
+					t.Errorf("Expected values for series %s to be %+v but are %+v", name, expected, series.Values)
+					break
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The interface is:

`func ApplyTransformation(list api.SeriesList, transform transform, parameters []value) (api.SeriesList, error)`

Where `parameters` are `value`s representing things like flags, modes, or durations (and correspond to all arguments after the first in the query)

The type `transform` is a synonym for the more verbose:

`func([]float64, []value, api.Timerange) ([]float64, error)`

The following transformations have been implemented: `transformDerivative`, `transformIntegral`, `transformRate`, `transformCumulative`, and `transformMovingAverage`.

Also implemented is `transformMapMaker` which maps a simple scalar functio `func(float64) float64` over the timeseries. The transform corresponding to taking the absolute value, for example, would be `transformMapMaker(math.Abs)`.

@jeeyoungk @achow 