### PR TITLE
Parallel fetch with refactor to use "MultiBackend."

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -28,3 +28,10 @@ type Backend interface {
 	// SampleMethod
 	FetchSingleSeries(request FetchSeriesRequest) (Timeseries, error)
 }
+
+type MultiBackend interface {
+	// FetchManySeries fetches the series provided by the given TaggedMetrics
+	// corresponding to the Timerange, down/upsampling if necessary using
+	// SampleMethod. It may fetch in series or parallel, etc.
+	FetchMultipleSeries(metrics []TaggedMetric, sampleMethod SampleMethod, timerange Timerange, api API) (SeriesList, error)
+}

--- a/api/backend/multibackend.go
+++ b/api/backend/multibackend.go
@@ -1,0 +1,129 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"github.com/square/metrics/api"
+)
+
+type SequentialMultiBackend struct {
+	Backend api.Backend
+}
+
+func (m *SequentialMultiBackend) FetchMultipleSeries(metrics []api.TaggedMetric, sampleMethod api.SampleMethod, timerange api.Timerange, myAPI api.API) (api.SeriesList, error) {
+
+	series := make([]api.Timeseries, len(metrics))
+	var err error = nil
+	for i, metric := range metrics {
+		series[i], err = m.Backend.FetchSingleSeries(api.FetchSeriesRequest{
+			Metric:       metric,
+			SampleMethod: sampleMethod,
+			Timerange:    timerange,
+			Api:          myAPI,
+		})
+		if err != nil {
+			return api.SeriesList{}, err
+		}
+	}
+
+	return api.SeriesList{
+		Series:    series,
+		Timerange: timerange,
+	}, nil
+}
+
+type ParallelMultiBackend struct {
+	limit   int
+	tickets chan struct{}
+	Backend api.Backend
+}
+
+func NewParallelMultiBackend(backend api.Backend, limit int) ParallelMultiBackend {
+	tickets := make(chan struct{}, limit)
+	for i := 0; i < limit; i++ {
+		tickets <- struct{}{}
+	}
+	return ParallelMultiBackend{
+		limit:   limit,
+		tickets: tickets,
+		Backend: backend,
+	}
+}
+
+// fetchLazy issues a goroutine to compute the timeseries once a fetchticket becomes available.
+// It returns a channel to wait for the response to finish (the error).
+// It stores the result of the function invokation in the series pointer it is given.
+func (m *ParallelMultiBackend) fetchLazy(result *api.Timeseries, fun func() (api.Timeseries, error), channel chan error) {
+	go func() {
+		ticket := <-m.tickets
+		series, err := fun()
+		// Put the ticket back (regardless of whether caller drops)
+		m.tickets <- ticket
+		// Store the result
+		*result = series
+		// Return the error (and sync up with the caller).
+		channel <- err
+	}()
+}
+
+// fetchManyLazy abstracts upon fetchLazy so that looping over the resulting channels is not needed.
+// It returns any overall error, as well as a slice of the resulting timeseries.
+func (m *ParallelMultiBackend) fetchManyLazy(funs []func() (api.Timeseries, error)) ([]api.Timeseries, error) {
+	results := make([]api.Timeseries, len(funs))
+	channel := make(chan error, len(funs)) // Buffering the channel means the goroutines won't need to wait.
+	for i := range results {
+		m.fetchLazy(&results[i], funs[i], channel)
+	}
+	var err error = nil
+	for _ = range funs {
+		thisErr := <-channel
+		if thisErr != nil {
+			err = thisErr
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (m *ParallelMultiBackend) FetchMultipleSeries(metrics []api.TaggedMetric, sampleMethod api.SampleMethod, timerange api.Timerange, myAPI api.API) (api.SeriesList, error) {
+
+	funs := make([]func() (api.Timeseries, error), len(metrics))
+	for i, metric := range metrics {
+		// Since we want to create a closure, we want to close over this particular metric,
+		// rather than the variable itself (which is the same between iterations).
+		// We accomplish this here:
+		metric := metric
+		funs[i] = func() (api.Timeseries, error) {
+			return m.Backend.FetchSingleSeries(api.FetchSeriesRequest{
+				Metric:       metric,
+				SampleMethod: sampleMethod,
+				Timerange:    timerange,
+				Api:          myAPI,
+			})
+		}
+	}
+
+	resultSeries, err := m.fetchManyLazy(funs)
+	if err != nil {
+		return api.SeriesList{}, err
+	}
+
+	return api.SeriesList{
+		Series:    resultSeries,
+		Timerange: timerange,
+	}, nil
+}

--- a/main/query.go
+++ b/main/query.go
@@ -62,7 +62,7 @@ func main() {
 		}
 		fmt.Println(query.PrintNode(n))
 
-		result, err := cmd.Execute(&backend.SequentialMultiBackend{myBackend}, apiInstance)
+		result, err := cmd.Execute(backend.NewSequentialMultiBackend(myBackend), apiInstance)
 		if err != nil {
 			fmt.Println("execution error:", err.Error())
 			continue

--- a/main/query.go
+++ b/main/query.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/peterh/liner"
+	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/api/backend/blueflood"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/query"
@@ -36,7 +37,7 @@ func main() {
 	}
 
 	apiInstance := common.NewAPI()
-	backend := blueflood.NewBlueflood(*common.BluefloodUrl, *common.BluefloodTenantId)
+	myBackend := blueflood.NewBlueflood(*common.BluefloodUrl, *common.BluefloodTenantId)
 
 	l := liner.NewLiner()
 	defer l.Close()
@@ -61,7 +62,7 @@ func main() {
 		}
 		fmt.Println(query.PrintNode(n))
 
-		result, err := cmd.Execute(backend, apiInstance)
+		result, err := cmd.Execute(&backend.SequentialMultiBackend{myBackend}, apiInstance)
 		if err != nil {
 			fmt.Println("execution error:", err.Error())
 			continue

--- a/query/command.go
+++ b/query/command.go
@@ -25,7 +25,7 @@ import (
 // given query against the API.
 type Command interface {
 	// Execute the given command. Returns JSON-encodable result or an error.
-	Execute(api.Backend, api.API) (interface{}, error)
+	Execute(api.MultiBackend, api.API) (interface{}, error)
 	Name() string
 }
 
@@ -48,7 +48,7 @@ type SelectCommand struct {
 }
 
 // Execute returns the list of tags satisfying the provided predicate.
-func (cmd *DescribeCommand) Execute(b api.Backend, a api.API) (interface{}, error) {
+func (cmd *DescribeCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
 	tags, _ := a.GetAllTags(cmd.metricName)
 	output := make([]string, 0, len(tags))
 	for _, tag := range tags {
@@ -64,7 +64,7 @@ func (cmd *DescribeCommand) Name() string {
 }
 
 // Execute of a DescribeAllCommand returns the list of all metrics.
-func (cmd *DescribeAllCommand) Execute(b api.Backend, a api.API) (interface{}, error) {
+func (cmd *DescribeAllCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
 	result, err := a.GetAllMetrics()
 	if err == nil {
 		sort.Sort(api.MetricKeys(result))
@@ -76,13 +76,13 @@ func (cmd *DescribeAllCommand) Name() string {
 }
 
 // Execute performs the query represented by the given query string, and returs the result.
-func (cmd *SelectCommand) Execute(b api.Backend, a api.API) (interface{}, error) {
+func (cmd *SelectCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
 	timerange, err := api.NewSnappedTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
 	if err != nil {
 		return nil, err
 	}
 	return evaluateExpressions(EvaluationContext{
-		Backend:      b,
+		MultiBackend: b,
 		Timerange:    timerange,
 		SampleMethod: cmd.context.SampleMethod,
 		Predicate:    cmd.predicate,

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -145,7 +145,7 @@ func TestCommand_Select(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*SelectCommand)
-		rawResult, err := command.Execute(&backend.SequentialMultiBackend{fakeBackend}, fakeApi)
+		rawResult, err := command.Execute(backend.NewSequentialMultiBackend(fakeBackend), fakeApi)
 		if err != nil {
 			if !test.expectError {
 				a.Errorf("Unexpected error while executing: %s", err.Error())

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/assert"
 	"github.com/square/metrics/mocks"
 )
@@ -144,7 +145,7 @@ func TestCommand_Select(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*SelectCommand)
-		rawResult, err := command.Execute(fakeBackend, fakeApi)
+		rawResult, err := command.Execute(&backend.SequentialMultiBackend{fakeBackend}, fakeApi)
 		if err != nil {
 			if !test.expectError {
 				a.Errorf("Unexpected error while executing: %s", err.Error())

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/assert"
 )
 
@@ -76,7 +77,7 @@ func Test_ScalarExpression(t *testing.T) {
 		a := assert.New(t).Contextf("%+v", test)
 
 		result, err := evaluateToSeriesList(test.expr, EvaluationContext{
-			Backend:      FakeBackend{},
+			MultiBackend: &backend.SequentialMultiBackend{FakeBackend{}},
 			Timerange:    test.timerange,
 			SampleMethod: api.SampleMean,
 		})
@@ -94,7 +95,7 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := EvaluationContext{FakeBackend{}, nil, api.Timerange{}, api.SampleMean, nil}
+	emptyContext := EvaluationContext{&backend.SequentialMultiBackend{FakeBackend{}}, nil, api.Timerange{}, api.SampleMean, nil}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -77,7 +77,7 @@ func Test_ScalarExpression(t *testing.T) {
 		a := assert.New(t).Contextf("%+v", test)
 
 		result, err := evaluateToSeriesList(test.expr, EvaluationContext{
-			MultiBackend: &backend.SequentialMultiBackend{FakeBackend{}},
+			MultiBackend: backend.NewSequentialMultiBackend(FakeBackend{}),
 			Timerange:    test.timerange,
 			SampleMethod: api.SampleMean,
 		})
@@ -95,7 +95,7 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := EvaluationContext{&backend.SequentialMultiBackend{FakeBackend{}}, nil, api.Timerange{}, api.SampleMean, nil}
+	emptyContext := EvaluationContext{backend.NewSequentialMultiBackend(FakeBackend{}), nil, api.Timerange{}, api.SampleMean, nil}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -76,7 +76,7 @@ func (q QueryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 
-	result, err := cmd.Execute(&backend.SequentialMultiBackend{q.Backend}, q.API)
+	result, err := cmd.Execute(backend.NewSequentialMultiBackend(q.Backend), q.API)
 	if err != nil {
 		errorResponse(writer, http.StatusInternalServerError, err)
 		return

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/log"
 	"github.com/square/metrics/query"
 )
@@ -75,7 +76,7 @@ func (q QueryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 
-	result, err := cmd.Execute(q.Backend, q.API)
+	result, err := cmd.Execute(&backend.SequentialMultiBackend{q.Backend}, q.API)
 	if err != nil {
 		errorResponse(writer, http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
A `Backend` has only a `FetchSingleSeries` method, while a `MultiBackend` has only a `FetchMultipleSeries` method. 

There are two `MultiBackend`s defined (both in `api/backend/multibackend.go`). There are `SequentialMultiBackend` and `ParallelMultiBackend`. Both take a `Backend` as a field which they use for performing fetches.

The `ParallelMultiBackend` should be constructed using the `NewParallelMultiBackend( )` function which takes a `Backend` and a `limit` (for maximum number of simultaneous fetches).

Everywhere that previously used a `Backend` now uses `MultiBackend`, using `SequentialMultiBackend` wherever needed.

There are no tests unit tests for these multibackends (only integrations with existing backends) and no tests for the `ParallelMultiBackend` at all.