### PR TITLE
Unify durations 

### DIFF
--- a/main/query.go
+++ b/main/query.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	apiInstance := common.NewAPI()
-	myBackend := blueflood.NewBlueflood(*common.BluefloodUrl, *common.BluefloodTenantId)
+	myBackend := blueflood.NewBlueflood(blueflood.BluefloodClientConfig{*common.BluefloodUrl, *common.BluefloodTenantId})
 
 	l := liner.NewLiner()
 	defer l.Close()

--- a/main/ui.go
+++ b/main/ui.go
@@ -20,6 +20,7 @@ import (
 	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/api/backend/blueflood"
 	"github.com/square/metrics/main/common"
+	"github.com/square/metrics/query"
 	"github.com/square/metrics/ui"
 )
 
@@ -34,5 +35,5 @@ func main() {
 	}
 	blueflood := blueflood.NewBlueflood(bluefloodConfig)
 	backend := backend.NewSequentialMultiBackend(blueflood)
-	ui.Main(apiInstance, backend)
+	ui.Main(query.ExecutionContext{backend, apiInstance, 1000})
 }

--- a/main/ui.go
+++ b/main/ui.go
@@ -28,6 +28,6 @@ func main() {
 	common.SetupLogger()
 
 	apiInstance := common.NewAPI()
-	backend := backend.NewSequentialMultiBackend(blueflood.NewBlueflood(*common.BluefloodUrl, *common.BluefloodTenantId))
+	backend := backend.NewSequentialMultiBackend(blueflood.NewBlueflood(blueflood.BluefloodClientConfig{*common.BluefloodUrl, *common.BluefloodTenantId}))
 	ui.Main(apiInstance, backend)
 }

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -113,8 +113,8 @@ func TestCommand_Select(t *testing.T) {
 		expectError bool
 		expected    api.SeriesList
 	}{
-		{"select does_not_exist from 0 to 120 resolution 30", true, api.SeriesList{}},
-		{"select series_1 from 0 to 120 resolution 30", false, api.SeriesList{
+		{"select does_not_exist from 0 to 120 resolution '30ms'", true, api.SeriesList{}},
+		{"select series_1 from 0 to 120 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{1, 2, 3, 4, 5},
 				api.ParseTagSet("dc=west"),
@@ -122,7 +122,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "series_1",
 		}},
-		{"select series_1 + 1 from 0 to 120 resolution 30", false, api.SeriesList{
+		{"select series_1 + 1 from 0 to 120 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4, 5, 6},
 				api.ParseTagSet("dc=west"),
@@ -130,7 +130,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "",
 		}},
-		{"select series_1 * 2 from 0 to 120 resolution 30", false, api.SeriesList{
+		{"select series_1 * 2 from 0 to 120 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 4, 6, 8, 10},
 				api.ParseTagSet("dc=west"),
@@ -138,7 +138,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "",
 		}},
-		{"select aggregate.max(series_2) from 0 to 120 resolution 30", false, api.SeriesList{
+		{"select aggregate.max(series_2) from 0 to 120 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{3, 2, 3, 6, 5},
 				api.NewTagSet(),
@@ -146,7 +146,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "series_2",
 		}},
-		{"select series_1 from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select series_1 from 0 to 60 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{1, 2, 3},
 				api.ParseTagSet("dc=west"),
@@ -154,7 +154,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'31ms') from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select timeshift(series_1,'31ms') from 0 to 60 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -162,7 +162,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'62ms') from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select timeshift(series_1,'62ms') from 0 to 60 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{3, 4, 5},
 				api.ParseTagSet("dc=west"),
@@ -170,7 +170,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'29ms') from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select timeshift(series_1,'29ms') from 0 to 60 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -178,7 +178,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'-31ms') from 60 to 120 resolution 30", false, api.SeriesList{
+		{"select timeshift(series_1,'-31ms') from 60 to 120 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -186,7 +186,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: lateTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'-29ms') from 60 to 120 resolution 30", false, api.SeriesList{
+		{"select timeshift(series_1,'-29ms') from 60 to 120 resolution '30ms'", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -229,7 +229,7 @@ func TestCommand_Select(t *testing.T) {
 	}
 
 	// Test that the limit is correct
-	command, err := Parse("select series_1, series_2 from 0 to 120 resolution 30")
+	command, err := Parse("select series_1, series_2 from 0 to 120 resolution '30ms'")
 	if err != nil {
 		t.Fatalf("Unexpected error while parsing")
 		return
@@ -246,7 +246,7 @@ func TestCommand_Select(t *testing.T) {
 		t.Fatalf("expected failure with limit = 2")
 		return
 	}
-	command, err = Parse("select series2 from 0 to 120 resolution 30")
+	command, err = Parse("select series2 from 0 to 120 resolution '30ms'")
 	if err != nil {
 		t.Fatalf("Unexpected error while parsing")
 		return

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -122,7 +122,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "series_1",
 		}},
-		{"select series_1 + 1 from 0 to 120 resolution '30ms'", false, api.SeriesList{
+		{"select series_1 + 1 from 0 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4, 5, 6},
 				api.ParseTagSet("dc=west"),
@@ -138,7 +138,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "",
 		}},
-		{"select aggregate.max(series_2) from 0 to 120 resolution '30ms'", false, api.SeriesList{
+		{"select aggregate.max(series_2) from 0 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{3, 2, 3, 6, 5},
 				api.NewTagSet(),
@@ -154,7 +154,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'31ms') from 0 to 60 resolution '30ms'", false, api.SeriesList{
+		{"select timeshift(series_1,'31ms') from 0 to 60 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),

--- a/query/language.peg
+++ b/query/language.peg
@@ -203,7 +203,7 @@ TAG_NAME <-    IDENTIFIER
 # TODO - may be refactored later.
 IDENTIFIER <-  "`" CHAR* "`" / !(KEYWORD !ID_CONT) ID_SEGMENT ("." ID_SEGMENT)*
 # `[[a-z]]?` allows for relative timestamps
-TIMESTAMP <- <NUMBER [[a-z]]?> / STRING / <"now">
+TIMESTAMP <- <NUMBER [[a-z]]*> / STRING / <"now">
 ID_SEGMENT <-  ID_START ID_CONT*
 # Hyphen (-) is intentionally omitted, since it makes the language ambiguous.
 # If hyphens are needed, use backticks instead.

--- a/query/language.peg.go
+++ b/query/language.peg.go
@@ -1020,8 +1020,9 @@ func (p *Parser) Init() {
 													if !_rules[ruleNUMBER]() {
 														goto l20
 													}
+												l33:
 													{
-														position33, tokenIndex33, depth33 := position, tokenIndex, depth
+														position34, tokenIndex34, depth34 := position, tokenIndex, depth
 														{
 															position35, tokenIndex35, depth35 := position, tokenIndex, depth
 															if c := buffer[position]; c < rune('a') || c > rune('z') {
@@ -1032,16 +1033,15 @@ func (p *Parser) Init() {
 														l36:
 															position, tokenIndex, depth = position35, tokenIndex35, depth35
 															if c := buffer[position]; c < rune('A') || c > rune('Z') {
-																goto l33
+																goto l34
 															}
 															position++
 														}
 													l35:
-														goto l34
-													l33:
-														position, tokenIndex, depth = position33, tokenIndex33, depth33
+														goto l33
+													l34:
+														position, tokenIndex, depth = position34, tokenIndex34, depth34
 													}
-												l34:
 													depth--
 													add(rulePegText, position32)
 												}
@@ -3725,7 +3725,7 @@ func (p *Parser) Init() {
 			position, tokenIndex, depth = position285, tokenIndex285, depth285
 			return false
 		},
-		/* 28 TIMESTAMP <- <((&('N' | 'n') <(('n' / 'N') ('o' / 'O') ('w' / 'W'))>) | (&('"' | '\'') STRING) | (&('-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9') <(NUMBER ([a-z] / [A-Z])?)>))> */
+		/* 28 TIMESTAMP <- <((&('N' | 'n') <(('n' / 'N') ('o' / 'O') ('w' / 'W'))>) | (&('"' | '\'') STRING) | (&('-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9') <(NUMBER ([a-z] / [A-Z])*)>))> */
 		nil,
 		/* 29 ID_SEGMENT <- <(ID_START ID_CONT*)> */
 		func() bool {

--- a/query/parser.go
+++ b/query/parser.go
@@ -402,13 +402,19 @@ func (p *Parser) insertPropertyKeyValue() {
 	case "resolution":
 		// The value must be determined to be an int if the key is "resolution".
 		intValue, err := strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			p.flagSyntaxError(SyntaxError{
-				token:   value,
-				message: fmt.Sprintf("Expected number but parse failed; %s", err.Error()),
-			})
+		if err == nil {
+			contextNode.Resolution = intValue
+			break
 		}
-		contextNode.Resolution = intValue
+		duration, err := toDuration(stringValue(value))
+		if err == nil {
+			contextNode.Resolution = duration
+			break
+		}
+		p.flagSyntaxError(SyntaxError{
+			token:   value,
+			message: fmt.Sprintf("Expected number but parse failed; %s", err.Error()),
+		})
 	default:
 		p.flagSyntaxError(SyntaxError{
 			token:   key,

--- a/query/parser.go
+++ b/query/parser.go
@@ -102,6 +102,11 @@ var dateFormats = []string{
 // parseDate converts the given datestring (from one of the allowable formats) into a millisecond offset from the Unix epoch.
 func parseDate(date string, now time.Time) (int64, error) {
 
+	// Millisecond epoch timestamp.
+	if epoch, err := strconv.ParseInt(date); err != nil {
+		return epoch, nil
+	}
+
 	relativeTime, err := toDuration(stringValue(date))
 	if err != nil {
 		// A relative date.
@@ -359,9 +364,7 @@ func (p *Parser) insertPropertyKeyValue() {
 				message: fmt.Sprintf("Expected sampling method 'max', 'min', or 'mean' but got %s", value),
 			})
 		}
-	case "from":
-		fallthrough
-	case "to":
+	case "from", "to":
 		var unix int64
 		var err error
 		now := time.Now()

--- a/query/parser.go
+++ b/query/parser.go
@@ -99,7 +99,10 @@ var dateFormats = []string{
 	time.RFC822Z,
 }
 
-var relativeTimeRegexp = regexp.MustCompile(`^now\s*([+-])\s*([0-9]+)([smhdwMy])$`)
+var (
+	relativeTimeRegexp      = regexp.MustCompile(`^now\s*([+-])\s*([0-9]+)([smhdwMy])$`)
+	relativeTimeRegexpShort = regexp.MustCompile(`(-)\s*([0-9]+)([smhdwMy])$`)
+)
 
 // parseDate converts the given datestring (from one of the allowable formats) into a millisecond offset from the Unix epoch.
 func parseDate(date string) (int64, error) {
@@ -109,6 +112,10 @@ func parseDate(date string) (int64, error) {
 	}
 
 	matches := relativeTimeRegexp.FindStringSubmatch(date)
+	if matches == nil {
+		// If the long match fails, try to short match.
+		matches = relativeTimeRegexpShort.FindStringSubmatch(date)
+	}
 	if matches != nil {
 		// This match can be used to determine the duration of time.
 		now := time.Now().Unix()

--- a/query/parser.go
+++ b/query/parser.go
@@ -99,7 +99,7 @@ var dateFormats = []string{
 	time.RFC822Z,
 }
 
-var relativeTimeRegexp = regexp.MustCompile(`^now\s*([+-])\s*(\d+)([smhdMy])$`)
+var relativeTimeRegexp = regexp.MustCompile(`^now\s*([+-])\s*([0-9]+)([smhdwMy])$`)
 
 // parseDate converts the given datestring (from one of the allowable formats) into a millisecond offset from the Unix epoch.
 func parseDate(date string) (int64, error) {
@@ -109,7 +109,7 @@ func parseDate(date string) (int64, error) {
 	}
 
 	matches := relativeTimeRegexp.FindStringSubmatch(date)
-	if matches == nil {
+	if matches != nil {
 		// This match can be used to determine the duration of time.
 		now := time.Now().Unix()
 		sign := int64(1)
@@ -130,6 +130,12 @@ func parseDate(date string) (int64, error) {
 			offset *= 60 * 60
 		case "d":
 			offset *= 60 * 60 * 24
+		case "w":
+			offset *= 60 * 60 * 24 * 7
+		case "M":
+			offset *= 60 * 60 * 24 * 30
+		case "y":
+			offset *= 60 * 60 * 24 * 365
 		default:
 			// Won't happen, regex can't produce any other value.
 			panic(matches[3])
@@ -141,7 +147,7 @@ func parseDate(date string) (int64, error) {
 	if err == nil {
 		return intValue, nil
 	}
-	errorMessage := "Expected formatted date or unix timestamp number (seconds)"
+	errorMessage := "Expected formatted date or relative time (string of the form 'now - 5h' for example)"
 	for _, format := range dateFormats {
 		t, err := time.Parse(format, date)
 		if err == nil {

--- a/query/parser.go
+++ b/query/parser.go
@@ -130,7 +130,6 @@ func parseDate(date string) (int64, error) {
 		}
 		switch matches[3] {
 		case "s":
-			offset *= 1
 		case "m":
 			offset *= 60
 		case "h":

--- a/query/parser.go
+++ b/query/parser.go
@@ -378,20 +378,16 @@ func (p *Parser) insertPropertyKeyValue() {
 		}
 	case "resolution":
 		// The value must be determined to be an int if the key is "resolution".
-		intValue, err := strconv.ParseInt(value, 10, 64)
-		if err == nil {
+		if intValue, err := strconv.ParseInt(value, 10, 64); err == nil {
 			contextNode.Resolution = intValue
-			break
-		}
-		duration, err := toDuration(stringValue(value))
-		if err == nil {
+		} else if duration, err := toDuration(stringValue(value)); err == nil {
 			contextNode.Resolution = duration
-			break
+		} else {
+			p.flagSyntaxError(SyntaxError{
+				token:   value,
+				message: fmt.Sprintf("Expected number but parse failed; %s", err.Error()),
+			})
 		}
-		p.flagSyntaxError(SyntaxError{
-			token:   value,
-			message: fmt.Sprintf("Expected number but parse failed; %s", err.Error()),
-		})
 	default:
 		p.flagSyntaxError(SyntaxError{
 			token:   key,

--- a/query/parser.go
+++ b/query/parser.go
@@ -365,9 +365,7 @@ func (p *Parser) insertPropertyKeyValue() {
 		var unix int64
 		var err error
 		now := time.Now()
-		if unix, err = parseDate(value, now); err == nil {
-			// Valid, so do nothing.
-		} else {
+		if unix, err = parseDate(value, now); err != nil {
 			p.flagSyntaxError(SyntaxError{
 				token:   value,
 				message: err.Error(),

--- a/query/parser.go
+++ b/query/parser.go
@@ -105,6 +105,9 @@ func parseDate(date string, now time.Time) (int64, error) {
 	relativeTime, err := toDuration(stringValue(date))
 	if err != nil {
 		// A relative date.
+		if relativeTime < 0 {
+			return 0, fmt.Errorf("relative times should be negative: %s", date)
+		}
 		return now.Unix()*1000 + relativeTime, nil
 	}
 

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -35,6 +35,7 @@ func Test_parseRelativeTime(t *testing.T) {
 		{"-3m", 1413321686000, true},
 		{"-4h", 1413307466000, true},
 		{"-5d", 1412889866000, true},
+		{"-3w", 1411507466000, true},
 		{"-1M", 1410729866000, true},
 		{"-1y", 1381785866000, true},
 		// Bad relative timestamps

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -31,19 +31,20 @@ func Test_parseRelativeTime(t *testing.T) {
 		expectSuccess     bool
 	}{
 		// Valid relative timestamps
-		{"now-2s", 1413321864000, true},
-		{"now-3m", 1413321686000, true},
-		{"now -4h", 1413307466000, true},
-		{"now- 5d", 1412889866000, true},
-		{"now   -1M", 1410729866000, true},
-		{"now   -   1y", 1381785866000, true},
+		{"-2s", 1413321864000, true},
+		{"-3m", 1413321686000, true},
+		{"-4h", 1413307466000, true},
+		{"-5d", 1412889866000, true},
+		{"-1M", 1410729866000, true},
+		{"-1y", 1381785866000, true},
+		{"1s", 1413321867000, true},
+		{"+1s", 1413321867000, true},
 		// Bad relative timestamps
-		{"now-5", -1, false},
-		{"5d", -1, false},
+		{"-5", -1, false},
 		{"-5d", -1, false},
-		{"now 5d", -1, false},
-		{"now 5dd", -1, false},
-		{"now-5dd", -1, false},
+		{" 5d", -1, false},
+		{"5dd", -1, false},
+		{"-5dd", -1, false},
 		{"-5z", -1, false},
 	}
 

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -31,20 +31,24 @@ func Test_parseRelativeTime(t *testing.T) {
 		expectSuccess     bool
 	}{
 		// Valid relative timestamps
-		{"-2s", 1413321864000, true},
-		{"-3m", 1413321686000, true},
-		{"-4h", 1413307466000, true},
-		{"-5d", 1412889866000, true},
-		{"-1M", 1410729866000, true},
-		{"-1y", 1381785866000, true},
+		{"now-2s", 1413321864000, true},
+		{"now-3m", 1413321686000, true},
+		{"now -4h", 1413307466000, true},
+		{"now- 5d", 1412889866000, true},
+		{"now   -1M", 1410729866000, true},
+		{"now   -   1y", 1381785866000, true},
 		// Bad relative timestamps
-		{"-5", -1, false},
+		{"now-5", -1, false},
 		{"5d", -1, false},
+		{"-5d", -1, false},
+		{"now 5d", -1, false},
+		{"now 5dd", -1, false},
+		{"now-5dd", -1, false},
 		{"-5z", -1, false},
 	}
 
 	for _, c := range timestampTests {
-		ts, err := parseRelativeTime(c.timeString, now)
+		ts, err := parseDate(c.timeString)
 		if err != nil && c.expectSuccess {
 			t.Fatal("Received unexpected error from parseRelativeTime: ", err)
 		}

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -38,10 +38,9 @@ func Test_parseRelativeTime(t *testing.T) {
 		{"-1M", 1410729866000, true},
 		{"-1y", 1381785866000, true},
 		// Bad relative timestamps
-		{"1s", -1, true},
-		{"+1s", -1, true},
+		{"1s", -1, false},
+		{"+1s", -1, false},
 		{"-5", -1, false},
-		{"-5d", -1, false},
 		{" 5d", -1, false},
 		{"5dd", -1, false},
 		{"-5dd", -1, false},

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -37,9 +37,9 @@ func Test_parseRelativeTime(t *testing.T) {
 		{"-5d", 1412889866000, true},
 		{"-1M", 1410729866000, true},
 		{"-1y", 1381785866000, true},
-		{"1s", 1413321867000, true},
-		{"+1s", 1413321867000, true},
 		// Bad relative timestamps
+		{"1s", -1, true},
+		{"+1s", -1, true},
 		{"-5", -1, false},
 		{"-5d", -1, false},
 		{" 5d", -1, false},

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -40,7 +40,6 @@ func Test_parseRelativeTime(t *testing.T) {
 		// Bad relative timestamps
 		{"1s", -1, false},
 		{"+1s", -1, false},
-		{"-5", -1, false},
 		{" 5d", -1, false},
 		{"5dd", -1, false},
 		{"-5dd", -1, false},

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -81,7 +81,7 @@ var inputs = []string{
 	// selects - testing out property values
 	"select x from 0 to 0",
 	"select x from 0 to 0",
-	"select x from 0 to 0 resolution 10",
+	"select x from 0 to 0 resolution '10s'",
 	"select x from 0 to 0 resolution '10h'",
 	"select x from 0 to 0 resolution '300s'",
 	"select x from 0 to 0 resolution '17m'",
@@ -126,7 +126,7 @@ var syntaxErrorQuery = []string{
 	"select x to 0",
 	"select x from 0 from 1 to 0",
 	"select x from 0 to 1 to 0",
-	"select x from 0 resolution 30 resolution 25 to 0",
+	"select x from 0 resolution '30s' resolution '25s' to 0",
 	"select x from 0 from 1 sample by 'min' sample by 'min' to 0",
 }
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -82,6 +82,9 @@ var inputs = []string{
 	"select x from 0 to 0",
 	"select x from 0 to 0",
 	"select x from 0 to 0 resolution 10",
+	"select x from 0 to 0 resolution '10h'",
+	"select x from 0 to 0 resolution '300s'",
+	"select x from 0 to 0 resolution '17m'",
 	"select x from 0 to 0 sample by 'max'",
 	"select x from 0 to 0 sample   by 'max'",
 	// Leading/trailing whitespace

--- a/query/value.go
+++ b/query/value.go
@@ -101,7 +101,7 @@ func toDuration(value value) (int64, error) {
 	}
 	matches := durationRegexp.FindStringSubmatch(timeString)
 	if matches == nil {
-		return -1, fmt.Errorf("expected duration to be of the form `[0-9]+[smhdwMy]`")
+		return -1, fmt.Errorf("expected duration to be of the form `%s`", durationRegexp.String())
 	}
 	duration, err := strconv.ParseInt(matches[1], 10, 0)
 	if err != nil {

--- a/query/value.go
+++ b/query/value.go
@@ -89,10 +89,10 @@ func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
 }
 
-var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy]|ms)$`)
+var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy]|ms|hr|mo|yr)$`)
 
 // toDuration will take a value, convert it to a string, and then parse it.
-// the valid suffixes are: ns, us (µs), ms, s, m, h
+// the valid suffixes are: ms, s, m, min, h, hr, d, w, M, mo, y, yr.
 // It converts the return value to milliseconds.
 func toDuration(value value) (int64, error) {
 	timeString, err := value.toString()
@@ -115,15 +115,15 @@ func toDuration(value value) (int64, error) {
 		scale = 1000
 	case "m":
 		scale = 1000 * 60
-	case "h":
+	case "h", "hr":
 		scale = 1000 * 60 * 60
 	case "d":
 		scale = 1000 * 60 * 60 * 24
 	case "w":
 		scale = 1000 * 60 * 60 * 24 * 7
-	case "M":
+	case "M", "mo":
 		scale = 1000 * 60 * 60 * 24 * 30
-	case "y":
+	case "y", "yr":
 		scale = 1000 * 60 * 60 * 24 * 365
 	}
 	return int64(duration) * scale, nil

--- a/query/value.go
+++ b/query/value.go
@@ -124,7 +124,7 @@ func toDuration(value value) (int64, error) {
 	case "M":
 		scale = 1000 * 60 * 60 * 24 * 30
 	case "y":
-		scale = 1000 * 60860 * 24 * 365
+		scale = 1000 * 60 * 60 * 24 * 365
 	}
 	return int64(duration) * scale, nil
 }

--- a/query/value.go
+++ b/query/value.go
@@ -97,15 +97,15 @@ var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy]|ms)$`)
 func toDuration(value value) (int64, error) {
 	timeString, err := value.toString()
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 	matches := durationRegexp.FindStringSubmatch(timeString)
 	if matches == nil {
-		return 0, fmt.Errorf("expected duration to be of the form `[0-9]+[smhdwMy]`")
+		return -1, fmt.Errorf("expected duration to be of the form `[0-9]+[smhdwMy]`")
 	}
 	duration, err := strconv.ParseInt(matches[1], 10, 0)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 	scale := int64(1)
 	switch matches[2] {

--- a/query/value.go
+++ b/query/value.go
@@ -89,7 +89,7 @@ func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
 }
 
-var durationRegexp = regexp.MustCompile(`^([0-9]+)([smhdwMy])$`)
+var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy])$`)
 
 // toDuration will take a value, convert it to a string, and then parse it.
 // the valid suffixes are: ns, us (µs), ms, s, m, h

--- a/query/value.go
+++ b/query/value.go
@@ -89,7 +89,7 @@ func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
 }
 
-var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy])$`)
+var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy]|ms)$`)
 
 // toDuration will take a value, convert it to a string, and then parse it.
 // the valid suffixes are: ns, us (µs), ms, s, m, h
@@ -109,20 +109,22 @@ func toDuration(value value) (int64, error) {
 	}
 	scale := int64(1)
 	switch matches[2] {
+	case "ms":
+		// no change in scale
 	case "s":
-		scale = 1
+		scale = 1000
 	case "m":
-		scale = 60
+		scale = 1000 * 60
 	case "h":
-		scale = 60 * 60
+		scale = 1000 * 60 * 60
 	case "d":
-		scale = 60 * 60 * 24
+		scale = 1000 * 60 * 60 * 24
 	case "w":
-		scale = 60 * 60 * 24 * 7
+		scale = 1000 * 60 * 60 * 24 * 7
 	case "M":
-		scale = 60 * 60 * 24 * 30
+		scale = 1000 * 60 * 60 * 24 * 30
 	case "y":
-		scale = 60860 * 24 * 365
+		scale = 1000 * 60860 * 24 * 365
 	}
-	return int64(duration) * scale * 1000, nil
+	return int64(duration) * scale, nil
 }

--- a/query/value_test.go
+++ b/query/value_test.go
@@ -1,0 +1,52 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"testing"
+)
+
+func TestToDuration(t *testing.T) {
+	helper := func(given string, expected int64) {
+		actual, err := toDuration(stringValue(given))
+		if err != nil || actual != expected {
+			t.Fatalf("Expected %s to produce %d but got %d", given, expected, actual)
+		}
+	}
+	// Verify that all of the following produce the expected result:
+	helper("7ms", 7)
+	helper("7s", 7000)
+	helper("7m", 7000*60)
+	helper("7h", 7000*60*60)
+	helper("7hr", 7000*60*60)
+	helper("7d", 7000*60*60*24)
+	helper("7w", 7000*60*60*24*7)
+	helper("7M", 7000*60*60*24*30)
+	helper("7mo", 7000*60*60*24*30)
+	helper("7y", 7000*60*60*24*365)
+	helper("7yr", 7000*60*60*24*365)
+
+	helper("-7ms", -7)
+	helper("-7s", -7000)
+	helper("-7m", -7000*60)
+	helper("-7h", -7000*60*60)
+	helper("-7hr", -7000*60*60)
+	helper("-7d", -7000*60*60*24)
+	helper("-7w", -7000*60*60*24*7)
+	helper("-7M", -7000*60*60*24*30)
+	helper("-7mo", -7000*60*60*24*30)
+	helper("-7y", -7000*60*60*24*365)
+	helper("-7yr", -7000*60*60*24*365)
+}


### PR DESCRIPTION
When using relative dates with `parseDate` (which now asks for a `now` time), the format is identical to `parseDuration`:

The units supported are `s`, `m`, `h`, `hr`, `d`, `w` (week = 7 days), `M`, `mo`, (month = 30 days), `y`, `yr`, (year = 365 days).