### PR TITLE
Fix Typos

### DIFF
--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -47,7 +47,7 @@ type QueryResponse struct {
 
 type MetricPoint struct {
 	Points    int     `json:"numPoints"`
-	Timestamp int64   `json:"timestamp`
+	Timestamp int64   `json:"timestamp"`
 	Average   float64 `json:"average"`
 	Max       float64 `json:"max"`
 	Min       float64 `json:"min"`
@@ -88,7 +88,7 @@ func (b *Blueflood) FetchSeries(metric api.TaggedMetric, predicate api.Predicate
 	case api.SampleMax:
 		selectResultField = "Max"
 	default:
-		return nil, errors.New(fmt.Sprintf("Unsupported SampleMethod %s", sampleMethod))
+		return nil, errors.New(fmt.Sprintf("Unsupported SampleMethod %d", sampleMethod))
 	}
 
 	// Issue GET to fetch metrics

--- a/query/expression.go
+++ b/query/expression.go
@@ -158,7 +158,7 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 		return evaluateBinaryOperation(context, expr.functionName, expr.arguments,
 			func(left, right float64) float64 { return left * right })
 	default:
-		return nil, errors.New(fmt.Sprintf("Invalid function: %s", functionName))
+		return nil, errors.New(fmt.Sprintf("Invalid function: %s", expr.functionName))
 	}
 }
 

--- a/query/language.peg
+++ b/query/language.peg
@@ -86,14 +86,14 @@ expressionList <-
 expression_1 <-
   expression_2
   (
-    (OP_ADD { p.addOperatorLiteral("*") } / OP_SUB { p.addOperatorLiteral("-") })
+    (OP_ADD { p.addOperatorLiteral("+") } / OP_SUB { p.addOperatorLiteral("-") })
     expression_2 { p.addOperatorFunction() }
   ) *
 
 expression_2 <-
   expression_3
   (
-    (OP_DIV { p.addOperatorLiteral("*") } / OP_MULT { p.addOperatorLiteral("*") })
+    (OP_DIV { p.addOperatorLiteral("/") } / OP_MULT { p.addOperatorLiteral("*") })
     expression_3 { p.addOperatorFunction() }
   ) *
 

--- a/query/language.peg.go
+++ b/query/language.peg.go
@@ -660,13 +660,13 @@ func (p *Parser) Execute() {
 		case ruleAction12:
 			p.appendExpression()
 		case ruleAction13:
-			p.addOperatorLiteral("*")
+			p.addOperatorLiteral("+")
 		case ruleAction14:
 			p.addOperatorLiteral("-")
 		case ruleAction15:
 			p.addOperatorFunction()
 		case ruleAction16:
-			p.addOperatorLiteral("*")
+			p.addOperatorLiteral("/")
 		case ruleAction17:
 			p.addOperatorLiteral("*")
 		case ruleAction18:
@@ -4378,13 +4378,13 @@ func (p *Parser) Init() {
 		nil,
 		/* 71 Action12 <- <{ p.appendExpression() }> */
 		nil,
-		/* 72 Action13 <- <{ p.addOperatorLiteral("*") }> */
+		/* 72 Action13 <- <{ p.addOperatorLiteral("+") }> */
 		nil,
 		/* 73 Action14 <- <{ p.addOperatorLiteral("-") }> */
 		nil,
 		/* 74 Action15 <- <{ p.addOperatorFunction() }> */
 		nil,
-		/* 75 Action16 <- <{ p.addOperatorLiteral("*") }> */
+		/* 75 Action16 <- <{ p.addOperatorLiteral("/") }> */
 		nil,
 		/* 76 Action17 <- <{ p.addOperatorLiteral("*") }> */
 		nil,

--- a/query/parser.go
+++ b/query/parser.go
@@ -337,7 +337,7 @@ func (p *Parser) insertPropertyKeyValue() {
 		default:
 			p.flagSyntaxError(SyntaxError{
 				token:   value,
-				message: fmt.Sprintf("Expected sampling method 'max', 'min', or 'mean'", value),
+				message: fmt.Sprintf("Expected sampling method 'max', 'min', or 'mean' but got %s", value),
 			})
 		}
 	case "from":


### PR DESCRIPTION
`p.addOperatorLiteral("*")` was called for both `OP_ADD` and `OP_DIV` prior to this change.