### PR TITLE
Unexport fields from api.Timerange and Standardize Milliseconds

### DIFF
--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -140,8 +140,8 @@ func (b *Blueflood) fetchSingleSeries(metric api.GraphiteMetric, sampleMethod ap
 	}
 
 	params := url.Values{}
-	params.Set("from", strconv.FormatInt(timerange.Start()*1000, 10))
-	params.Set("to", strconv.FormatInt(timerange.End()*1000, 10))
+	params.Set("from", strconv.FormatInt(timerange.Start(), 10))
+	params.Set("to", strconv.FormatInt(timerange.End(), 10))
 	params.Set("resolution", bluefloodResolution(timerange.Resolution()))
 	params.Set("select", fmt.Sprintf("numPoints,%s", strings.ToLower(selectResultField)))
 
@@ -184,15 +184,15 @@ func (b *Blueflood) fetchSingleSeries(metric api.GraphiteMetric, sampleMethod ap
 // between them.
 func bluefloodResolution(r int64) string {
 	switch {
-	case r < 5*60:
+	case r < 5*60*1000:
 		return ResolutionFull
-	case r < 20*60:
+	case r < 20*60*1000:
 		return Resolution5Min
-	case r < 60*60:
+	case r < 60*60*1000:
 		return Resolution20Min
-	case r < 240*60:
+	case r < 240*60*1000:
 		return Resolution60Min
-	case r < 1440*60:
+	case r < 1440*60*1000:
 		return Resolution240Min
 	}
 	return Resolution1440Min

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -140,9 +140,9 @@ func (b *Blueflood) fetchSingleSeries(metric api.GraphiteMetric, sampleMethod ap
 	}
 
 	params := url.Values{}
-	params.Set("from", strconv.FormatInt(timerange.Start*1000, 10))
-	params.Set("to", strconv.FormatInt(timerange.End*1000, 10))
-	params.Set("resolution", bluefloodResolution(timerange.Resolution))
+	params.Set("from", strconv.FormatInt(timerange.Start()*1000, 10))
+	params.Set("to", strconv.FormatInt(timerange.End()*1000, 10))
+	params.Set("resolution", bluefloodResolution(timerange.Resolution()))
 	params.Set("select", fmt.Sprintf("numPoints,%s", strings.ToLower(selectResultField)))
 
 	queryUrl.RawQuery = params.Encode()

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -23,7 +23,11 @@ import (
 )
 
 func Test_Blueflood(t *testing.T) {
-	timerange, _ := api.NewTimerange(100, 105, 5)
+	timerange, err := api.NewTimerange(100, 105, 5)
+	if err != nil {
+		t.Fatalf("invalid testcase timerange")
+		return
+	}
 	for _, test := range []struct {
 		metricMap          map[api.GraphiteMetric]api.TaggedMetric
 		queryMetric        api.TaggedMetric
@@ -53,7 +57,7 @@ func Test_Blueflood(t *testing.T) {
 			},
 			predicate:    nil,
 			sampleMethod: api.SampleMean,
-			timerange:    timerange,
+			timerange:    *timerange,
 			baseUrl:      "https://blueflood.url",
 			tenantId:     "square",
 			queryUrl:     "https://blueflood.url/v2.0/square/views/some.key.graphite?from=1000&resolution=FULL&select=numPoints%2Caverage&to=6000",
@@ -87,7 +91,7 @@ func Test_Blueflood(t *testing.T) {
 						}),
 					},
 				},
-				Timerange: timerange,
+				Timerange: *timerange,
 				Name:      "",
 			},
 		},

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Test_Blueflood(t *testing.T) {
-	timerange, err := api.NewTimerange(100, 105, 5)
+	timerange, err := api.NewTimerange(1000, 6000, 5)
 	if err != nil {
 		t.Fatalf("invalid testcase timerange")
 		return

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func Test_Blueflood(t *testing.T) {
+	timerange, _ := api.NewTimerange(100, 105, 5)
 	for _, test := range []struct {
 		metricMap          map[api.GraphiteMetric]api.TaggedMetric
 		queryMetric        api.TaggedMetric
@@ -52,7 +53,7 @@ func Test_Blueflood(t *testing.T) {
 			},
 			predicate:    nil,
 			sampleMethod: api.SampleMean,
-			timerange:    api.Timerange{1, 6, 5},
+			timerange:    timerange,
 			baseUrl:      "https://blueflood.url",
 			tenantId:     "square",
 			queryUrl:     "https://blueflood.url/v2.0/square/views/some.key.graphite?from=1000&resolution=FULL&select=numPoints%2Caverage&to=6000",
@@ -86,7 +87,7 @@ func Test_Blueflood(t *testing.T) {
 						}),
 					},
 				},
-				Timerange: api.Timerange{1, 6, 5},
+				Timerange: timerange,
 				Name:      "",
 			},
 		},

--- a/api/types.go
+++ b/api/types.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"regexp"
 	"sort"
 )
