### PR TITLE
Refactor expressions to return Value instead of *api.SeriesList

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -138,10 +138,10 @@ type Timerange struct {
 
 // IsValid determines whether the given timerange meets the constraint.
 func (tr Timerange) IsValid() bool {
-	return (tr.Start%tr.Resolution == 0 &&
+	return tr.Resolution > 0 &&
+		tr.Start%tr.Resolution == 0 &&
 		tr.End%tr.Resolution == 0 &&
-		tr.Resolution > 0 &&
-		tr.Start <= tr.End)
+		tr.Start <= tr.End
 }
 
 // Slots represent the total # of data points

--- a/query/expression.go
+++ b/query/expression.go
@@ -51,7 +51,7 @@ type ConversionError struct {
 }
 
 func (e ConversionError) Error() string {
-	return fmt.Sprintf("cannot convert from type %from to type %to%")
+	return fmt.Sprintf("cannot convert from type %s to type %s", e.from, e.to)
 }
 
 // A SeriesListValue is a value which holds a SeriesList

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -35,8 +35,8 @@ type LiteralExpression struct {
 	Values []float64
 }
 
-func (expr *LiteralExpression) Evaluate(context EvaluationContext) (Value, error) {
-	return SeriesListValue(api.SeriesList{
+func (expr *LiteralExpression) Evaluate(context EvaluationContext) (value, error) {
+	return seriesListValue(api.SeriesList{
 		Series:    []api.Timeseries{api.Timeseries{expr.Values, api.NewTagSet()}},
 		Timerange: api.Timerange{},
 	}), nil
@@ -46,7 +46,7 @@ type LiteralSeriesExpression struct {
 	Values []api.Timeseries
 }
 
-func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (Value, error) {
+func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (value, error) {
 	result := api.SeriesList{
 		Series:    make([]api.Timeseries, len(expr.Values)),
 		Timerange: api.Timerange{},
@@ -54,7 +54,7 @@ func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (Value,
 	for i, values := range expr.Values {
 		result.Series[i] = values
 	}
-	return SeriesListValue(result), nil
+	return seriesListValue(result), nil
 }
 
 func Test_ScalarExpression(t *testing.T) {
@@ -84,7 +84,7 @@ func Test_ScalarExpression(t *testing.T) {
 	} {
 		a := assert.New(t).Contextf("%+v", test)
 
-		result, err := EvaluateToSeriesList(test.expr, EvaluationContext{
+		result, err := evaluateToSeriesList(test.expr, EvaluationContext{
 			Backend:      FakeBackend{},
 			Timerange:    test.timerange,
 			SampleMethod: api.SampleMean,
@@ -308,7 +308,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			continue
 		}
 
-		result, err := value.ToSeriesList(test.context.Timerange)
+		result, err := value.toSeriesList(test.context.Timerange)
 		if err != nil {
 			a.EqBool(err == nil, test.expectSuccess)
 			continue


### PR DESCRIPTION
To better enable string and scalar parameters to functions, `Expression`s return a `Value` interface type instead of always returning `*api.SeriesList`. The `Value` interface defines methods to cast (with possible error returned) to `api.SeriesList`, `string`, or `float64`. There are three instances of the `Value` interface defined, one for each type. Each can only be casted to its own value, except for `ScalarValue` which can produce an `api.SeriesList`.

This change required modifying the corresponding test file to work with the new types.

@jeeyoungk @achow 