### PR TITLE
Functions compute names

### DIFF
--- a/query/command_test.go
+++ b/query/command_test.go
@@ -256,3 +256,77 @@ func TestCommand_Select(t *testing.T) {
 		t.Fatalf("expected success with limit = 2 but got %s", err.Error())
 	}
 }
+
+func TestNaming(t *testing.T) {
+	fakeApi := mocks.NewFakeApi()
+	fakeBackend := backend.NewSequentialMultiBackend(fakeApiBackend{})
+	tests := []struct {
+		query    string
+		expected string
+	}{
+		{
+			query:    "select series_1 from 0 to 0",
+			expected: "series_1",
+		},
+		{
+			query:    "select series_1 + 17 from 0 to 0",
+			expected: "(series_1 + 17)",
+		},
+		{
+			query:    "select series_1 + 2342.32 from 0 to 0",
+			expected: "(series_1 + 2342.32)",
+		},
+		{
+			query:    "select series_1*17 from 0 to 0",
+			expected: "(series_1 * 17)",
+		},
+		{
+			query:    "select aggregate.sum(series_1) from 0 to 0",
+			expected: "aggregate.sum(series_1)",
+		},
+		{
+			query:    "select aggregate.sum(series_1 group by dc) from 0 to 0",
+			expected: "aggregate.sum(series_1 group by dc)",
+		},
+		{
+			query:    "select aggregate.sum(series_1 group by dc,env) from 0 to 0",
+			expected: "aggregate.sum(series_1 group by dc, env)",
+		},
+		{
+			query:    "select transform.alias(aggregate.sum(series_1 group by dc,env), 'hello') from 0 to 0",
+			expected: "hello",
+		},
+		{
+			query:    "select transform.moving_average(series_2, '2h') from 0 to 0",
+			expected: "transform.moving_average(series_2, 2h)",
+		},
+		{
+			query:    "select filter.lowest_max(series_2, 6) from 0 to 0",
+			expected: "filter.lowest_max(series_2, 6)",
+		},
+	}
+	for _, test := range tests {
+		rawCommand, err := Parse(test.query)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing")
+			return
+		}
+		command := rawCommand.(*SelectCommand)
+		rawResult, err := command.Execute(ExecutionContext{fakeBackend, fakeApi, 1000})
+		if err != nil {
+			t.Errorf("Unexpected error while execution: %s", err.Error())
+			continue
+		}
+		seriesListList, ok := rawResult.([]value)
+		if !ok || len(seriesListList) != 1 {
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			continue
+		}
+		actual := api.SeriesList(seriesListList[0].(seriesListValue)).Name
+		if actual != test.expected {
+			t.Errorf("Expected `%s` but got `%s` for query `%s`", test.expected, actual, test.query)
+			continue
+		}
+	}
+
+}

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -154,7 +154,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'31ms') from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select transform.timeshift(series_1,'31ms') from 0 to 60 resolution 30", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -162,7 +162,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'62ms') from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select transform.timeshift(series_1,'62ms') from 0 to 60 resolution 30", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{3, 4, 5},
 				api.ParseTagSet("dc=west"),
@@ -170,7 +170,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'29ms') from 0 to 60 resolution 30", false, api.SeriesList{
+		{"select transform.timeshift(series_1,'29ms') from 0 to 60 resolution 30", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -178,7 +178,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'-31ms') from 60 to 120 resolution 30", false, api.SeriesList{
+		{"select transform.timeshift(series_1,'-31ms') from 60 to 120 resolution 30", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -186,7 +186,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: lateTimerange,
 			Name:      "series_1",
 		}},
