### PR TITLE
Fill in timeseries with NaN for missing data (Blueflood backend)

### DIFF
--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -115,16 +115,16 @@ func (b *Blueflood) FetchSeries(metric api.TaggedMetric, predicate api.Predicate
 	}, nil
 }
 
-func addMetricPoint(metricPoint MetricPoint, field func(MetricPoint) float64, timerange api.Timerange, buckets [][]float64) error {
+func addMetricPoint(metricPoint MetricPoint, field func(MetricPoint) float64, timerange api.Timerange, buckets [][]float64) bool {
 	value := field(metricPoint)
 	// The index to assign within the array is computed using the timestamp.
 	// It floors to the nearest index.
 	index := (metricPoint.Timestamp - timerange.Start()) / timerange.Resolution()
 	if index < 0 || index >= int64(timerange.Slots()) {
-		return errors.New("index out of range")
+		return false
 	}
 	buckets[index] = append(buckets[index], value)
-	return nil
+	return true
 }
 
 func bucketsFromMetricPoints(metricPoints []MetricPoint, resultField func(MetricPoint) float64, timerange api.Timerange) [][]float64 {

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -116,9 +116,7 @@ func (b *Blueflood) FetchSeries(metric api.TaggedMetric, predicate api.Predicate
 }
 
 func addMetricPoint(metricPoint MetricPoint, field func(MetricPoint) float64, timerange api.Timerange, buckets [][]float64) error {
-	// TODO: check the result of .FieldByName against nil (or a panic will occur)
 	value := field(metricPoint)
-	// TODO: check the result of .FieldByName against nil (or a panic will occur)
 	timestamp := metricPoint.Timestamp
 	// The index to assign within the array is computed using the timestamp.
 	// It rounds to the nearest index.

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -218,6 +218,18 @@ func (b *Blueflood) fetchSingleSeries(metric api.GraphiteMetric, sampleMethod ap
 				value += v
 			}
 			values[i] = value / float64(len(bucket))
+		case api.SampleMin:
+			value := bucket[0]
+			for _, v := range bucket {
+				value = math.Min(value, v)
+			}
+			values[i] = value
+		case api.SampleMax:
+			value := bucket[0]
+			for _, v := range bucket {
+				value = math.Max(value, v)
+			}
+			values[i] = value
 		default:
 			return nil, errors.New(fmt.Sprintf("Unsupported SampleMethod %d", sampleMethod))
 		}

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -117,10 +117,9 @@ func (b *Blueflood) FetchSeries(metric api.TaggedMetric, predicate api.Predicate
 
 func addMetricPoint(metricPoint MetricPoint, field func(MetricPoint) float64, timerange api.Timerange, buckets [][]float64) error {
 	value := field(metricPoint)
-	timestamp := metricPoint.Timestamp
 	// The index to assign within the array is computed using the timestamp.
-	// It rounds to the nearest index.
-	index := (timestamp - timerange.Start() + timerange.Resolution()/2) / timerange.Resolution()
+	// It floors to the nearest index.
+	index := (metricPoint.Timestamp - timerange.Start()) / timerange.Resolution()
 	if index < 0 || index >= int64(timerange.Slots()) {
 		return errors.New("index out of range")
 	}

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Test_Blueflood(t *testing.T) {
-	timerange, err := api.NewTimerange(1000, 6000, 5)
+	timerange, err := api.NewTimerange(12000, 13000, 1000)
 	if err != nil {
 		t.Fatalf("invalid testcase timerange")
 		return
@@ -60,18 +60,18 @@ func Test_Blueflood(t *testing.T) {
 			timerange:    *timerange,
 			baseUrl:      "https://blueflood.url",
 			tenantId:     "square",
-			queryUrl:     "https://blueflood.url/v2.0/square/views/some.key.graphite?from=1000&resolution=FULL&select=numPoints%2Caverage&to=6000",
+			queryUrl:     "https://blueflood.url/v2.0/square/views/some.key.graphite?from=12000&resolution=FULL&select=numPoints%2Caverage&to=13000",
 			queryResponse: `{
         "unit": "unknown", 
         "values": [
           {
             "numPoints": 1,
-            "timestamp": 1000,
+            "timestamp": 12000,
             "average": 5
           },
           {
             "numPoints": 1,
-            "timestamp": 6000,
+            "timestamp": 13000,
             "average": 3
           }
         ],

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -131,11 +131,11 @@ func TestSeriesFromMetricPoints(t *testing.T) {
 			Average:   1,
 		},
 		{
-			Timestamp: 4199, // Slightly off to test rounding
+			Timestamp: 4299, // Test flooring behavior
 			Average:   2,
 		},
 		{
-			Timestamp: 4403, // Slightly off to test rounding
+			Timestamp: 4403, // Test flooring behavior
 			Average:   3,
 		},
 		{

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -15,7 +15,6 @@
 package blueflood
 
 import (
-	"math"
 	"testing"
 
 	"github.com/square/metrics/api"
@@ -147,24 +146,27 @@ func TestSeriesFromMetricPoints(t *testing.T) {
 			Timestamp: 4700,
 			Average:   5,
 		},
+		{
+			Timestamp: 4749,
+			Average:   6,
+		},
 	}
-	expected := []float64{math.NaN(), 1, 2, math.NaN(), 3, 4, math.NaN(), 5, math.NaN()}
-	result := seriesFromMetricPoints(points, func(point MetricPoint) float64 { return point.Average }, *timerange)
+	expected := [][]float64{{}, {1}, {2}, {}, {3}, {4}, {}, {5, 6}, {}}
+	result := bucketsFromMetricPoints(points, func(point MetricPoint) float64 { return point.Average }, *timerange)
 	if len(result) != len(expected) {
 		t.Fatalf("Expected %+v but got %+v", expected, result)
 		return
 	}
 	for i, expect := range expected {
-		if math.IsNaN(expect) != math.IsNaN(result[i]) {
-			t.Fatalf("Expected %+v but got %+v", expected, result)
+		if len(result[i]) != len(expect) {
+			t.Fatalf("Exected %+v but got %+v", expected, result)
 			return
 		}
-		if math.IsNaN(expect) {
-			continue
-		}
-		if expect != result[i] {
-			t.Fatalf("Expected %+v but got %+v", expected, result)
-			return
+		for j := range expect {
+			if result[i][j] != expect[j] {
+				t.Fatalf("Expected %+v but got %+v", expected, result)
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fills in missing data with `NaN`, so that all response series have `len(Values) == timerange.Slots()`. Also combines things with buckets if there's more than one datapoint returned for a given interval.

@jeeyoungk @achow 