@@ -172,8 +173,17 @@ func (tr Timerange) Resolution() int64 {
 
 // NewTimerange creates a timerange which is validated, providing error otherwise.
 func NewTimerange(start, end, resolution int64) (*Timerange, error) {
-	if resolution == 0 || start%resolution != 0 || end%resolution != 0 || start > end {
-		return nil, errors.New("invalid timernage")
+	if resolution <= 0 {
+		return nil, errors.New(fmt.Sprintf("resolution must be more than 0 (resolution=%d)", resolution))
+	}
+	if start%resolution != 0 {
+		return nil, errors.New(fmt.Sprintf("start % resolution must be 0 (start=%d, resolution=%d)", start, resolution))
+	}
+	if end%resolution != 0 {
+		return nil, errors.new(fmt.Sprintf("end % resolution must be 0 (end=%d, resolution=%d)", end, resolution))
+	}
+	if start > end {
+		return nil, errors.new(fmt.Sprintf("start must be <= end (start=%d, end=%d)", start, end))
 	}
 	return &Timerange{start: start, end: end, resolution: resolution}, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -170,20 +170,12 @@ func (tr Timerange) Resolution() int64 {
 	return tr.start
 }
 
-func NewTimerange(start, end, resolution int64) (Timerange, error) {
-	result := Timerange{start: start, end: end, resolution: resolution}
-	if !result.isValid() {
-		return Timerange{}, errors.New("invalid timerange")
+// NewTimerange creates a timerange which is validated, providing error otherwise.
+func NewTimerange(start, end, resolution int64) (*Timerange, error) {
+	if resolution == 0 || start%resolution != 0 || end%resolution != 0 || start > end {
+		return nil, errors.New("invalid timernage")
 	}
-	return result, nil
-}
-
-// IsValid determines whether the given timerange meets the constraint.
-func (tr Timerange) isValid() bool {
-	return tr.resolution > 0 &&
-		tr.start%tr.resolution == 0 &&
-		tr.end%tr.resolution == 0 &&
-		tr.start <= tr.end
+	return &Timerange{start: start, end: end, resolution: resolution}, nil
 }
 
 func snap(n, boundary int64) int64 {
@@ -254,10 +246,6 @@ type SeriesList struct {
 
 // IsValid determines whether the given time series is valid.
 func (list SeriesList) isValid() bool {
-	if !list.Timerange.isValid() {
-		// timerange must be valid.
-		return false
-	}
 	for _, series := range list.Series {
 		// # of slots per series must be valid.
 		if len(series.Values) != list.Timerange.Slots() {

--- a/api/types.go
+++ b/api/types.go
@@ -180,10 +180,10 @@ func NewTimerange(start, end, resolution int64) (*Timerange, error) {
 		return nil, errors.New(fmt.Sprintf("start % resolution must be 0 (start=%d, resolution=%d)", start, resolution))
 	}
 	if end%resolution != 0 {
-		return nil, errors.new(fmt.Sprintf("end % resolution must be 0 (end=%d, resolution=%d)", end, resolution))
+		return nil, errors.New(fmt.Sprintf("end % resolution must be 0 (end=%d, resolution=%d)", end, resolution))
 	}
 	if start > end {
-		return nil, errors.new(fmt.Sprintf("start must be <= end (start=%d, end=%d)", start, end))
+		return nil, errors.New(fmt.Sprintf("start must be <= end (start=%d, end=%d)", start, endg))
 	}
 	return &Timerange{start: start, end: end, resolution: resolution}, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -177,10 +177,10 @@ func NewTimerange(start, end, resolution int64) (*Timerange, error) {
 		return nil, errors.New(fmt.Sprintf("resolution must be more than 0 (resolution=%d)", resolution))
 	}
 	if start%resolution != 0 {
-		return nil, errors.New(fmt.Sprintf("start % resolution must be 0 (start=%d, resolution=%d)", start, resolution))
+		return nil, errors.New(fmt.Sprintf("start %% resolution (mod) must be 0 (start=%d, resolution=%d)", start, resolution))
 	}
 	if end%resolution != 0 {
-		return nil, errors.New(fmt.Sprintf("end % resolution must be 0 (end=%d, resolution=%d)", end, resolution))
+		return nil, errors.New(fmt.Sprintf("end %% resolution (mod) must be 0 (end=%d, resolution=%d)", end, resolution))
 	}
 	if start > end {
 		return nil, errors.New(fmt.Sprintf("start must be <= end (start=%d, end=%d)", start, end))

--- a/api/types.go
+++ b/api/types.go
@@ -183,7 +183,7 @@ func NewTimerange(start, end, resolution int64) (*Timerange, error) {
 		return nil, errors.New(fmt.Sprintf("end % resolution must be 0 (end=%d, resolution=%d)", end, resolution))
 	}
 	if start > end {
-		return nil, errors.New(fmt.Sprintf("start must be <= end (start=%d, end=%d)", start, endg))
+		return nil, errors.New(fmt.Sprintf("start must be <= end (start=%d, end=%d)", start, end))
 	}
 	return &Timerange{start: start, end: end, resolution: resolution}, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -162,12 +162,12 @@ func (tr Timerange) Start() int64 {
 
 // End() returns the .end field
 func (tr Timerange) End() int64 {
-	return tr.start
+	return tr.end
 }
 
 // Resolution() returns the .resolution field
 func (tr Timerange) Resolution() int64 {
-	return tr.start
+	return tr.resolution
 }
 
 // NewTimerange creates a timerange which is validated, providing error otherwise.
@@ -196,18 +196,18 @@ func snap(n, boundary int64) int64 {
 // Round() will fix some invalid timeranges by rounding their starts and ends.
 func (tr Timerange) Snap() Timerange {
 
-	if tr.Resolution == 0 {
+	if tr.resolution == 0 {
 		return tr
 	}
-	tr.Start = snap(tr.Start, tr.Resolution)
-	tr.End = snap(tr.End, tr.Resolution)
+	tr.start = snap(tr.start, tr.resolution)
+	tr.end = snap(tr.end, tr.resolution)
 	return tr
 }
 
 // Later() returns a timerange which is forward in time by the amount given
 func (tr Timerange) Shift(time int64) Timerange {
-	tr.Start += time
-	tr.End += time
+	tr.start += time
+	tr.end += time
 	return tr.Snap()
 }
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -108,32 +108,35 @@ func TestTagSet_ParseTagSet(t *testing.T) {
 
 func TestTimerange(t *testing.T) {
 	for _, suite := range []struct {
-		Timerange     Timerange
+		Start         int64
+		End           int64
+		Resolution    int64
 		ExpectedValid bool
 		ExpectedSlots int
 	}{
 		// valid cases
-		{Timerange{0, 0, 1}, true, 1},
-		{Timerange{0, 1, 1}, true, 2},
-		{Timerange{0, 100, 1}, true, 101},
-		{Timerange{0, 100, 5}, true, 21},
+		{0, 0, 1, true, 1},
+		{0, 1, 1, true, 2},
+		{0, 100, 1, true, 101},
+		{0, 100, 5, true, 21},
 		// invalid cases
-		{Timerange{100, 0, 1}, false, 0},
-		{Timerange{0, 100, 6}, false, 0},
-		{Timerange{0, 100, 200}, false, 0},
+		{100, 0, 1, false, 0},
+		{0, 100, 6, false, 0},
+		{0, 100, 200, false, 0},
 	} {
 		a := assert.New(t).Contextf("input=%d:%d:%d",
-			suite.Timerange.start,
-			suite.Timerange.end,
-			suite.Timerange.resolution,
+			suite.Start,
+			suite.End,
+			suite.Resolution,
 		)
-		a.EqBool(suite.Timerange.isValid(), suite.ExpectedValid)
-		// If invalid, nothing else to check
+		timerange, err := NewTimerange(suite.Start, suite.End, suite.Resolution)
+		a.EqBool(timerange != nil, suite.ExpectedValid)
+		a.EqBool(err == nil, suite.ExpectedValid)
 		if !suite.ExpectedValid {
 			continue
 		}
 
-		a.EqInt(suite.Timerange.Slots(), suite.ExpectedSlots)
+		a.EqInt(timerange.Slots(), suite.ExpectedSlots)
 	}
 }
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -144,29 +144,29 @@ func TestTimerangeLater(t *testing.T) {
 	// Check that when moving forward, when moving backward, etc., time ranges work as expected.
 	ranges := []Timerange{
 		{
-			Start:      400,
-			End:        900,
-			Resolution: 100,
+			start:      400,
+			end:        900,
+			resolution: 100,
 		},
 		{
-			Start:      400,
-			End:        900,
-			Resolution: 1,
+			start:      400,
+			end:        900,
+			resolution: 1,
 		},
 		{
-			Start:      120,
-			End:        150,
-			Resolution: 30,
+			start:      120,
+			end:        150,
+			resolution: 30,
 		},
 		{
-			Start:      400,
-			End:        520,
-			Resolution: 40,
+			start:      400,
+			end:        520,
+			resolution: 40,
 		},
 	}
 	for _, time := range ranges {
 		// A sanity check for the above calculations.
-		if !time.IsValid() {
+		if _, err := NewTimerange(time.start, time.end, time.resolution); err != nil {
 			panic("Invalid timerange used as test case")
 		}
 	}
@@ -197,12 +197,12 @@ func TestTimerangeLater(t *testing.T) {
 	for _, offset := range offsets {
 		for _, time := range ranges {
 			later := time.Shift(offset)
-			if later.End-later.Start != time.End-time.Start || later.Resolution != time.Resolution || !later.IsValid() {
+			if later.End()-later.Start() != time.End()-time.Start() || later.Resolution() != time.Resolution() {
 				t.Errorf("Range %+v on offset %d fails; produces %+v", time, offset, later)
 				continue
 			}
 			later = time.Shift(-offset)
-			if later.End-later.Start != time.End-time.Start || later.Resolution != time.Resolution || !later.IsValid() {
+			if later.End()-later.Start() != time.End()-time.Start() || later.Resolution() != time.Resolution() {
 				t.Errorf("Range %+v on offset %d fails; produces %+v", time, -offset, later)
 				continue
 			}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -123,11 +123,11 @@ func TestTimerange(t *testing.T) {
 		{Timerange{0, 100, 200}, false, 0},
 	} {
 		a := assert.New(t).Contextf("input=%d:%d:%d",
-			suite.Timerange.Start,
-			suite.Timerange.End,
-			suite.Timerange.Resolution,
+			suite.Timerange.start,
+			suite.Timerange.end,
+			suite.Timerange.resolution,
 		)
-		a.EqBool(suite.Timerange.IsValid(), suite.ExpectedValid)
+		a.EqBool(suite.Timerange.isValid(), suite.ExpectedValid)
 		// If invalid, nothing else to check
 		if !suite.ExpectedValid {
 			continue

--- a/main/common/common.go
+++ b/main/common/common.go
@@ -17,9 +17,10 @@ package common
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/internal"
-	"os"
 )
 
 var (

--- a/main/query.go
+++ b/main/query.go
@@ -19,10 +19,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/square/metrics/api/backend/blueflood"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/query"
-	"os"
 )
 
 var (

--- a/main/query.go
+++ b/main/query.go
@@ -54,7 +54,7 @@ func main() {
 
 		n, ok := cmd.(query.Node)
 		if !ok {
-			fmt.Println("error: %+v doesn't implement Node", cmd)
+			fmt.Println(fmt.Sprintf("error: %+v doesn't implement Node", cmd))
 			continue
 		}
 		fmt.Println(query.PrintNode(n))

--- a/main/ruletester.go
+++ b/main/ruletester.go
@@ -22,12 +22,13 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"github.com/square/metrics/api"
-	"github.com/square/metrics/internal"
-	"github.com/square/metrics/main/common"
 	"io/ioutil"
 	"os"
 	"sort"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/internal"
+	"github.com/square/metrics/main/common"
 )
 
 var (

--- a/query/aggregate/aggregate_test.go
+++ b/query/aggregate/aggregate_test.go
@@ -220,7 +220,7 @@ func Test_applyAggregation(t *testing.T) {
 
 func Test_AggregateBy(t *testing.T) {
 
-	timerange, err := api.NewTimerange(40, 280, 6)
+	timerange, err := api.NewTimerange(42, 270, 6)
 	if err != nil {
 		t.Fatalf("Timerange for test is invalid")
 		return

--- a/query/aggregate/aggregate_test.go
+++ b/query/aggregate/aggregate_test.go
@@ -69,7 +69,7 @@ func Test_groupBy(t *testing.T) {
 					},
 				},
 			},
-			Timerange: api.Timerange{},
+			Timerange: api.DefaultTimerange(),
 			Name:      "",
 		}
 	)
@@ -277,7 +277,7 @@ func Test_AggregateBy(t *testing.T) {
 				},
 			},
 		},
-		timerange,
+		*timerange,
 		"Test.List",
 	}
 

--- a/query/aggregate/aggregate_test.go
+++ b/query/aggregate/aggregate_test.go
@@ -219,6 +219,13 @@ func Test_applyAggregation(t *testing.T) {
 }
 
 func Test_AggregateBy(t *testing.T) {
+
+	timerange, err := api.NewTimerange(40, 280, 6)
+	if err != nil {
+		t.Fatalf("Timerange for test is invalid")
+		return
+	}
+
 	var testList = api.SeriesList{
 		[]api.Timeseries{
 			api.Timeseries{
@@ -270,11 +277,7 @@ func Test_AggregateBy(t *testing.T) {
 				},
 			},
 		},
-		api.Timerange{
-			40,
-			280,
-			6,
-		},
+		timerange,
 		"Test.List",
 	}
 

--- a/query/command.go
+++ b/query/command.go
@@ -14,9 +14,7 @@
 
 package query
 
-import (
-	"github.com/square/metrics/api"
-)
+import "github.com/square/metrics/api"
 
 // Command is the final result of the parsing.
 // A command contains all the information to execute the
@@ -63,9 +61,13 @@ func (cmd *DescribeAllCommand) Execute(b api.Backend) (interface{}, error) {
 
 // Execute performs the query represented by the given query string, and returs the result.
 func (cmd *SelectCommand) Execute(b api.Backend) (interface{}, error) {
+	timerange, err := api.NewTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
+	if err != nil {
+		return nil, err
+	}
 	return evaluateExpressions(EvaluationContext{
 		Backend:      b,
-		Timerange:    cmd.context.Timerange,
+		Timerange:    timerange,
 		SampleMethod: cmd.context.SampleMethod,
 		Predicate:    cmd.predicate,
 	}, cmd.expressions)

--- a/query/command.go
+++ b/query/command.go
@@ -67,7 +67,7 @@ func (cmd *SelectCommand) Execute(b api.Backend) (interface{}, error) {
 	}
 	return evaluateExpressions(EvaluationContext{
 		Backend:      b,
-		Timerange:    timerange,
+		Timerange:    *timerange,
 		SampleMethod: cmd.context.SampleMethod,
 		Predicate:    cmd.predicate,
 	}, cmd.expressions)

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -16,9 +16,10 @@
 package query
 
 import (
+	"testing"
+
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/assert"
-	"testing"
 )
 
 type fakeApiBackend struct {

--- a/query/expression.go
+++ b/query/expression.go
@@ -87,9 +87,6 @@ func (value stringValue) toScalar() (float64, error) {
 type scalarValue float64
 
 func (value scalarValue) toSeriesList(timerange api.Timerange) (api.SeriesList, error) {
-	if !timerange.IsValid() {
-		return api.SeriesList{}, errors.New("Invalid context.Timerange")
-	}
 
 	series := make([]float64, timerange.Slots())
 	for i := range series {

--- a/query/expression.go
+++ b/query/expression.go
@@ -108,8 +108,8 @@ func (value scalarValue) toScalar() (float64, error) {
 }
 
 // toDuration will take a value, convert it to a string, and then parse it.
-// It produces a millisecond count as a signed int64.
-// the valid ns, us (µs), ms, s, m, h
+// the valid suffixes are: ns, us (µs), ms, s, m, h
+// It converts the return value to milliseconds.
 func toDuration(value value) (int64, error) {
 	timeString, err := value.toString()
 	if err != nil {
@@ -119,9 +119,6 @@ func toDuration(value value) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// Divide by 1000000 = 1,000,000 = 1 million
-	// to convert from the "nanoseconds" produced by Duration into
-	// the MILLISECONDS used by timeranges
 	return int64(duration / 1000000), nil
 }
 

--- a/query/expression.go
+++ b/query/expression.go
@@ -122,7 +122,7 @@ func toDuration(value value) (int64, error) {
 	// Divide by 1000000 = 1,000,000 = 1 million
 	// to convert from the "nanoseconds" produced by Duration into
 	// the MILLISECONDS used by timeranges
-	return duration / 1000000, nil
+	return int64(duration / 1000000), nil
 }
 
 // Expression is a piece of code, which can be evaluated in a given

--- a/query/expression.go
+++ b/query/expression.go
@@ -108,9 +108,9 @@ func (value scalarValue) toScalar() (float64, error) {
 }
 
 // toDuration will take a value, convert it to a string, and then parse it.
-// It produces a nanosecond count as a signed int64.
+// It produces a millisecond count as a signed int64.
 // the valid ns, us (µs), ms, s, m, h
-func toDuration(value value) (time.Duration, error) {
+func toDuration(value value) (int64, error) {
 	timeString, err := value.toString()
 	if err != nil {
 		return 0, err
@@ -119,7 +119,10 @@ func toDuration(value value) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	return duration, nil
+	// Divide by 1000000 = 1,000,000 = 1 million
+	// to convert from the "nanoseconds" produced by Duration into
+	// the MILLISECONDS used by timeranges
+	return duration / 1000000, nil
 }
 
 // Expression is a piece of code, which can be evaluated in a given

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -58,28 +58,21 @@ func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (value,
 }
 
 func Test_ScalarExpression(t *testing.T) {
+	timerangeA, _ := api.NewTimerange(0, 10, 2)
 	for _, test := range []struct {
-		expectSuccess  bool
 		expr           scalarExpression
 		timerange      api.Timerange
 		expectedSeries []api.Timeseries
 	}{
 		{
-			true,
 			scalarExpression{5},
-			api.Timerange{0, 10, 2},
+			timerangeA,
 			[]api.Timeseries{
 				api.Timeseries{
 					[]float64{5.0, 5.0, 5.0, 5.0, 5.0, 5.0},
 					api.NewTagSet(),
 				},
 			},
-		},
-		{
-			false,
-			scalarExpression{5},
-			api.Timerange{0, 10, 3},
-			[]api.Timeseries{},
 		},
 	} {
 		a := assert.New(t).Contextf("%+v", test)
@@ -90,10 +83,8 @@ func Test_ScalarExpression(t *testing.T) {
 			SampleMethod: api.SampleMean,
 		})
 
-		a.EqBool(err == nil, test.expectSuccess)
-
-		if !test.expectSuccess {
-			continue
+		if err != nil {
+			t.Fatalf("failed to convert number into serieslist")
 		}
 
 		a.EqInt(len(result.Series), len(test.expectedSeries))

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -38,7 +38,7 @@ type LiteralExpression struct {
 func (expr *LiteralExpression) Evaluate(context EvaluationContext) (value, error) {
 	return seriesListValue(api.SeriesList{
 		Series:    []api.Timeseries{api.Timeseries{expr.Values, api.NewTagSet()}},
-		Timerange: api.Timerange{},
+		Timerange: api.DefaultTimerange(),
 	}), nil
 }
 
@@ -49,7 +49,7 @@ type LiteralSeriesExpression struct {
 func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (value, error) {
 	result := api.SeriesList{
 		Series:    make([]api.Timeseries, len(expr.Values)),
-		Timerange: api.Timerange{},
+		Timerange: DefaultTimerange(),
 	}
 	for i, values := range expr.Values {
 		result.Series[i] = values
@@ -100,7 +100,7 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := EvaluationContext{FakeBackend{}, api.Timerange{}, api.SampleMean, nil}
+	emptyContext := EvaluationContext{FakeBackend{}, api.DefaultTimerange(), api.SampleMean, nil}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string
@@ -120,7 +120,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						TagSet: api.TagSet{},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			seriesListValue(api.SeriesList{
@@ -130,7 +130,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						TagSet: api.TagSet{},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			func(left, right float64) float64 { return left + right },
@@ -146,7 +146,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						Values: []float64{1, 2, 3},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			seriesListValue(api.SeriesList{
@@ -155,7 +155,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						Values: []float64{4, 5, 1},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			func(left, right float64) float64 { return left - right },
@@ -189,7 +189,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			seriesListValue(api.SeriesList{
@@ -207,7 +207,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			func(left, right float64) float64 { return left + right },
@@ -241,7 +241,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			seriesListValue(api.SeriesList{
@@ -259,7 +259,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			func(left, right float64) float64 { return left * right },
@@ -293,7 +293,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			seriesListValue(api.SeriesList{
@@ -311,7 +311,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
+				api.DefaultTimerange(),
 				"",
 			}),
 			func(left, right float64) float64 { return left - right },

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -49,7 +49,7 @@ type LiteralSeriesExpression struct {
 func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (value, error) {
 	result := api.SeriesList{
 		Series:    make([]api.Timeseries, len(expr.Values)),
-		Timerange: DefaultTimerange(),
+		Timerange: api.DefaultTimerange(),
 	}
 	for i, values := range expr.Values {
 		result.Series[i] = values

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -58,7 +58,11 @@ func (expr *LiteralSeriesExpression) Evaluate(context EvaluationContext) (value,
 }
 
 func Test_ScalarExpression(t *testing.T) {
-	timerangeA, _ := api.NewTimerange(0, 10, 2)
+	timerangeA, err := api.NewTimerange(0, 10, 2)
+	if err != nil {
+		t.Fatalf("invalid timerange used for testcase")
+		return
+	}
 	for _, test := range []struct {
 		expr           scalarExpression
 		timerange      api.Timerange
@@ -66,7 +70,7 @@ func Test_ScalarExpression(t *testing.T) {
 	}{
 		{
 			scalarExpression{5},
-			timerangeA,
+			*timerangeA,
 			[]api.Timeseries{
 				api.Timeseries{
 					[]float64{5.0, 5.0, 5.0, 5.0, 5.0, 5.0},

--- a/query/join_test.go
+++ b/query/join_test.go
@@ -36,12 +36,12 @@ var (
 
 	voidSeries = api.Timeseries{[]float64{0, 0, 0}, map[string]string{}}
 
-	emptyList = api.SeriesList{[]api.Timeseries{}, api.Timerange{}, ""}
-	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}, api.Timerange{}, ""}
-	dcList    = api.SeriesList{[]api.Timeseries{seriesDC_A, seriesDC_B, seriesDC_C}, api.Timerange{}, ""}
-	envList   = api.SeriesList{[]api.Timeseries{seriesENV_PROD, seriesENV_STAGE}, api.Timerange{}, ""}
+	emptyList = api.SeriesList{[]api.Timeseries{}, api.DefaultTimerange(), ""}
+	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}, api.DefaultTimerange(), ""}
+	dcList    = api.SeriesList{[]api.Timeseries{seriesDC_A, seriesDC_B, seriesDC_C}, api.DefaultTimerange(), ""}
+	envList   = api.SeriesList{[]api.Timeseries{seriesENV_PROD, seriesENV_STAGE}, api.DefaultTimerange(), ""}
 
-	voidList = api.SeriesList{[]api.Timeseries{voidSeries}, api.Timerange{}, ""}
+	voidList = api.SeriesList{[]api.Timeseries{voidSeries}, api.DefaultTimerange(), ""}
 )
 
 var testCases = []struct {

--- a/query/node.go
+++ b/query/node.go
@@ -132,7 +132,9 @@ type evaluationContextValue struct {
 
 // evaluationContextMap represents a collection of key-value pairs that form the evaluation context.
 type evaluationContextNode struct {
-	Timerange    api.Timerange    // Timerange to fetch data from
+	Start        int64            // Start of data timerange
+	End          int64            // End of data timerange
+	Resolution   int64            // Resolution of data timerange
 	SampleMethod api.SampleMethod // to use when up/downsampling to match requested resolution
 	assigned     map[string]bool  // a map for knowing which elements of the context have been assigned
 }
@@ -261,7 +263,9 @@ func (node *evaluationContextValue) Print(buffer *bytes.Buffer, indent int) {
 
 func (node *evaluationContextNode) Print(buffer *bytes.Buffer, indent int) {
 	printType(buffer, indent, node)
-	printUnknown(buffer, indent+1, node.Timerange)
+	printUnknown(buffer, indent+1, node.Start)
+	printUnknown(buffer, indent+1, node.End)
+	printUnknown(buffer, indent+1, node.Resolution)
 	printUnknown(buffer, indent+1, node.SampleMethod)
 	printUnknown(buffer, indent+1, node.assigned)
 }

--- a/query/parser.go
+++ b/query/parser.go
@@ -99,6 +99,7 @@ var dateFormats = []string{
 	time.RFC822Z,
 }
 
+// parseDate converts the given datestring (from one of the allowable formats) into a millisecond offset from the Unix epoch.
 func parseDate(date string) (int64, error) {
 	intValue, err := strconv.ParseInt(date, 10, 64)
 	if err == nil {
@@ -108,8 +109,6 @@ func parseDate(date string) (int64, error) {
 	for _, format := range dateFormats {
 		t, err := time.Parse(format, date)
 		if err == nil {
-			// Multiply the number of seconds by 1000 to convert to milliseconds,
-			// and divide the number of extra nanoseconds by 1 million to convert to milliseconds.
 			return t.Unix()*1000 + int64(t.Nanosecond()/1000000), nil
 		}
 		errorMessage += "\nfailed: " + err.Error()

--- a/query/parser.go
+++ b/query/parser.go
@@ -282,7 +282,7 @@ func (p *Parser) addPropertyValue(value string) {
 
 func (p *Parser) addEvaluationContext() {
 	p.pushNode(&evaluationContextNode{
-		api.DefaultTimerange(),
+		0, 0, 30,
 		api.SampleMean,
 		make(map[string]bool),
 	})
@@ -347,9 +347,9 @@ func (p *Parser) insertPropertyKeyValue() {
 			})
 		}
 		if key == "from" {
-			contextNode.Timerange, _ = api.NewTimerange(unix, contextNode.Timerange.End(), contextNode.Timerange.Resolution())
+			contextNode.Start = unix
 		} else {
-			contextNode.Timerange, _ = api.NewTimerange(contextNode.Timerange.Start(), unix, contextNode.Timerange.Resolution())
+			contextNode.End = unix
 		}
 	case "resolution":
 		// The value must be determined to be an int if the key is "resolution".
@@ -360,7 +360,7 @@ func (p *Parser) insertPropertyKeyValue() {
 				message: fmt.Sprintf("Expected number but parse failed; %s", err.Error()),
 			})
 		}
-		contextNode.Timerange, _ = api.NewTimerange(contextNode.Timerange.Start(), contextNode.Timerange.End(), intValue)
+		contextNode.Resolution = intValue
 	default:
 		p.flagSyntaxError(SyntaxError{
 			token:   key,

--- a/query/parser.go
+++ b/query/parser.go
@@ -108,7 +108,9 @@ func parseDate(date string) (int64, error) {
 	for _, format := range dateFormats {
 		t, err := time.Parse(format, date)
 		if err == nil {
-			return t.Unix(), nil
+			// Multiply the number of seconds by 1000 to convert to milliseconds,
+			// and divide the number of extra nanoseconds by 1 million to convert to milliseconds.
+			return t.Unix()*1000 + int64(t.Nanosecond()/1000000), nil
 		}
 		errorMessage += "\nfailed: " + err.Error()
 	}

--- a/query/parser.go
+++ b/query/parser.go
@@ -282,11 +282,7 @@ func (p *Parser) addPropertyValue(value string) {
 
 func (p *Parser) addEvaluationContext() {
 	p.pushNode(&evaluationContextNode{
-		api.Timerange{
-			Start:      0,
-			End:        0,
-			Resolution: 30,
-		},
+		api.DefaultTimerange(),
 		api.SampleMean,
 		make(map[string]bool),
 	})
@@ -351,9 +347,9 @@ func (p *Parser) insertPropertyKeyValue() {
 			})
 		}
 		if key == "from" {
-			contextNode.Timerange.Start = unix
+			contextNode.Timerange, _ = api.NewTimerange(unix, contextNode.Timerange.End(), contextNode.Timerange.Resolution())
 		} else {
-			contextNode.Timerange.End = unix
+			contextNode.Timerange, _ = api.NewTimerange(contextNode.Timerange.Start(), unix, contextNode.Timerange.Resolution())
 		}
 	case "resolution":
 		// The value must be determined to be an int if the key is "resolution".
@@ -364,7 +360,7 @@ func (p *Parser) insertPropertyKeyValue() {
 				message: fmt.Sprintf("Expected number but parse failed; %s", err.Error()),
 			})
 		}
-		contextNode.Timerange.Resolution = intValue
+		contextNode.Timerange, _ = api.NewTimerange(contextNode.Timerange.Start(), contextNode.Timerange.End(), intValue)
 	default:
 		p.flagSyntaxError(SyntaxError{
 			token:   key,

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -15,8 +15,9 @@
 package query
 
 import (
-	"github.com/square/metrics/assert"
 	"testing"
+
+	"github.com/square/metrics/assert"
 )
 
 func TestUnescapeLiteral(t *testing.T) {

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -42,7 +42,7 @@ func transformTimeseries(series api.Timeseries, transform transform, parameters 
 // timerangeScale takes an api.Timerange and computes the "scale" or duration of one sample (in seconds).
 // It is useful for transformations that normalize on time (like derivative or integral).
 func timerangeScale(timerange api.Timerange) float64 {
-	return float64(timerange.Resolution())
+	return float64(timerange.Resolution()) / 1000.0
 }
 
 // applyTransform applies the given transform to the entire list of series.

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -42,7 +42,7 @@ func transformTimeseries(series api.Timeseries, transform transform, parameters 
 // timerangeScale takes an api.Timerange and computes the "scale" or duration of one sample (in seconds).
 // It is useful for transformations that normalize on time (like derivative or integral).
 func timerangeScale(timerange api.Timerange) float64 {
-	return float64(timerange.Resolution)
+	return float64(timerange.Resolution())
 }
 
 // applyTransform applies the given transform to the entire list of series.

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -91,7 +91,7 @@ func TestTransformTimeseries(t *testing.T) {
 				continue
 			}
 			if len(result.Values) != len(transform.expected) {
-				t.Errorf("Expected result to have length %d but has length %d", transform.expected, result.Values)
+				t.Errorf("Expected result to have length %d but has length %d", len(transform.expected), len(result.Values))
 				continue
 			}
 			// Now check that the values are approximately equal

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -105,10 +105,12 @@ func TestTransformTimeseries(t *testing.T) {
 	}
 }
 
-// Skip handling the error and assume the timerange is well-formed.
-var testTimerange, _ = api.NewTimerange(758300, 758300+30*5, 30)
-
 func TestApplyTransform(t *testing.T) {
+	var testTimerange, err = api.NewTimerange(758300, 758300+30*5, 30)
+	if err != nil {
+		t.Fatalf("invalid timerange used for testcase")
+		return
+	}
 	epsilon := 1e-10
 	list := api.SeriesList{
 		Series: []api.Timeseries{
@@ -131,7 +133,7 @@ func TestApplyTransform(t *testing.T) {
 				},
 			},
 		},
-		Timerange: testTimerange,
+		Timerange: *testTimerange,
 		Name:      "test",
 	}
 	testCases := []struct {
@@ -212,6 +214,11 @@ func TestApplyTransform(t *testing.T) {
 }
 
 func TestApplyTransformFailure(t *testing.T) {
+	var testTimerange, err = api.NewTimerange(758300, 758300+30*5, 30)
+	if err != nil {
+		t.Fatalf("invalid timerange used for testcase")
+		return
+	}
 	list := api.SeriesList{
 		Series: []api.Timeseries{
 			{
@@ -233,7 +240,7 @@ func TestApplyTransformFailure(t *testing.T) {
 				},
 			},
 		},
-		Timerange: testTimerange,
+		Timerange: *testTimerange,
 		Name:      "test",
 	}
 	testCases := []struct {

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -105,6 +105,9 @@ func TestTransformTimeseries(t *testing.T) {
 	}
 }
 
+// Skip handling the error and assume the timerange is well-formed.
+var testTimerange, _ = api.NewTimerange(758300, 758300+30*5, 30)
+
 func TestApplyTransform(t *testing.T) {
 	epsilon := 1e-10
 	list := api.SeriesList{
@@ -128,12 +131,8 @@ func TestApplyTransform(t *testing.T) {
 				},
 			},
 		},
-		Timerange: api.Timerange{
-			Start:      758300,
-			End:        758300 + 30*5,
-			Resolution: 30,
-		},
-		Name: "test",
+		Timerange: testTimerange,
+		Name:      "test",
 	}
 	testCases := []struct {
 		transform transform
@@ -234,12 +233,8 @@ func TestApplyTransformFailure(t *testing.T) {
 				},
 			},
 		},
-		Timerange: api.Timerange{
-			Start:      758300,
-			End:        758300 + 30*5,
-			Resolution: 30,
-		},
-		Name: "test",
+		Timerange: testTimerange,
+		Name:      "test",
 	}
 	testCases := []struct {
 		transform transform

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -106,7 +106,7 @@ func TestTransformTimeseries(t *testing.T) {
 }
 
 func TestApplyTransform(t *testing.T) {
-	var testTimerange, err = api.NewTimerange(758300, 758300+30*5, 30)
+	var testTimerange, err = api.NewTimerange(758400, 758400+30*5, 30)
 	if err != nil {
 		t.Fatalf("invalid timerange used for testcase")
 		return
@@ -214,7 +214,7 @@ func TestApplyTransform(t *testing.T) {
 }
 
 func TestApplyTransformFailure(t *testing.T) {
-	var testTimerange, err = api.NewTimerange(758300, 758300+30*5, 30)
+	var testTimerange, err = api.NewTimerange(758400, 758400+30*5, 30)
 	if err != nil {
 		t.Fatalf("invalid timerange used for testcase")
 		return


### PR DESCRIPTION
This commit un-exports the fields `start`, `end`, and `resolution` from `api.Timerange`. To read them, the methods `.Start()`, `.End()`, and `.Resolution()` are provided.

To construct a new timerange, invoke `api.NewTimerange(start, end, resolution)` which returns `(api.Timerange, error)`.

All instances of `api.Timerange{ ... }` have been replaced with a call to `api.NewTimerange(...)` or `api.DefaultTimerange()` so that all instantiated timeranges are valid, even if they're never used.

To create a valid default timerange, you can call `api.DefaultTimerange()` which gives a timerange corresponding to `{0, 0, 30}`. 

It's still possible to construct an invalid timerange, namely the "zero" timerange `api.Timerange{}`. This behavior is nowhere used (they have all been replaced with `api.DefaultTimerange()`).

@jeeyoungk @achow 