### PR TITLE
Fixing Filter + Filter Tests

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -83,6 +83,27 @@ func (assert Assert) EqInt(actual, expected int) {
 	}
 }
 
+func (assert Assert) EqFloatArray(actual, expected []float64, epsilon float64) {
+	if len(actual) != len(expected) {
+		assert.withCaller("Expected=%+v, actual=%+v", expected, actual)
+		return
+	}
+	for i := range actual {
+		if math.IsNaN(expected[i]) {
+			if !math.IsNaN(actual[i]) {
+				assert.withCaller("Expected=%+v, actual=%+v", expected, actual)
+				return
+			}
+		} else {
+			delta := actual[i] - expected[i]
+			if math.IsNaN(delta) || delta > epsilon {
+				assert.withCaller("Expected=%+v, actual=%+v", expected, actual)
+				return
+			}
+		}
+	}
+}
+
 // EqFloat fails the test if two floats aren't equal. NaNs are considered equal.
 func (assert Assert) EqFloat(actual, expected, epsilon float64) {
 	delta := math.Abs(actual - expected)

--- a/query/aggregate/aggregate.go
+++ b/query/aggregate/aggregate.go
@@ -84,7 +84,7 @@ func filterNaN(array []float64) []float64 {
 
 // The sum aggregator returns the mean of the given array
 func AggregateSum(array []float64) float64 {
-	// array = filterNaN(array)
+	array = filterNaN(array)
 	sum := 0.0
 	for _, v := range array {
 		sum += v

--- a/query/aggregate/aggregate.go
+++ b/query/aggregate/aggregate.go
@@ -72,8 +72,19 @@ func groupBy(list api.SeriesList, tags []string) []group {
 	return result
 }
 
+func filterNaN(array []float64) []float64 {
+	result := []float64{}
+	for _, v := range array {
+		if !math.IsNaN(v) {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
 // The sum aggregator returns the mean of the given array
 func AggregateSum(array []float64) float64 {
+	// array = filterNaN(array)
 	sum := 0.0
 	for _, v := range array {
 		sum += v
@@ -83,6 +94,7 @@ func AggregateSum(array []float64) float64 {
 
 // The mean aggregator returns the mean of the given array
 func AggregateMean(array []float64) float64 {
+	array = filterNaN(array)
 	if len(array) == 0 {
 		// The mean of an empty list is not well-defined
 		return math.NaN()
@@ -96,6 +108,7 @@ func AggregateMean(array []float64) float64 {
 
 // The minimum aggregator returns the minimum
 func AggregateMin(array []float64) float64 {
+	array = filterNaN(array)
 	if len(array) == 0 {
 		// The minimum of an empty list is not well-defined
 		return math.NaN()
@@ -109,6 +122,7 @@ func AggregateMin(array []float64) float64 {
 
 // The maximum aggregator returns the maximum
 func AggregateMax(array []float64) float64 {
+	array = filterNaN(array)
 	if len(array) == 0 {
 		// The maximum of an empty list is not well-defined
 		return math.NaN()
@@ -132,36 +146,20 @@ func applyAggregation(group group, aggregator func([]float64) float64) api.Times
 		panic("applyAggregation given empty group for tagset")
 	}
 
-	series := api.Timeseries{
+	result := api.Timeseries{
 		Values: make([]float64, len(list[0].Values)), // The first Series in the given list is used to determine this length
 		TagSet: tagSet,                               // The tagset is supplied by an argument (it will be the values grouped on)
 	}
 
-	// Make a slice of time to reuse.
-	// Each entry corresponds to a particular Series, all having the same index within their corresponding Series.
-	// The timeslice has 0 size but len(list) capacity so that it won't need to be resized.
-	timeSlice := make([]float64, 0, len(list))
-
-	for i := range series.Values {
-		// Re-slice the timeslice to be empty again, but with the same capacity.
-		// (So that we re-use it rather than re-allocating it)
-		timeSlice = timeSlice[:0]
-		// We need to determine each value in turn.
+	for i := range result.Values {
+		timeSlice := make([]float64, len(list))
 		for j := range list {
-			value := list[j].Values[i]
-			if !math.IsNaN(value) {
-				timeSlice = append(timeSlice, value)
-			}
+			timeSlice[j] = list[j].Values[i]
 		}
-		if len(timeSlice) == 0 {
-			series.Values[i] = math.NaN()
-		} else {
-			// Find the aggregated value:
-			series.Values[i] = aggregator(timeSlice)
-		}
+		result.Values[i] = aggregator(timeSlice)
 	}
 
-	return series
+	return result
 }
 
 // This function is the culmination of all others.

--- a/query/filter.go
+++ b/query/filter.go
@@ -31,7 +31,7 @@ func (list filterList) Len() int {
 	return len(list.index)
 }
 func (list filterList) Less(i, j int) bool {
-	if math.IsNaN(list.values[j]) && !math.IsNaN(list.values[i]) {
+	if math.IsNaN(list.value[j]) && !math.IsNaN(list.value[i]) {
 		return true
 	}
 	if list.ascending {
@@ -56,12 +56,12 @@ func newFilterList(size int, ascending bool) filterList {
 
 // FilteryBy reduces the number of things in the series `list` to at most the given `count`.
 // They're chosen by sorting by `summary` in `ascending` or descending order.
-func FilterBy(list api.SeriesList, count int, summary func([]float64) float64, ascending bool) api.SeriesList {
+func FilterBy(list api.SeriesList, count int, summary func([]float64) float64, lowest bool) api.SeriesList {
 	if len(list.Series) < count {
 		// No need to change if there's already fewer.
 		return list
 	}
-	array := newFilterList(len(list.Series), ascending)
+	array := newFilterList(len(list.Series), lowest)
 	for i := range array.index {
 		array.index[i] = i
 		array.value[i] = summary(list.Series[i].Values)

--- a/query/filter.go
+++ b/query/filter.go
@@ -15,6 +15,7 @@
 package query
 
 import (
+	"math"
 	"sort"
 
 	"github.com/square/metrics/api"
@@ -30,7 +31,15 @@ func (list filterList) Len() int {
 	return len(list.index)
 }
 func (list filterList) Less(i, j int) bool {
-	return (list.value[i] < list.value[j]) == list.ascending
+	if math.IsNaN(list.values[j]) && !math.IsNaN(list.values[i]) {
+		return true
+	}
+	if list.ascending {
+		return list.value[i] < list.value[j]
+	} else {
+		return list.value[j] < list.value[i]
+	}
+
 }
 func (list filterList) Swap(i, j int) {
 	list.index[i], list.index[j] = list.index[j], list.index[i]

--- a/query/filter_test.go
+++ b/query/filter_test.go
@@ -1,0 +1,183 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/assert"
+	"github.com/square/metrics/query/aggregate"
+)
+
+func TestFilter(t *testing.T) {
+	a := assert.New(t)
+	timerange, err := api.NewTimerange(1300, 1700, 100)
+	if err != nil {
+		t.Fatalf("invalid timerange used in testcase")
+	}
+
+	series := map[string]api.Timeseries{
+		"A": {
+			Values: []float64{3, 3, 3, 3, 3},
+			TagSet: api.TagSet{
+				"name": "A",
+			},
+		},
+		"B": {
+			Values: []float64{1, 2, 2, 1, 0},
+			TagSet: api.TagSet{
+				"name": "B",
+			},
+		},
+		"C": {
+			Values: []float64{1, 2, 3, 4, 5.1},
+			TagSet: api.TagSet{
+				"name": "C",
+			},
+		},
+		"D": {
+			Values: []float64{4, 4, 3, 4, 3},
+			TagSet: api.TagSet{
+				"name": "D",
+			},
+		},
+	}
+
+	list := api.SeriesList{
+		Series:    []api.Timeseries{series["A"], series["B"], series["C"], series["D"]},
+		Timerange: timerange,
+		Name:      "test_series",
+	}
+	tests := []struct {
+		summary func([]float64) float64
+		lowest  bool
+		count   int
+		expect  []string
+	}{
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  true,
+			count:   6,
+			expect:  []string{"A", "B", "C", "D"},
+		},
+
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  false,
+			count:   6,
+			expect:  []string{"A", "B", "C", "D"},
+		},
+
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  true,
+			count:   4,
+			expect:  []string{"A", "B", "C", "D"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  true,
+			count:   3,
+			expect:  []string{"A", "B", "C"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  true,
+			count:   2,
+			expect:  []string{"A", "B"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  true,
+			count:   1,
+			expect:  []string{"B"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  false,
+			count:   4,
+			expect:  []string{"A", "B", "C", "D"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  false,
+			count:   3,
+			expect:  []string{"A", "C", "D"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  false,
+			count:   2,
+			expect:  []string{"C", "D"},
+		},
+		{
+			summary: aggregate.AggregateSum,
+			lowest:  false,
+			count:   1,
+			expect:  []string{"D"},
+		},
+		{
+			summary: aggregate.AggregateMax,
+			lowest:  false,
+			count:   1,
+			expect:  []string{"C"},
+		},
+		{
+			summary: aggregate.AggregateMax,
+			lowest:  false,
+			count:   2,
+			expect:  []string{"C", "D"},
+		},
+		{
+			summary: aggregate.AggregateMin,
+			lowest:  false,
+			count:   2,
+			expect:  []string{"A", "D"},
+		},
+		{
+			summary: aggregate.AggregateMin,
+			lowest:  false,
+			count:   3,
+			expect:  []string{"A", "C", "D"},
+		},
+	}
+	for _, test := range tests {
+		filtered := FilterBy(list, test.count, test.summary, test.lowest)
+		// Verify that every series in the result is from the original.
+		// Also verify that we only get the ones we expect.
+		if len(filtered.Series) != len(test.expect) {
+			t.Errorf("Expected only %d in results but got %d", len(test.expect), len(filtered.Series))
+			continue
+		}
+		for _, s := range filtered.Series {
+			original, ok := series[s.TagSet["name"]]
+			if !ok {
+				t.Fatalf("Result tagset called '%s' is not an original", s.TagSet["name"])
+			}
+			a.EqFloatArray(original.Values, s.Values, 1e-7)
+		}
+		names := map[string]bool{}
+		for _, name := range test.expect {
+			names[name] = true
+		}
+		for _, s := range filtered.Series {
+			if !names[s.TagSet["name"]] {
+				t.Fatalf("TagSets %+v aren't expected; %+v are", filtered.Series, test.expect)
+			}
+			names[s.TagSet["name"]] = false // Use up the name so that a seocnd Series can't also use it.
+		}
+	}
+}


### PR DESCRIPTION
The main issues with filtering are due to (1) inconsistent/confusing behavior for totally missing series (all NaN) and (2) the aggregating functions failed whenever a single entry in their argument arrays was NaN.

This PR moves the not-NaN filter from the `applyAggregate` function into each one of the aggregators, so that they can be used as useful summarizes for `FilterBy`.

The tests don't cover expression evaluation directly but do cover the functionality of `FilterBy()` which is used by expressions registered as filters.

`FilterBy`'s argument "`ascending`" has been renamed to the more-clear "`lowest`" meaning that when `true`, it will return the `N` lowest results (if false, it returns the `N` highest). [This change doesn't effect behavior in calling the function].
