### PR TITLE
Refactoring backend, command, and API

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -15,10 +15,17 @@
 package api
 
 // Backend describes how to fetch time-series data from a given backend.
+type FetchSeriesRequest struct {
+	Metric       TaggedMetric
+	Predicate    Predicate
+	SampleMethod SampleMethod
+	Timerange    Timerange
+	Api          API
+}
+
 type Backend interface {
-	Api() API
 	// FetchSeries fetches the series described by the provided TaggedMetric
 	// corresponding to the Timerange, down/upsampling if necessary using
 	// SampleMethod
-	FetchSeries(metric TaggedMetric, predicate Predicate, sampleMethod SampleMethod, timerange Timerange) (*SeriesList, error)
+	FetchSeries(request FetchSeriesRequest) (*SeriesList, error)
 }

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -106,10 +106,13 @@ func Test_Blueflood(t *testing.T) {
 		fakeHttpClient := mocks.NewFakeHttpClient()
 		fakeHttpClient.SetResponse(test.queryUrl, test.queryResponse)
 
-		b := NewBlueflood(fakeApi, test.baseUrl, test.tenantId)
+		b := NewBlueflood(test.baseUrl, test.tenantId)
 		b.client = fakeHttpClient
 
-		seriesList, err := b.FetchSeries(test.queryMetric, test.predicate, test.sampleMethod, test.timerange)
+		seriesList, err := b.FetchSeries(api.FetchSeriesRequest{
+			test.queryMetric, test.predicate, test.sampleMethod, test.timerange,
+			fakeApi,
+		})
 		if err != nil {
 			a.CheckError(err)
 			continue

--- a/main/query.go
+++ b/main/query.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	apiInstance := common.NewAPI()
-	backend := blueflood.NewBlueflood(apiInstance, *BluefloodUrl, *BluefloodTenantId)
+	backend := blueflood.NewBlueflood(*BluefloodUrl, *BluefloodTenantId)
 
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
@@ -59,7 +59,7 @@ func main() {
 		}
 		fmt.Println(query.PrintNode(n))
 
-		result, err := cmd.Execute(backend)
+		result, err := cmd.Execute(backend, apiInstance)
 		if err != nil {
 			fmt.Println("execution error:", err.Error())
 			continue

--- a/query/command.go
+++ b/query/command.go
@@ -24,7 +24,7 @@ import (
 // given query against the API.
 type Command interface {
 	// Execute the given command. Returns JSON-encodable result or an error.
-	Execute(b api.Backend) (interface{}, error)
+	Execute(api.Backend, api.API) (interface{}, error)
 }
 
 // DescribeCommand describes the tag set managed by the given metric indexer.
@@ -46,8 +46,8 @@ type SelectCommand struct {
 }
 
 // Execute returns the list of tags satisfying the provided predicate.
-func (cmd *DescribeCommand) Execute(b api.Backend) (interface{}, error) {
-	tags, _ := b.Api().GetAllTags(cmd.metricName)
+func (cmd *DescribeCommand) Execute(b api.Backend, a api.API) (interface{}, error) {
+	tags, _ := a.GetAllTags(cmd.metricName)
 	output := make([]string, 0, len(tags))
 	for _, tag := range tags {
 		if cmd.predicate.Apply(tag) {
@@ -59,8 +59,8 @@ func (cmd *DescribeCommand) Execute(b api.Backend) (interface{}, error) {
 }
 
 // Execute of a DescribeAllCommand returns the list of all metrics.
-func (cmd *DescribeAllCommand) Execute(b api.Backend) (interface{}, error) {
-	result, err := b.Api().GetAllMetrics()
+func (cmd *DescribeAllCommand) Execute(b api.Backend, a api.API) (interface{}, error) {
+	result, err := a.GetAllMetrics()
 	if err == nil {
 		sort.Sort(api.MetricKeys(result))
 	}
@@ -68,7 +68,7 @@ func (cmd *DescribeAllCommand) Execute(b api.Backend) (interface{}, error) {
 }
 
 // Execute performs the query represented by the given query string, and returs the result.
-func (cmd *SelectCommand) Execute(b api.Backend) (interface{}, error) {
+func (cmd *SelectCommand) Execute(b api.Backend, a api.API) (interface{}, error) {
 	timerange, err := api.NewTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
 	if err != nil {
 		return nil, err

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -38,15 +38,9 @@ func (f simpleFakeApi) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error)
 	}, nil
 }
 
-func (f fakeApiBackend) Api() api.API {
-	return simpleFakeApi{}
-}
-
-func (f fakeApiBackend) FetchSeries(
-	metric api.TaggedMetric,
-	predicate api.Predicate,
-	sampleMethod api.SampleMethod,
-	timerange api.Timerange) (*api.SeriesList, error) {
+func (f fakeApiBackend) FetchSeries(request api.FetchSeriesRequest) (*api.SeriesList, error) {
+	metric := request.Metric
+	timerange := request.Timerange
 	if metric.MetricKey == "error_series" {
 		return nil, errors.New("backend error")
 	} else if metric.MetricKey == "series_1" {
@@ -99,7 +93,7 @@ func TestCommand_Describe(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*DescribeCommand)
-		rawResult, _ := command.Execute(test.backend)
+		rawResult, _ := command.Execute(test.backend, simpleFakeApi{})
 		parsedResult := rawResult.([]string)
 		a.EqInt(len(parsedResult), test.length)
 	}
@@ -159,7 +153,7 @@ func TestCommand_Select(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*SelectCommand)
-		rawResult, err := command.Execute(fakeBackend)
+		rawResult, err := command.Execute(fakeBackend, simpleFakeApi{})
 		if err != nil {
 			if !test.expectError {
 				a.Errorf("Unexpected error while executing: %s", err.Error())

--- a/query/expression.go
+++ b/query/expression.go
@@ -31,12 +31,10 @@ import (
 // * Contains current timerange being queried for - this can be
 // changed by say, application of time shift function.
 type EvaluationContext struct {
-	// Backend to fetch data from
-	Backend api.Backend
-	// Timerange to fetch data from
-	Timerange api.Timerange
-	// SampleMethod to use when up/downsampling to match the requested resolution
-	SampleMethod api.SampleMethod
+	Backend      api.Backend      // Backend to fetch data from
+	API          api.API          // Api to obtain metadata from
+	Timerange    api.Timerange    // Timerange to fetch data from
+	SampleMethod api.SampleMethod // SampleMethod to use when up/downsampling to match the requested resolution
 	Predicate    api.Predicate
 }
 
@@ -161,7 +159,10 @@ func (expr *metricFetchExpression) Evaluate(context EvaluationContext) (value, e
 		predicate = &andPredicate{[]api.Predicate{expr.predicate, context.Predicate}}
 	}
 
-	series, err := context.Backend.FetchSeries(api.TaggedMetric{api.MetricKey(expr.metricName), nil}, predicate, context.SampleMethod, context.Timerange)
+	series, err := context.Backend.FetchSeries(api.FetchSeriesRequest{
+		api.TaggedMetric{api.MetricKey(expr.metricName), nil}, predicate, context.SampleMethod, context.Timerange,
+		context.API,
+	})
 	if err != nil {
 		return seriesListValue{}, err
 	}

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -27,7 +27,7 @@ func (b FakeBackend) Api() api.API {
 	return nil
 }
 
-func (b FakeBackend) FetchSeries(metric api.TaggedMetric, tagConstraints api.Predicate, sampleMethod api.SampleMethod, timerange api.Timerange) (*api.SeriesList, error) {
+func (b FakeBackend) FetchSeries(api.FetchSeriesRequest) (*api.SeriesList, error) {
 	return &api.SeriesList{}, nil
 }
 
@@ -100,7 +100,7 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := EvaluationContext{FakeBackend{}, api.DefaultTimerange(), api.SampleMean, nil}
+	emptyContext := EvaluationContext{FakeBackend{}, nil, api.DefaultTimerange(), api.SampleMean, nil}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string


### PR DESCRIPTION

    
    * Backend used to have a reference to API, but this is now removed.
    * Making Backend.Fetch()'s arguments into a single object - this allows
    us to add more parameters in future with ease.
    * Refactoring the backend to not have API() endpoint.
    * Refactoring EvaluationContext to have an API field.
    * Refactoring Command to have API as an argument.
