### PR TITLE
Aggregation Function Calling Implementation

### DIFF
--- a/query/expression.go
+++ b/query/expression.go
@@ -175,6 +175,18 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 		}
 		return evaluateBinaryOperation(context, name, left, right, operatorMap[name])
 	case "aggregate.sum":
+		fallthrough
+	case "aggregate.mean":
+		fallthrough
+	case "aggregate.min":
+		fallthrough
+	case "aggregate.max":
+		funMap := map[string]aggregate{
+			"aggregate.sum":  sumAggregate,
+			"aggregate.mean": meanAggregate,
+			"aggregate.min":  minAggregate,
+			"aggregate.max":  maxAggregate,
+		}
 		if len(arguments) != 1 {
 			return nil, errors.New(fmt.Sprintf("Function `%s` expected 2 operands but received %d (%+v)", name, len(arguments), arguments))
 		}
@@ -182,7 +194,7 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 		if err != nil {
 			return nil, err
 		}
-		return seriesListValue(aggregateBy(list, aggregateMap[sumAggregate], expr.groupBy)), nil
+		return seriesListValue(aggregateBy(list, aggregateMap[funMap[name]], expr.groupBy)), nil
 	default:
 		return nil, errors.New(fmt.Sprintf("Invalid function: %s", functionName))
 	}

--- a/query/expression.go
+++ b/query/expression.go
@@ -174,6 +174,15 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 			"/": func(x, y float64) float64 { return x / y },
 		}
 		return evaluateBinaryOperation(context, name, left, right, operatorMap[name])
+	case "aggregate.sum":
+		if len(arguments) != 1 {
+			return nil, errors.New(fmt.Sprintf("Function `%s` expected 2 operands but received %d (%+v)", name, len(arguments), arguments))
+		}
+		list, err := arguments[0].toSeriesList(context.Timerange)
+		if err != nil {
+			return nil, err
+		}
+		return seriesListValue(aggregateBy(list, aggregateMap[sumAggregate], expr.groupBy)), nil
 	default:
 		return nil, errors.New(fmt.Sprintf("Invalid function: %s", functionName))
 	}

--- a/query/expression.go
+++ b/query/expression.go
@@ -144,19 +144,36 @@ func (expr *metricFetchExpression) Evaluate(context EvaluationContext) (value, e
 }
 
 func (expr *functionExpression) Evaluate(context EvaluationContext) (value, error) {
-	switch expr.functionName {
+	arguments := make([]value, len(expr.arguments))
+	var err error
+	for i := range arguments {
+		arguments[i], err = expr.arguments[i].Evaluate(context)
+		if err != nil {
+			return nil, err
+		}
+	}
+	name := expr.functionName
+	switch name {
 	case "+":
-		return evaluateBinaryOperation(context, expr.functionName, expr.arguments,
-			func(left, right float64) float64 { return left + right })
+		fallthrough
 	case "-":
-		return evaluateBinaryOperation(context, expr.functionName, expr.arguments,
-			func(left, right float64) float64 { return left - right })
-	case "/":
-		return evaluateBinaryOperation(context, expr.functionName, expr.arguments,
-			func(left, right float64) float64 { return left / right })
+		fallthrough
 	case "*":
-		return evaluateBinaryOperation(context, expr.functionName, expr.arguments,
-			func(left, right float64) float64 { return left * right })
+		fallthrough
+	case "/":
+		// Evaluation of a binary operator:
+		if len(arguments) != 2 {
+			return nil, errors.New(fmt.Sprintf("Function `%s` expects 2 operands but received %d (%+v)", name, len(arguments), arguments))
+		}
+		left := arguments[0]
+		right := arguments[1]
+		operatorMap := map[string]func(float64, float64) float64{
+			"+": func(x, y float64) float64 { return x + y },
+			"-": func(x, y float64) float64 { return x - y },
+			"*": func(x, y float64) float64 { return x * y },
+			"/": func(x, y float64) float64 { return x / y },
+		}
+		return evaluateBinaryOperation(context, name, left, right, operatorMap[name])
 	default:
 		return nil, errors.New(fmt.Sprintf("Invalid function: %s", functionName))
 	}
@@ -182,23 +199,16 @@ func evaluateExpression(context EvaluationContext, expr Expression) (value, erro
 func evaluateBinaryOperation(
 	context EvaluationContext,
 	functionName string,
-	operands []Expression,
+	leftValue value,
+	rightValue value,
 	evaluate func(float64, float64) float64,
 ) (value, error) {
-	if len(operands) != 2 {
-		return nil, errors.New(fmt.Sprintf("Function `%s` expects 2 operands but received %d (%+v)", functionName, len(operands), operands))
-	}
 
-	results, err := evaluateExpressions(context, operands)
+	leftList, err := leftValue.toSeriesList(context.Timerange)
 	if err != nil {
 		return nil, err
 	}
-
-	leftList, err := results[0].toSeriesList(context.Timerange)
-	if err != nil {
-		return nil, err
-	}
-	rightList, err := results[1].toSeriesList(context.Timerange)
+	rightList, err := rightValue.toSeriesList(context.Timerange)
 	if err != nil {
 		return nil, err
 	}

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -109,7 +109,8 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string
-		operands             []Expression
+		left                 value
+		right                value
 		evalFunction         func(float64, float64) float64
 		expectSuccess        bool
 		expectedResultValues [][]float64
@@ -117,14 +118,26 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		{
 			emptyContext,
 			"add",
-			[]Expression{
-				&LiteralExpression{
-					[]float64{1, 2, 3},
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					{
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{},
+					},
 				},
-				&LiteralExpression{
-					[]float64{4, 5, 1},
+				api.Timerange{},
+				"",
+			}),
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					{
+						Values: []float64{4, 5, 1},
+						TagSet: api.TagSet{},
+					},
 				},
-			},
+				api.Timerange{},
+				"",
+			}),
 			func(left, right float64) float64 { return left + right },
 			true,
 			[][]float64{{5, 7, 4}},
@@ -132,14 +145,24 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		{
 			emptyContext,
 			"subtract",
-			[]Expression{
-				&LiteralExpression{
-					[]float64{1, 2, 3},
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					{
+						Values: []float64{1, 2, 3},
+					},
 				},
-				&LiteralExpression{
-					[]float64{4, 5, 1},
+				api.Timerange{},
+				"",
+			}),
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					{
+						Values: []float64{4, 5, 1},
+					},
 				},
-			},
+				api.Timerange{},
+				"",
+			}),
 			func(left, right float64) float64 { return left - right },
 			true,
 			[][]float64{{-3, -3, 2}},