-		{"select timeshift(series_1,'-29ms') from 60 to 120 resolution 30", false, api.SeriesList{
+		{"select transform.timeshift(series_1,'-29ms') from 60 to 120 resolution 30", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),

--- a/query/expression.go
+++ b/query/expression.go
@@ -45,6 +45,7 @@ func init() {
 	MustRegister(MakeTransformMetricFunction("transform.abs", 0, transformMapMaker("abs", math.Abs)))
 	// Timeshift
 	MustRegister(TimeshiftFunction)
+	MustRegister(AliasFunction)
 	// Filter
 	MustRegister(MakeFilterMetricFunction("filter.highest_mean", aggregate.AggregateMean, false))
 	MustRegister(MakeFilterMetricFunction("filter.lowest_mean", aggregate.AggregateMean, true))

--- a/query/expression.go
+++ b/query/expression.go
@@ -148,6 +148,8 @@ func (expr *metricFetchExpression) Evaluate(context EvaluationContext) (value, e
 		return nil, err
 	}
 
+	serieslist.Name = expr.metricName
+
 	return seriesListValue(serieslist), nil
 }
 

--- a/query/function.go
+++ b/query/function.go
@@ -121,6 +121,7 @@ func MakeAggregateMetricFunction(name string, aggregator func([]float64) float64
 		Name:        name,
 		MinArgument: 1,
 		MaxArgument: 1,
+		Groups:      true,
 		Compute: func(context EvaluationContext, args []Expression, groups []string) (value, error) {
 			argument := args[0]
 			value, err := argument.Evaluate(context)
@@ -152,7 +153,6 @@ func MakeTransformMetricFunction(name string, parameterCount int, transformer fu
 		Name:        name,
 		MinArgument: parameterCount + 1,
 		MaxArgument: parameterCount + 1,
-		Groups:      true,
 		Compute: func(context EvaluationContext, args []Expression, groups []string) (value, error) {
 			// ApplyTransform(list api.SeriesList, transform transform, parameters []value) (api.SeriesList, error)
 			listValue, err := args[0].Evaluate(context)

--- a/query/function.go
+++ b/query/function.go
@@ -216,6 +216,32 @@ var TimeshiftFunction = MetricFunction{
 	},
 }
 
+var AliasFunction = MetricFunction{
+	Name:        "transform.alias",
+	MinArgument: 2,
+	MaxArgument: 2,
+	Compute: func(context EvaluationContext, arguments []Expression, groups []string) (value, error) {
+		value, err := arguments[0].Evaluate(context)
+		if err != nil {
+			return nil, err
+		}
+		list, err := value.toSeriesList(context.Timerange)
+		if err != nil {
+			return nil, err
+		}
+		nameValue, err := arguments[1].Evaluate(context)
+		if err != nil {
+			return nil, err
+		}
+		name, err := nameValue.toString()
+		if err != nil {
+			return nil, err
+		}
+		list.Name = name
+		return seriesListValue(list), nil
+	},
+}
+
 func MakeFilterMetricFunction(name string, summary func([]float64) float64, ascending bool) MetricFunction {
 	return MetricFunction{
 		Name:        name,

--- a/query/value.go
+++ b/query/value.go
@@ -27,6 +27,7 @@ type value interface {
 	toSeriesList(api.Timerange) (api.SeriesList, error)
 	toString() (string, error)
 	toScalar() (float64, error)
+	name() string
 }
 
 type conversionError struct {
@@ -50,6 +51,9 @@ func (value seriesListValue) toString() (string, error) {
 func (value seriesListValue) toScalar() (float64, error) {
 	return 0, conversionError{"SeriesList", "scalar"}
 }
+func (value seriesListValue) name() string {
+	return api.SeriesList(value).Name
+}
 
 // A stringValue holds a string
 type stringValue string
@@ -62,6 +66,9 @@ func (value stringValue) toString() (string, error) {
 }
 func (value stringValue) toScalar() (float64, error) {
 	return 0, conversionError{"string", "scalar"}
+}
+func (value stringValue) name() string {
+	return string(value)
 }
 
 // A scalarValue holds a float and can be converted to a serieslist
@@ -79,13 +86,14 @@ func (value scalarValue) toSeriesList(timerange api.Timerange) (api.SeriesList, 
 		Timerange: timerange,
 	}, nil
 }
-
 func (value scalarValue) toString() (string, error) {
 	return "", conversionError{"scalar", "string"}
 }
-
 func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
+}
+func (value scalarValue) name() string {
+	return fmt.Sprintf("%d", value)
 }
 
 // toDuration will take a value, convert it to a string, and then parse it.

--- a/query/value.go
+++ b/query/value.go
@@ -93,7 +93,7 @@ func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
 }
 func (value scalarValue) name() string {
-	return fmt.Sprintf("%f", value)
+	return fmt.Sprintf("%g", value)
 }
 
 // toDuration will take a value, convert it to a string, and then parse it.

--- a/query/value.go
+++ b/query/value.go
@@ -93,7 +93,7 @@ func (value scalarValue) toScalar() (float64, error) {
 	return float64(value), nil
 }
 func (value scalarValue) name() string {
-	return fmt.Sprintf("%d", value)
+	return fmt.Sprintf("%f", value)
 }
 
 // toDuration will take a value, convert it to a string, and then parse it.


### PR DESCRIPTION
A serieslist produced by evaluation now has a proper name, based on the functions which evaluated it.

For example, `select aggregate.sum(cpu group by 'app')` will have a name like `"aggregate.sum(cpu group by app)"`

@jeeyoungk @achow 