### PR TITLE
Implement Filter Functions

### DIFF
--- a/query/expression.go
+++ b/query/expression.go
@@ -55,7 +55,7 @@ func init() {
 				sum += x
 			}
 		}
-		return sum / count
+		return sum / float64(count)
 	}
 	MustRegister(MakeFilterMetricFunction("filter.highest_mean", meanSummary, false))
 	MustRegister(MakeFilterMetricFunction("filter.lowest_mean", meanSummary, true))

--- a/query/expression.go
+++ b/query/expression.go
@@ -46,7 +46,6 @@ func init() {
 	// Timeshift
 	MustRegister(TimeshiftFunction)
 	// Filter
-
 	MustRegister(MakeFilterMetricFunction("filter.highest_mean", aggregate.AggregateMean, false))
 	MustRegister(MakeFilterMetricFunction("filter.lowest_mean", aggregate.AggregateMean, true))
 	MustRegister(MakeFilterMetricFunction("filter.highest_max", aggregate.AggregateMax, false))

--- a/query/expression.go
+++ b/query/expression.go
@@ -46,41 +46,13 @@ func init() {
 	// Timeshift
 	MustRegister(TimeshiftFunction)
 	// Filter
-	meanSummary := func(xs []float64) float64 {
-		count := 0
-		sum := 0.0
-		for _, x := range xs {
-			if !math.IsNaN(x) {
-				count++
-				sum += x
-			}
-		}
-		return sum / float64(count)
-	}
-	MustRegister(MakeFilterMetricFunction("filter.highest_mean", meanSummary, false))
-	MustRegister(MakeFilterMetricFunction("filter.lowest_mean", meanSummary, true))
-	maxSummary := func(xs []float64) float64 {
-		high := math.NaN()
-		for _, x := range xs {
-			if math.IsNaN(high) || x > high {
-				high = x
-			}
-		}
-		return high
-	}
-	minSummary := func(xs []float64) float64 {
-		low := math.NaN()
-		for _, x := range xs {
-			if math.IsNaN(low) || x < low {
-				low = x
-			}
-		}
-		return low
-	}
-	MustRegister(MakeFilterMetricFunction("filter.highest_max", maxSummary, false))
-	MustRegister(MakeFilterMetricFunction("filter.lowest_max", maxSummary, true))
-	MustRegister(MakeFilterMetricFunction("filter.highest_min", minSummary, false))
-	MustRegister(MakeFilterMetricFunction("filter.lowest_min", minSummary, true))
+
+	MustRegister(MakeFilterMetricFunction("filter.highest_mean", aggregate.AggregateMean, false))
+	MustRegister(MakeFilterMetricFunction("filter.lowest_mean", aggregate.AggregateMean, true))
+	MustRegister(MakeFilterMetricFunction("filter.highest_max", aggregate.AggregateMax, false))
+	MustRegister(MakeFilterMetricFunction("filter.lowest_max", aggregate.AggregateMax, true))
+	MustRegister(MakeFilterMetricFunction("filter.highest_min", aggregate.AggregateMin, false))
+	MustRegister(MakeFilterMetricFunction("filter.lowest_min", aggregate.AggregateMin, true))
 }
 
 // EvaluationContext is the central piece of logic, providing

--- a/query/filter.go
+++ b/query/filter.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"sort"
+
+	"github.com/square/metrics/api"
+)
+
+type filterList struct {
+	index     []int
+	value     []float64
+	ascending bool
+}
+
+func (list filterList) Len() int {
+	return len(list.index)
+}
+func (list filterList) Less(i, j int) bool {
+	return (list.value[i] < list.value[j]) == list.ascending
+}
+func (list filterList) Swap(i, j int) {
+	list.index[i], list.index[j] = list.index[j], list.index[i]
+	list.value[i], list.value[j] = list.value[j], list.value[i]
+}
+
+func newFilterList(size int, ascending bool) filterList {
+	return filterList{
+		index:     make([]int, size),
+		value:     make([]float64, size),
+		ascending: ascending,
+	}
+}
+
+// FilteryBy reduces the number of things in the series `list` to at most the given `count`.
+// They're chosen by sorting by `summary` in `ascending` or descending order.
+func FilterBy(list api.SeriesList, count int, summary func([]float64) float64, ascending bool) api.SeriesList {
+	if len(list.Series) < count {
+		// No need to change if there's already fewer.
+		return list
+	}
+	array := newFilterList(len(list.Series), ascending)
+	for i := range array.index {
+		array.index[i] = i
+		array.value[i] = summary(list.Series[i].Values)
+	}
+	sort.Sort(array)
+
+	series := make([]api.Timeseries, count)
+	for i := range series {
+		series[i] = list.Series[array.index[i]]
+	}
+
+	return api.SeriesList{
+		Series:    series,
+		Timerange: list.Timerange,
+	}
+}

--- a/query/function.go
+++ b/query/function.go
@@ -197,3 +197,37 @@ var TimeshiftFunction = MetricFunction{
 
 	},
 }
+
+func MakeFilterMetricFunction(name string, summary func([]float64) float64, ascending bool) MetricFunction {
+	return MetricFunction{
+		Name:        name,
+		MinArgument: 2,
+		MaxArgument: 2,
+		Compute: func(context EvaluationContext, arguments []Expression, groups []string) (value, error) {
+			value, err := arguments[0].Evaluate(context)
+			if err != nil {
+				return nil, err
+			}
+			// The value must be a SeriesList.
+			list, err := value.toSeriesList(context.Timerange)
+			if err != nil {
+				return nil, err
+			}
+			countValue, err := arguments[1].Evaluate(context)
+			if err != nil {
+				return nil, err
+			}
+			countFloat, err := countValue.toScalar()
+			if err != nil {
+				return nil, err
+			}
+			// Round to the nearest integer.
+			count := int(countFloat + 0.5)
+			if count < 0 {
+				return nil, fmt.Errorf("expected positive count but got %d", count)
+			}
+			result := FilterBy(list, count, summary, ascending)
+			return seriesListValue(result), nil
+		},
+	}
+}


### PR DESCRIPTION
This PR is based on #95 and adds on the definition of several "filtering" functions, which limit the number of returned Timeseries.

#95 should be finalized before this branch.