### PR TITLE
Limit the number of fetches

### DIFF
--- a/main/query.go
+++ b/main/query.go
@@ -62,7 +62,7 @@ func main() {
 		}
 		fmt.Println(query.PrintNode(n))
 
-		result, err := cmd.Execute(backend.NewSequentialMultiBackend(myBackend), apiInstance)
+		result, err := cmd.Execute(query.ExecutionContext{Backend: backend.NewSequentialMultiBackend(myBackend), API: apiInstance, FetchLimit: 1000})
 		if err != nil {
 			fmt.Println("execution error:", err.Error())
 			continue

--- a/main/ui.go
+++ b/main/ui.go
@@ -20,6 +20,7 @@ import (
 	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/api/backend/blueflood"
 	"github.com/square/metrics/main/common"
+	"github.com/square/metrics/query"
 	"github.com/square/metrics/ui"
 )
 
@@ -29,5 +30,5 @@ func main() {
 
 	apiInstance := common.NewAPI()
 	backend := backend.NewSequentialMultiBackend(blueflood.NewBlueflood(*common.BluefloodUrl, *common.BluefloodTenantId))
-	ui.Main(apiInstance, backend)
+	ui.Main(query.ExecutionContext{API: apiInstance, Backend: backend, FetchLimit: 1000})
 }

--- a/query/command.go
+++ b/query/command.go
@@ -82,12 +82,14 @@ func (cmd *SelectCommand) Execute(b api.MultiBackend, a api.API) (interface{}, e
 	if err != nil {
 		return nil, err
 	}
+	FetchLimit := 1000
 	return evaluateExpressions(EvaluationContext{
 		MultiBackend: b,
 		Timerange:    timerange,
 		SampleMethod: cmd.context.SampleMethod,
 		Predicate:    cmd.predicate,
 		API:          a,
+		FetchLimit:   &FetchLimit,
 	}, cmd.expressions)
 }
 

--- a/query/command.go
+++ b/query/command.go
@@ -90,8 +90,8 @@ func (cmd *DescribeAllCommand) Name() string {
 }
 
 // Execute asks for all metrics with the given name.
-func (cmd *DescribeMetricsCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
-	return a.GetMetricsForTag(cmd.tagKey, cmd.tagValue)
+func (cmd *DescribeMetricsCommand) Execute(context ExecutionContext) (interface{}, error) {
+	return context.API.GetMetricsForTag(cmd.tagKey, cmd.tagValue)
 }
 
 func (cmd *DescribeMetricsCommand) Name() string {

--- a/query/command.go
+++ b/query/command.go
@@ -89,14 +89,13 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 	if err != nil {
 		return nil, err
 	}
-	FetchLimit := context.FetchLimit
 	return evaluateExpressions(EvaluationContext{
 		MultiBackend: context.Backend,
 		Timerange:    timerange,
 		SampleMethod: cmd.context.SampleMethod,
 		Predicate:    cmd.predicate,
 		API:          context.API,
-		FetchLimit:   &FetchLimit,
+		FetchLimit:   NewFetchCounter(context.FetchLimit),
 	}, cmd.expressions)
 }
 

--- a/query/command.go
+++ b/query/command.go
@@ -89,7 +89,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 	if err != nil {
 		return nil, err
 	}
-	FetchLimit := 1000
+	FetchLimit := context.FetchLimit
 	return evaluateExpressions(EvaluationContext{
 		MultiBackend: context.Backend,
 		Timerange:    timerange,

--- a/query/command.go
+++ b/query/command.go
@@ -20,12 +20,19 @@ import (
 	"github.com/square/metrics/api"
 )
 
+// ExecutionContext is the context supplied when invoking a command.
+type ExecutionContext struct {
+	Backend    api.MultiBackend // the backend
+	API        api.API          // the api
+	FetchLimit int              // the maximum number of fetches
+}
+
 // Command is the final result of the parsing.
 // A command contains all the information to execute the
 // given query against the API.
 type Command interface {
 	// Execute the given command. Returns JSON-encodable result or an error.
-	Execute(api.MultiBackend, api.API) (interface{}, error)
+	Execute(ExecutionContext) (interface{}, error)
 	Name() string
 }
 
@@ -48,8 +55,8 @@ type SelectCommand struct {
 }
 
 // Execute returns the list of tags satisfying the provided predicate.
-func (cmd *DescribeCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
-	tags, _ := a.GetAllTags(cmd.metricName)
+func (cmd *DescribeCommand) Execute(context ExecutionContext) (interface{}, error) {
+	tags, _ := context.API.GetAllTags(cmd.metricName)
 	output := make([]string, 0, len(tags))
 	for _, tag := range tags {
 		if cmd.predicate.Apply(tag) {
@@ -64,8 +71,8 @@ func (cmd *DescribeCommand) Name() string {
 }
 
 // Execute of a DescribeAllCommand returns the list of all metrics.
-func (cmd *DescribeAllCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
-	result, err := a.GetAllMetrics()
+func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (interface{}, error) {
+	result, err := context.API.GetAllMetrics()
 	if err == nil {
 		sort.Sort(api.MetricKeys(result))
 	}
@@ -77,18 +84,18 @@ func (cmd *DescribeAllCommand) Name() string {
 }
 
 // Execute performs the query represented by the given query string, and returs the result.
-func (cmd *SelectCommand) Execute(b api.MultiBackend, a api.API) (interface{}, error) {
+func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error) {
 	timerange, err := api.NewSnappedTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
 	if err != nil {
 		return nil, err
 	}
 	FetchLimit := 1000
 	return evaluateExpressions(EvaluationContext{
-		MultiBackend: b,
+		MultiBackend: context.Backend,
 		Timerange:    timerange,
 		SampleMethod: cmd.context.SampleMethod,
 		Predicate:    cmd.predicate,
-		API:          a,
+		API:          context.API,
 		FetchLimit:   &FetchLimit,
 	}, cmd.expressions)
 }

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -77,7 +77,7 @@ func TestCommand_Describe(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*DescribeCommand)
-		rawResult, _ := command.Execute(nil, test.backend)
+		rawResult, _ := command.Execute(ExecutionContext{nil, test.backend, 1000})
 		parsedResult := rawResult.([]string)
 		a.EqInt(len(parsedResult), test.length)
 	}
@@ -199,7 +199,7 @@ func TestCommand_Select(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*SelectCommand)
-		rawResult, err := command.Execute(backend.NewSequentialMultiBackend(fakeBackend), fakeApi)
+		rawResult, err := command.Execute(ExecutionContext{backend.NewSequentialMultiBackend(fakeBackend), fakeApi, 1000})
 		if err != nil {
 			if !test.expectError {
 				a.Errorf("Unexpected error while executing: %s", err.Error())

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -225,9 +225,30 @@ func TestCommand_Select(t *testing.T) {
 	}
 
 	// Test that the limit is correct
-	rawCommand, err := Parse("select series_1 from 0 to 12 resolution 30")
+	command, err := Parse("select series_1, series_2 from 0 to 120 resolution 30")
 	if err != nil {
-		a.Errorf("Unexpected error while parsing")
+		t.Fatalf("Unexpected error while parsing")
 		return
+	}
+	context := ExecutionContext{backend.NewSequentialMultiBackend(fakeBackend), fakeApi, 3}
+	_, err = command.Execute(context)
+	if err != nil {
+		t.Fatalf("expected success with limit 3 but got err = %s", err.Error())
+		return
+	}
+	context.FetchLimit = 2
+	_, err = command.Execute(context)
+	if err == nil {
+		t.Fatalf("expected failure with limit = 2")
+		return
+	}
+	command, err = Parse("select series2 from 0 to 120 resolution 30")
+	if err != nil {
+		t.Fatalf("Unexpected error while parsing")
+		return
+	}
+	_, err = command.Execute(context)
+	if err != nil {
+		t.Fatalf("expected success with limit = 2 but got %s", err.Error())
 	}
 }

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -223,4 +223,11 @@ func TestCommand_Select(t *testing.T) {
 			}
 		}
 	}
+
+	// Test that the limit is correct
+	rawCommand, err := Parse("select series_1 from 0 to 12 resolution 30")
+	if err != nil {
+		a.Errorf("Unexpected error while parsing")
+		return
+	}
 }

--- a/query/expression.go
+++ b/query/expression.go
@@ -47,7 +47,7 @@ type fetchCounter struct {
 func NewFetchCounter(n int) fetchCounter {
 	f := fetchCounter{
 		count:  &n,
-		ticket: make(chan struct{}),
+		ticket: make(chan struct{}, 1),
 	}
 	f.ticket <- struct{}{}
 	return f
@@ -56,7 +56,7 @@ func NewFetchCounter(n int) fetchCounter {
 func (c fetchCounter) Consume(n int) bool {
 	<-c.ticket
 	*c.count -= n
-	r := *c.count < 0
+	r := *c.count >= 0
 	c.ticket <- struct{}{}
 	return r
 }

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -75,11 +75,12 @@ func Test_ScalarExpression(t *testing.T) {
 		},
 	} {
 		a := assert.New(t).Contextf("%+v", test)
-
+		fetchLimit := 1000
 		result, err := evaluateToSeriesList(test.expr, EvaluationContext{
 			MultiBackend: backend.NewSequentialMultiBackend(FakeBackend{}),
 			Timerange:    test.timerange,
 			SampleMethod: api.SampleMean,
+			FetchLimit:   &fetchLimit,
 		})
 
 		if err != nil {
@@ -95,7 +96,8 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := EvaluationContext{backend.NewSequentialMultiBackend(FakeBackend{}), nil, api.Timerange{}, api.SampleMean, nil}
+	fetchLimit := 1000
+	emptyContext := EvaluationContext{backend.NewSequentialMultiBackend(FakeBackend{}), nil, api.Timerange{}, api.SampleMean, nil, &fetchLimit}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -75,12 +75,11 @@ func Test_ScalarExpression(t *testing.T) {
 		},
 	} {
 		a := assert.New(t).Contextf("%+v", test)
-		fetchLimit := 1000
 		result, err := evaluateToSeriesList(test.expr, EvaluationContext{
 			MultiBackend: backend.NewSequentialMultiBackend(FakeBackend{}),
 			Timerange:    test.timerange,
 			SampleMethod: api.SampleMean,
-			FetchLimit:   &fetchLimit,
+			FetchLimit:   NewFetchCounter(1000),
 		})
 
 		if err != nil {
@@ -96,8 +95,7 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	fetchLimit := 1000
-	emptyContext := EvaluationContext{backend.NewSequentialMultiBackend(FakeBackend{}), nil, api.Timerange{}, api.SampleMean, nil, &fetchLimit}
+	emptyContext := EvaluationContext{backend.NewSequentialMultiBackend(FakeBackend{}), nil, api.Timerange{}, api.SampleMean, nil, NewFetchCounter(1000)}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -22,14 +22,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/square/metrics/api"
 	"github.com/square/metrics/log"
 	"github.com/square/metrics/query"
 )
 
 type QueryHandler struct {
-	API     api.API
-	Backend api.MultiBackend
+	context query.ExecutionContext
 }
 
 type Response struct {
@@ -75,7 +73,7 @@ func (q QueryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 
-	result, err := cmd.Execute(q.Backend, q.API)
+	result, err := cmd.Execute(q.context)
 	if err != nil {
 		errorResponse(writer, http.StatusInternalServerError, err)
 		return
@@ -93,10 +91,9 @@ func (h StaticHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reque
 	http.ServeFile(writer, request, res)
 }
 
-func Main(apiInstance api.API, backend api.MultiBackend) {
+func Main(context query.ExecutionContext) {
 	handler := QueryHandler{
-		API:     apiInstance,
-		Backend: backend,
+		context: context,
 	}
 
 	httpMux := http.NewServeMux()


### PR DESCRIPTION
An `ExecutionContext` type has been created which replaces the `(API, MultiBackend)` passed to each `.Execute(...)` call.

Before a fetch is performed, the number available is checked against the number of series desired. If not enough are available, the metric fetching expression returns an error.

@jeeyoungk @achow 