### PR TITLE
Add timeshift function

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -157,13 +157,22 @@ func (tr Timerange) IsValid() bool {
 		tr.Start <= tr.End
 }
 
+func rounder(x, r int64) int64 {
+	if x < 0 {
+		return -rounder(-x, r)
+	}
+	// This performs a round
+	return (x + r/2) / r * r
+}
+
 // Round() will fix some invalid timeranges by rounding their starts and ends.
 func (tr Timerange) Round() Timerange {
+
 	if tr.Resolution == 0 {
 		return tr
 	}
-	tr.Start = (tr.Start + tr.Resolution/2) / tr.Resolution * tr.Resolution // This performs a round
-	tr.End = (tr.End + tr.Resolution/2) / tr.Resolution * tr.Resolution     // This performs a round
+	tr.Start = rounder(tr.Start, tr.Resolution)
+	tr.End = rounder(tr.End, tr.Resolution)
 	return tr
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -161,7 +161,14 @@ func snap(n, boundary int64) int64 {
 	if n < 0 {
 		return -snap(-n, boundary)
 	}
-	// This performs a round
+	// This performs a round.
+	// Dividing by `boundary` truncates towards zero.
+	// The resulting integer is then multiplied by `boundary` again.
+	// Thus the result is a multiple of `boundary`.
+	// For integer division, x/r*r = (x/r)*r in general rounds to a multiple of r towards 0.
+	// Adding `boundary/2` changes this instead to a "round to nearest" rather than "round towards 0".
+	// (Where "up" is the round for values exactly halfway between).
+	// These halfway points round "away from zero" (rather than "towards -infinity").
 	return (n + boundary/2) / boundary * boundary
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -157,6 +157,23 @@ func (tr Timerange) IsValid() bool {
 		tr.Start <= tr.End
 }
 
+// Round() will fix some invalid timeranges by rounding their starts and ends.
+func (tr Timerange) Round() Timerange {
+	if tr.Resolution == 0 {
+		return tr
+	}
+	tr.Start = (tr.Start + tr.Resolution/2) / tr.Resolution * tr.Resolution // This performs a round
+	tr.End = (tr.End + tr.Resolution/2) / tr.Resolution * tr.Resolution     // This performs a round
+	return tr
+}
+
+// Later() returns a timerange which is forward in time by the amount given
+func (tr Timerange) Later(time int64) Timerange {
+	tr.Start += time
+	tr.End += time
+	return tr.Round()
+}
+
 // Slots represent the total # of data points
 // Behavior is undefined when operating on an invalid Timerange. There's a
 // circular dependency here, but it all works out.

--- a/api/types.go
+++ b/api/types.go
@@ -157,30 +157,30 @@ func (tr Timerange) IsValid() bool {
 		tr.Start <= tr.End
 }
 
-func rounder(x, r int64) int64 {
-	if x < 0 {
-		return -rounder(-x, r)
+func snap(n, boundary int64) int64 {
+	if n < 0 {
+		return -snap(-n, boundary)
 	}
 	// This performs a round
-	return (x + r/2) / r * r
+	return (n + boundary/2) / boundary * boundary
 }
 
 // Round() will fix some invalid timeranges by rounding their starts and ends.
-func (tr Timerange) Round() Timerange {
+func (tr Timerange) Snap() Timerange {
 
 	if tr.Resolution == 0 {
 		return tr
 	}
-	tr.Start = rounder(tr.Start, tr.Resolution)
-	tr.End = rounder(tr.End, tr.Resolution)
+	tr.Start = snap(tr.Start, tr.Resolution)
+	tr.End = snap(tr.End, tr.Resolution)
 	return tr
 }
 
 // Later() returns a timerange which is forward in time by the amount given
-func (tr Timerange) Later(time int64) Timerange {
+func (tr Timerange) Shift(time int64) Timerange {
 	tr.Start += time
 	tr.End += time
-	return tr.Round()
+	return tr.Snap()
 }
 
 // Slots represent the total # of data points

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -136,3 +136,73 @@ func TestTimerange(t *testing.T) {
 		a.EqInt(suite.Timerange.Slots(), suite.ExpectedSlots)
 	}
 }
+
+func TestTimerangeLater(t *testing.T) {
+	// Check that when moving forward, when moving backward, etc., time ranges work as expected.
+	ranges := []Timerange{
+		{
+			Start:      400,
+			End:        900,
+			Resolution: 100,
+		},
+		{
+			Start:      400,
+			End:        900,
+			Resolution: 1,
+		},
+		{
+			Start:      120,
+			End:        150,
+			Resolution: 30,
+		},
+		{
+			Start:      400,
+			End:        520,
+			Resolution: 40,
+		},
+	}
+	for _, time := range ranges {
+		// A sanity check for the above calculations.
+		if !time.IsValid() {
+			panic("Invalid timerange used as test case")
+		}
+	}
+	offsets := []int64{
+		0,
+		1,
+		10,
+		100,
+		28,
+		30,
+		40,
+		50,
+		51,
+		56,
+		76,
+		99,
+		100,
+		101,
+		110,
+		140,
+		149,
+		150,
+		151,
+		199,
+		200,
+		201,
+	}
+	for _, offset := range offsets {
+		for _, time := range ranges {
+			later := time.Later(offset)
+			if later.End-later.Start != time.End-time.Start || later.Resolution != time.Resolution || !later.IsValid() {
+				t.Errorf("Range %+v on offset %d fails; produces %+v", time, offset, later)
+				continue
+			}
+			later = time.Later(-offset)
+			if later.End-later.Start != time.End-time.Start || later.Resolution != time.Resolution || !later.IsValid() {
+				t.Errorf("Range %+v on offset %d fails; produces %+v", time, -offset, later)
+				continue
+			}
+		}
+	}
+}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -193,12 +193,12 @@ func TestTimerangeLater(t *testing.T) {
 	}
 	for _, offset := range offsets {
 		for _, time := range ranges {
-			later := time.Later(offset)
+			later := time.Shift(offset)
 			if later.End-later.Start != time.End-time.Start || later.Resolution != time.Resolution || !later.IsValid() {
 				t.Errorf("Range %+v on offset %d fails; produces %+v", time, offset, later)
 				continue
 			}
-			later = time.Later(-offset)
+			later = time.Shift(-offset)
 			if later.End-later.Start != time.End-time.Start || later.Resolution != time.Resolution || !later.IsValid() {
 				t.Errorf("Range %+v on offset %d fails; produces %+v", time, -offset, later)
 				continue

--- a/query/expression.go
+++ b/query/expression.go
@@ -262,7 +262,7 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 			return nil, err
 		}
 		newContext := context
-		newContext.Timerange = newContext.Timerange.Later(int64(duration))
+		newContext.Timerange = newContext.Timerange.Shift(int64(duration))
 		value, err := expr.arguments[0].Evaluate(newContext)
 		if err != nil {
 			return nil, err

--- a/query/expression.go
+++ b/query/expression.go
@@ -113,7 +113,7 @@ func (value scalarValue) toScalar() (float64, error) {
 // toDuration will take a value, convert it to a string, and then parse it.
 // It produces a nanosecond count as a signed int64.
 // the valid ns, us (µs), ms, s, m, h
-func toDuration(value value) (int64, error) {
+func toDuration(value value) (time.Duration, error) {
 	timeString, err := value.toString()
 	if err != nil {
 		return 0, err
@@ -122,7 +122,7 @@ func toDuration(value value) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return int64(duration), nil
+	return duration, nil
 }
 
 // Expression is a piece of code, which can be evaluated in a given
@@ -257,12 +257,12 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 		if err != nil {
 			return nil, err
 		}
-		durationNano, err := toDuration(shift)
+		duration, err := toDuration(shift)
 		if err != nil {
 			return nil, err
 		}
 		newContext := context
-		newContext.Timerange = newContext.Timerange.Later(durationNano)
+		newContext.Timerange = newContext.Timerange.Later(int64(duration))
 		value, err := expr.arguments[0].Evaluate(newContext)
 		if err != nil {
 			return nil, err

--- a/query/expression.go
+++ b/query/expression.go
@@ -17,6 +17,7 @@ package query
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/query/aggregate"
@@ -107,6 +108,21 @@ func (value scalarValue) toString() (string, error) {
 
 func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
+}
+
+// toDuration will take a value, convert it to a string, and then parse it.
+// It produces a nanosecond count as a signed int64.
+// the valid ns, us (µs), ms, s, m, h
+func toDuration(value value) (int64, error) {
+	timeString, err := value.toString()
+	if err != nil {
+		return 0, err
+	}
+	duration, err := time.ParseDuration(timeString)
+	if err != nil {
+		return 0, err
+	}
+	return int64(duration), nil
 }
 
 // Expression is a piece of code, which can be evaluated in a given
@@ -228,6 +244,26 @@ func (expr *functionExpression) Evaluate(context EvaluationContext) (value, erro
 			return nil, err
 		}
 		return seriesListValue(series), nil
+	}
+
+	if name == "timeshift" {
+		// A timeshift performs a modification to the evaluation context.
+		// In the future, it may be one of a class of functions which performs a similar modification.
+		// A timeshift has two parameters: its first (which it evaluates), and its second (the time offset).
+		if len(expr.arguments) != 2 {
+			return nil, errors.New(fmt.Sprintf("Function `timeshift` expects 2 parameters but is given %d (%+v)", len(expr.arguments), expr.arguments))
+		}
+		shift, err := expr.arguments[1].Evaluate(context)
+		if err != nil {
+			return nil, err
+		}
+		durationNano, err := toDuration(shift)
+		if err != nil {
+			return nil, err
+		}
+		newContext := context
+		newContext.Timerange = newContext.Timerange.Later(durationNano)
+		return expr.arguments[0].Evaluate(newContext)
 	}
 
 	return nil, errors.New(fmt.Sprintf("unknown function name `%s`", name))


### PR DESCRIPTION
This PR adds a special case for `timeshift` as a function to be invoked by expressions. It works by modifying the evaluation context before evaluating its first argument.

Currently, timeshifting is a special case, since no other function or operation during expression evaluation actually changes the `EvaluationContext`.