### PR TITLE
Define transform.nan_keep_last

### DIFF
--- a/query/expression.go
+++ b/query/expression.go
@@ -43,6 +43,7 @@ func init() {
 	MustRegister(MakeTransformMetricFunction("transform.moving_average", 1, transformMovingAverage))
 	MustRegister(MakeTransformMetricFunction("transform.default", 1, transformDefault))
 	MustRegister(MakeTransformMetricFunction("transform.abs", 0, transformMapMaker("abs", math.Abs)))
+	MustRegister(MakeTransformMetricFunction("transform.last_value", 0, transformLastValue))
 	// Timeshift
 	MustRegister(TimeshiftFunction)
 	MustRegister(AliasFunction)

--- a/query/expression.go
+++ b/query/expression.go
@@ -43,7 +43,7 @@ func init() {
 	MustRegister(MakeTransformMetricFunction("transform.moving_average", 1, transformMovingAverage))
 	MustRegister(MakeTransformMetricFunction("transform.default", 1, transformDefault))
 	MustRegister(MakeTransformMetricFunction("transform.abs", 0, transformMapMaker("abs", math.Abs)))
-	MustRegister(MakeTransformMetricFunction("transform.last_value", 0, transformLastValue))
+	MustRegister(MakeTransformMetricFunction("transform.nan_keep_last", 0, transformNaNKeepLast))
 	// Timeshift
 	MustRegister(TimeshiftFunction)
 	MustRegister(AliasFunction)

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -217,8 +217,9 @@ func transformDefault(values []float64, parameters []value, scale float64) ([]fl
 	return result, nil
 }
 
-func transformLastValue(values []float64, parameters []value, scale float64) ([]float64, error) {
-	if err := checkParameters("transform.last_value", 0, parameters); err != nil {
+// transformNaNKeepLast will replace missing NaN data with the data before it
+func transformNaNKeepLast(values []float64, parameters []value, scale float64) ([]float64, error) {
+	if err := checkParameters("transform.nan_keep_last", 0, parameters); err != nil {
 		return nil, err
 	}
 	result := make([]float64, len(values))

--- a/query/transformation.go
+++ b/query/transformation.go
@@ -216,3 +216,17 @@ func transformDefault(values []float64, parameters []value, scale float64) ([]fl
 	}
 	return result, nil
 }
+
+func transformLastValue(values []float64, parameters []value, scale float64) ([]float64, error) {
+	if err := checkParameters("transform.last_value", 0, parameters); err != nil {
+		return nil, err
+	}
+	result := make([]float64, len(values))
+	for i := range result {
+		result[i] = values[i]
+		if math.IsNaN(result[i]) && i > 0 {
+			result[i] = result[i-1]
+		}
+	}
+	return result, nil
+}

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -71,7 +71,7 @@ func TestTransformTimeseries(t *testing.T) {
 				{
 					fun:      transformLastValue,
 					expected: {0, 1, 2, 3, 4, 5},
-					usParam:  false,
+					useParam: false,
 				},
 			},
 		},

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -70,7 +70,7 @@ func TestTransformTimeseries(t *testing.T) {
 				},
 				{
 					fun:      transformLastValue,
-					expected: {0, 1, 2, 3, 4, 5},
+					expected: []float64{0, 1, 2, 3, 4, 5},
 					useParam: false,
 				},
 			},

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -68,6 +68,11 @@ func TestTransformTimeseries(t *testing.T) {
 					expected: []float64{0, -1, -2, -3, -4, -5},
 					useParam: false,
 				},
+				{
+					fun:      transformLastValue,
+					expected: {0, 1, 2, 3, 4, 5},
+					usParam:  false,
+				},
 			},
 		},
 	}
@@ -302,6 +307,15 @@ func TestApplyTransformNaN(t *testing.T) {
 				"A": {0, 1, 17, 3, 4, 5},
 				"B": {2, 17, 17, 17, 3, 3},
 				"C": {0, 1, 2, 17, 2, 1},
+			},
+		},
+		{
+			transform:  transformLastValue,
+			parameters: []value{},
+			expected: map[string][]float64{
+				"A": {0, 1, 1, 3, 4, 5},
+				"B": {2, 2, 2, 2, 3, 3},
+				"C": {0, 1, 2, 2, 2, 1},
 			},
 		},
 	}

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -69,7 +69,7 @@ func TestTransformTimeseries(t *testing.T) {
 					useParam: false,
 				},
 				{
-					fun:      transformLastValue,
+					fun:      transformNaNKeepLast,
 					expected: []float64{0, 1, 2, 3, 4, 5},
 					useParam: false,
 				},
@@ -310,7 +310,7 @@ func TestApplyTransformNaN(t *testing.T) {
 			},
 		},
 		{
-			transform:  transformLastValue,
+			transform:  transformNaNKeepLast,
 			parameters: []value{},
 			expected: map[string][]float64{
 				"A": {0, 1, 1, 3, 4, 5},


### PR DESCRIPTION
The function `transform.nan_keep_last` replaces any `NaN` with the first non-`NaN` that came before (unless there are none, in which case it stays `NaN`).