@@ -147,49 +170,51 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		{
 			emptyContext,
 			"add",
-			[]Expression{
-				&LiteralSeriesExpression{
-					[]api.Timeseries{
-						api.Timeseries{
-							[]float64{1, 2, 3},
-							api.TagSet{
-								"env":  "production",
-								"host": "#1",
-							},
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					api.Timeseries{
+						[]float64{1, 2, 3},
+						api.TagSet{
+							"env":  "production",
+							"host": "#1",
 						},
-						api.Timeseries{
-							[]float64{7, 7, 7},
-							api.TagSet{
-								"env":  "staging",
-								"host": "#2",
-							},
+					},
+					api.Timeseries{
+						[]float64{7, 7, 7},
+						api.TagSet{
+							"env":  "staging",
+							"host": "#2",
 						},
-						api.Timeseries{
-							[]float64{1, 0, 2},
-							api.TagSet{
-								"env":  "staging",
-								"host": "#3",
-							},
+					},
+					api.Timeseries{
+						[]float64{1, 0, 2},
+						api.TagSet{
+							"env":  "staging",
+							"host": "#3",
 						},
 					},
 				},
-				&LiteralSeriesExpression{
-					[]api.Timeseries{
-						api.Timeseries{
-							[]float64{5, 5, 5},
-							api.TagSet{
-								"env": "staging",
-							},
+				api.Timerange{},
+				"",
+			}),
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					api.Timeseries{
+						[]float64{5, 5, 5},
+						api.TagSet{
+							"env": "staging",
 						},
-						api.Timeseries{
-							[]float64{10, 100, 1000},
-							api.TagSet{
-								"env": "production",
-							},
+					},
+					api.Timeseries{
+						[]float64{10, 100, 1000},
+						api.TagSet{
+							"env": "production",
 						},
 					},
 				},
-			},
+				api.Timerange{},
+				"",
+			}),
 			func(left, right float64) float64 { return left + right },
 			true,
 			[][]float64{{11, 102, 1003}, {12, 12, 12}, {6, 5, 7}},
@@ -197,49 +222,51 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		{
 			emptyContext,
 			"add",
-			[]Expression{
-				&LiteralSeriesExpression{
-					[]api.Timeseries{
-						api.Timeseries{
-							[]float64{1, 2, 3},
-							api.TagSet{
-								"env":  "production",
-								"host": "#1",
-							},
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					api.Timeseries{
+						[]float64{1, 2, 3},
+						api.TagSet{
+							"env":  "production",
+							"host": "#1",
 						},
-						api.Timeseries{
-							[]float64{4, 5, 6},
-							api.TagSet{
-								"env":  "staging",
-								"host": "#2",
-							},
+					},
+					api.Timeseries{
+						[]float64{4, 5, 6},
+						api.TagSet{
+							"env":  "staging",
+							"host": "#2",
 						},
-						api.Timeseries{
-							[]float64{7, 8, 9},
-							api.TagSet{
-								"env":  "staging",
-								"host": "#3",
-							},
+					},
+					api.Timeseries{
+						[]float64{7, 8, 9},
+						api.TagSet{
+							"env":  "staging",
+							"host": "#3",
 						},
 					},
 				},
-				&LiteralSeriesExpression{
-					[]api.Timeseries{
-						api.Timeseries{
-							[]float64{2, 2, 2},
-							api.TagSet{
-								"env": "staging",
-							},
+				api.Timerange{},
+				"",
+			}),
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					api.Timeseries{
+						[]float64{2, 2, 2},
+						api.TagSet{
+							"env": "staging",
 						},
-						api.Timeseries{
-							[]float64{3, 3, 3},
-							api.TagSet{
-								"env": "staging",
-							},
+					},
+					api.Timeseries{
+						[]float64{3, 3, 3},
+						api.TagSet{
+							"env": "staging",
 						},
 					},
 				},
-			},
+				api.Timerange{},
+				"",
+			}),
 			func(left, right float64) float64 { return left * right },
 			true,
 			[][]float64{{8, 10, 12}, {14, 16, 18}, {12, 15, 18}, {21, 24, 27}},
@@ -247,49 +274,51 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		{
 			emptyContext,
 			"add",
-			[]Expression{
-				&LiteralSeriesExpression{
-					[]api.Timeseries{
-						api.Timeseries{
-							[]float64{103, 103, 103},
-							api.TagSet{
-								"env":  "production",
-								"host": "#1",
-							},
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					api.Timeseries{
+						[]float64{103, 103, 103},
+						api.TagSet{
+							"env":  "production",
+							"host": "#1",
 						},
-						api.Timeseries{
-							[]float64{203, 203, 203},
-							api.TagSet{
-								"env":  "staging",
-								"host": "#2",
-							},
+					},
+					api.Timeseries{
+						[]float64{203, 203, 203},
+						api.TagSet{
+							"env":  "staging",
+							"host": "#2",
 						},
-						api.Timeseries{
-							[]float64{303, 303, 303},
-							api.TagSet{
-								"env":  "staging",
-								"host": "#3",
-							},
+					},
+					api.Timeseries{
+						[]float64{303, 303, 303},
+						api.TagSet{
+							"env":  "staging",
+							"host": "#3",
 						},
 					},
 				},
-				&LiteralSeriesExpression{
-					[]api.Timeseries{
-						api.Timeseries{
-							[]float64{1, 2, 3},
-							api.TagSet{
-								"env": "staging",
-							},
+				api.Timerange{},
+				"",
+			}),
+			seriesListValue(api.SeriesList{
+				[]api.Timeseries{
+					api.Timeseries{
+						[]float64{1, 2, 3},
+						api.TagSet{
+							"env": "staging",
 						},
-						api.Timeseries{
-							[]float64{3, 0, 3},
-							api.TagSet{
-								"env": "production",
-							},
+					},
+					api.Timeseries{
+						[]float64{3, 0, 3},
+						api.TagSet{
+							"env": "production",
 						},
 					},
 				},
-			},
+				api.Timerange{},
+				"",
+			}),
 			func(left, right float64) float64 { return left - right },
 			true,
 			[][]float64{{100, 103, 100}, {202, 201, 200}, {302, 301, 300}},
@@ -300,7 +329,8 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		value, err := evaluateBinaryOperation(
 			test.context,
 			test.functionName,
-			test.operands,
+			test.left,
+			test.right,
 			test.evalFunction,
 		)
 		if err != nil {


### PR DESCRIPTION
An aggregate function can now be called by doing (for example), `aggregate.sum( series * 2 group by key )`.

As a related change (to mirror this one), `evaluateBinaryExpression` now takes two `value`-type operands, rather than `[]Expression` and is validated before calling, rather than having it validate its input itself (this required changing the test file).


