### PR TITLE
Collect data in Profilers stored in Contexts

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,8 @@
 // for the terminology.
 package api
 
+import "github.com/square/metrics/inspect"
+
 // API is the set of public methods exposed by the indexer library.
 type API interface {
 	// AddMetric adds the metric to the system.
@@ -43,6 +45,41 @@ type API interface {
 	// For a given tag key-value pair, obtain the list of all the MetricKeys
 	// associated with them.
 	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
+}
+
+// ProfilingAPI wraps an ordinary API and also records profiling metrics to a given Profiler object.
+type ProfilingAPI struct {
+	Profiler *inspect.Profiler
+	API      API
+}
+
+func (api ProfilingAPI) AddMetric(metric TaggedMetric) error {
+	defer api.Profiler.Add("api.AddMetric")
+	return api.API.AddMetric(metric)
+}
+func (api ProfilingAPI) RemoveMetric(metric TaggedMetric) error {
+	defer api.Profiler.Add("api.RemoveMetric")
+	return api.API.RemoveMetric(metric)
+}
+func (api ProfilingAPI) ToGraphiteName(metric TaggedMetric) (GraphiteMetric, error) {
+	defer api.Profiler.Add("api.ToGraphiteName")
+	return api.API.ToGraphiteName(metric)
+}
+func (api ProfilingAPI) ToTaggedName(metric GraphiteMetric) (TaggedMetric, error) {
+	defer api.Profiler.Add("api.ToTaggedName")
+	return api.API.ToTaggedName(metric)
+}
+func (api ProfilingAPI) GetAllTags(metricKey MetricKey) ([]TagSet, error) {
+	defer api.Profiler.Add("api.GetAllTags")
+	return api.API.GetAllTags(metricKey)
+}
+func (api ProfilingAPI) GetAllMetrics() ([]MetricKey, error) {
+	defer api.Profiler.Add("api.GetAllMetrics")
+	return api.API.GetAllMetrics()
+}
+func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error) {
+	defer api.Profiler.Add("api.GetMetircsForTag")
+	return api.API.GetMetricsForTag(tagKey, tagValue)
 }
 
 // Configuration is the struct that tells how to instantiate a new copy of an API.

--- a/api/api.go
+++ b/api/api.go
@@ -47,41 +47,6 @@ type API interface {
 	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
 }
 
-// ProfilingAPI wraps an ordinary API and also records profiling metrics to a given Profiler object.
-type ProfilingAPI struct {
-	Profiler *inspect.Profiler
-	API      API
-}
-
-func (api ProfilingAPI) AddMetric(metric TaggedMetric) error {
-	defer api.Profiler.Add("api.AddMetric")
-	return api.API.AddMetric(metric)
-}
-func (api ProfilingAPI) RemoveMetric(metric TaggedMetric) error {
-	defer api.Profiler.Add("api.RemoveMetric")
-	return api.API.RemoveMetric(metric)
-}
-func (api ProfilingAPI) ToGraphiteName(metric TaggedMetric) (GraphiteMetric, error) {
-	defer api.Profiler.Add("api.ToGraphiteName")
-	return api.API.ToGraphiteName(metric)
-}
-func (api ProfilingAPI) ToTaggedName(metric GraphiteMetric) (TaggedMetric, error) {
-	defer api.Profiler.Add("api.ToTaggedName")
-	return api.API.ToTaggedName(metric)
-}
-func (api ProfilingAPI) GetAllTags(metricKey MetricKey) ([]TagSet, error) {
-	defer api.Profiler.Add("api.GetAllTags")
-	return api.API.GetAllTags(metricKey)
-}
-func (api ProfilingAPI) GetAllMetrics() ([]MetricKey, error) {
-	defer api.Profiler.Add("api.GetAllMetrics")
-	return api.API.GetAllMetrics()
-}
-func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error) {
-	defer api.Profiler.Add("api.GetMetircsForTag")
-	return api.API.GetMetricsForTag(tagKey, tagValue)
-}
-
 // Configuration is the struct that tells how to instantiate a new copy of an API.
 type Config struct {
 	ConversionRulesPath string `yaml:"conversion_rules_path"` // Location of the rule yaml file.
@@ -91,4 +56,39 @@ type Config struct {
 	// https://github.com/gocql/gocql/blob/master/cluster.go
 	Hosts    []string `yaml:"hosts"`
 	Keyspace string   `yaml:"keyspace"`
+}
+
+// ProfilingAPI wraps an ordinary API and also records profiling metrics to a given Profiler object.
+type ProfilingAPI struct {
+	Profiler *inspect.Profiler
+	API      API
+}
+
+func (api ProfilingAPI) AddMetric(metric TaggedMetric) error {
+	defer api.Profiler.Record("api.AddMetric")
+	return api.API.AddMetric(metric)
+}
+func (api ProfilingAPI) RemoveMetric(metric TaggedMetric) error {
+	defer api.Profiler.Record("api.RemoveMetric")
+	return api.API.RemoveMetric(metric)
+}
+func (api ProfilingAPI) ToGraphiteName(metric TaggedMetric) (GraphiteMetric, error) {
+	defer api.Profiler.Record("api.ToGraphiteName")
+	return api.API.ToGraphiteName(metric)
+}
+func (api ProfilingAPI) ToTaggedName(metric GraphiteMetric) (TaggedMetric, error) {
+	defer api.Profiler.Record("api.ToTaggedName")
+	return api.API.ToTaggedName(metric)
+}
+func (api ProfilingAPI) GetAllTags(metricKey MetricKey) ([]TagSet, error) {
+	defer api.Profiler.Record("api.GetAllTags")
+	return api.API.GetAllTags(metricKey)
+}
+func (api ProfilingAPI) GetAllMetrics() ([]MetricKey, error) {
+	defer api.Profiler.Record("api.GetAllMetrics")
+	return api.API.GetAllMetrics()
+}
+func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error) {
+	defer api.Profiler.Record("api.GetMetircsForTag")
+	return api.API.GetMetricsForTag(tagKey, tagValue)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -65,30 +65,30 @@ type ProfilingAPI struct {
 }
 
 func (api ProfilingAPI) AddMetric(metric TaggedMetric) error {
-	defer api.Profiler.Record("api.AddMetric")
+	defer api.Profiler.Record("api.AddMetric")()
 	return api.API.AddMetric(metric)
 }
 func (api ProfilingAPI) RemoveMetric(metric TaggedMetric) error {
-	defer api.Profiler.Record("api.RemoveMetric")
+	defer api.Profiler.Record("api.RemoveMetric")()
 	return api.API.RemoveMetric(metric)
 }
 func (api ProfilingAPI) ToGraphiteName(metric TaggedMetric) (GraphiteMetric, error) {
-	defer api.Profiler.Record("api.ToGraphiteName")
+	defer api.Profiler.Record("api.ToGraphiteName")()
 	return api.API.ToGraphiteName(metric)
 }
 func (api ProfilingAPI) ToTaggedName(metric GraphiteMetric) (TaggedMetric, error) {
-	defer api.Profiler.Record("api.ToTaggedName")
+	defer api.Profiler.Record("api.ToTaggedName")()
 	return api.API.ToTaggedName(metric)
 }
 func (api ProfilingAPI) GetAllTags(metricKey MetricKey) ([]TagSet, error) {
-	defer api.Profiler.Record("api.GetAllTags")
+	defer api.Profiler.Record("api.GetAllTags")()
 	return api.API.GetAllTags(metricKey)
 }
 func (api ProfilingAPI) GetAllMetrics() ([]MetricKey, error) {
-	defer api.Profiler.Record("api.GetAllMetrics")
+	defer api.Profiler.Record("api.GetAllMetrics")()
 	return api.API.GetAllMetrics()
 }
 func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error) {
-	defer api.Profiler.Record("api.GetMetircsForTag")
+	defer api.Profiler.Record("api.GetMetricsForTag")()
 	return api.API.GetMetricsForTag(tagKey, tagValue)
 }

--- a/api/backend.go
+++ b/api/backend.go
@@ -138,7 +138,7 @@ type ProfilingBackend struct {
 }
 
 func (b ProfilingBackend) FetchSingleSeries(request FetchSeriesRequest) (Timeseries, error) {
-	defer request.Profiler.Record("fetchSingleSeries")
+	defer request.Profiler.Record("fetchSingleSeries")()
 	return b.Backend.FetchSingleSeries(request)
 }
 
@@ -148,6 +148,6 @@ type ProfilingMultiBackend struct {
 }
 
 func (b ProfilingMultiBackend) FetchMultipleSeries(request FetchMultipleRequest) (SeriesList, error) {
-	defer request.Profiler.Record("fetchMultipleSeries")
+	defer request.Profiler.Record("fetchMultipleSeries")()
 	return b.MultiBackend.FetchMultipleSeries(request)
 }

--- a/api/backend.go
+++ b/api/backend.go
@@ -90,31 +90,11 @@ type Backend interface {
 	FetchSingleSeries(request FetchSeriesRequest) (Timeseries, error)
 }
 
-// ProfilingBackend wraps an ordinary backend so that whenever data is fetched, a profile is recorded for the fetch's duration.
-type ProfilingBackend struct {
-	Backend Backend
-}
-
-func (b ProfilingBackend) FetchSingleSeries(request FetchSeriesRequest) (Timeseries, error) {
-	defer request.Profiler.Add("fetchSingleSeries")
-	return b.Backend.FetchSingleSeries(request)
-}
-
 type MultiBackend interface {
 	// FetchManySeries fetches the series provided by the given TaggedMetrics
 	// corresponding to the Timerange, down/upsampling if necessary using
 	// SampleMethod. It may fetch in series or parallel, etc.
 	FetchMultipleSeries(request FetchMultipleRequest) (SeriesList, error)
-}
-
-// ProfilingMultiBackend wraps an ordinary multibackend so that whenever data is fetched, a profile is recorded for the fetches' durations.
-type ProfilingMultiBackend struct {
-	MultiBackend MultiBackend
-}
-
-func (b ProfilingMultiBackend) FetchMultipleSeries(request FetchMultipleRequest) (SeriesList, error) {
-	defer request.Profiler.Add("fetchMultipleSeries")
-	return b.MultiBackend.FetchMultipleSeries(request)
 }
 
 type BackendErrorCode int
@@ -150,4 +130,24 @@ func (err BackendError) Error() string {
 		formatted = formatted + " - " + err.Message
 	}
 	return formatted
+}
+
+// ProfilingBackend wraps an ordinary backend so that whenever data is fetched, a profile is recorded for the fetch's duration.
+type ProfilingBackend struct {
+	Backend Backend
+}
+
+func (b ProfilingBackend) FetchSingleSeries(request FetchSeriesRequest) (Timeseries, error) {
+	defer request.Profiler.Record("fetchSingleSeries")
+	return b.Backend.FetchSingleSeries(request)
+}
+
+// ProfilingMultiBackend wraps an ordinary multibackend so that whenever data is fetched, a profile is recorded for the fetches' durations.
+type ProfilingMultiBackend struct {
+	MultiBackend MultiBackend
+}
+
+func (b ProfilingMultiBackend) FetchMultipleSeries(request FetchMultipleRequest) (SeriesList, error) {
+	defer request.Profiler.Record("fetchMultipleSeries")
+	return b.MultiBackend.FetchMultipleSeries(request)
 }

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -173,9 +173,11 @@ func Test_Blueflood(t *testing.T) {
 		b.client = fakeHttpClient
 
 		seriesList, err := b.FetchSingleSeries(api.FetchSeriesRequest{
-			test.queryMetric, test.sampleMethod, test.timerange,
-			fakeApi,
-			api.NewCancellable(),
+			Metric:       test.queryMetric,
+			SampleMethod: test.sampleMethod,
+			Timerange:    test.timerange,
+			API:          fakeApi,
+			Cancellable:  api.NewCancellable(),
 		})
 
 		if test.expectedErrorCode != 0 {

--- a/inspect/profile.go
+++ b/inspect/profile.go
@@ -21,16 +21,17 @@ import (
 
 // Profiler contains a sequence of profiles which are collected over the course of a query execution.
 type Profiler struct {
+	now      func() time.Time
 	mutex    *sync.Mutex
 	profiles []Profile
 }
 
 func New() *Profiler {
-	profiler := Profiler{
+	return &Profiler{
+		now:      time.Now,
 		mutex:    &sync.Mutex{},
 		profiles: []Profile{},
 	}
-	return &profiler
 }
 
 // Record will create a profile of the given name from `start` until the current time.
@@ -40,11 +41,11 @@ func (p *Profiler) Record(name string) func() {
 		// If the profiler instance doesn't exist, then don't attempt to operate on it.
 		return func() {}
 	}
-	start := time.Now()
+	start := p.now()
 	return func() {
 		p.mutex.Lock()
 		defer p.mutex.Unlock()
-		p.profiles = append(p.profiles, Profile{name: name, startTime: start, finishTime: time.Now()})
+		p.profiles = append(p.profiles, Profile{name: name, startTime: start, finishTime: p.now()})
 	}
 }
 

--- a/inspect/profile.go
+++ b/inspect/profile.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect
+
+import "time"
+
+// Profiler contains a sequence of profiles which are collected over the course of a query execution.
+type Profiler struct {
+	profiles []Profile
+}
+
+// Add will create a profile of the given name from `start` until the current time.
+// Add acts in a threadsafe manner.
+func (p *Profiler) Add(name string) func() {
+	if p == nil {
+		// If the profiler instance doesn't exist, then don't attempt to operate on it.
+		return func() {}
+	}
+	start := time.Now()
+	return func() {
+		p.profiles = append(p.profiles, Profile{name: name, startTime: start, finishTime: time.Now()})
+	}
+}
+
+// All returns the list of profiles collected thus far.
+func (p *Profiler) All() []Profile {
+	if p == nil {
+		// If the profiler instance doesn't exist, then don't attempt to operate on it.
+		return []Profile{}
+	}
+	return p.profiles
+}
+
+// A profile is a single data point collected by the profiler.
+type Profile struct {
+	name       string    // name identifies the measured quantity ("fetchSingle() or api.GetAllMetrics()")
+	startTime  time.Time // the start time of the task
+	finishTime time.Time // the end time of the task
+}
+
+// Name is the name of the profile.
+func (p Profile) Name() string {
+	return p.name
+}
+
+// Start is the start time of the profile.
+func (p Profile) Start() time.Time {
+	return p.startTime
+}
+
+// Finish is the finish time of the profile.
+func (p Profile) Finish() time.Time {
+	return p.finishTime
+}
+
+// Duration is the duration of the profile (Finish - Start).
+func (p Profile) Duration() time.Duration {
+	return p.finishTime.Sub(p.startTime)
+}

--- a/inspect/profile_test.go
+++ b/inspect/profile_test.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/square/metrics/assert"
+)
+
+func TestProfilerSimple(t *testing.T) {
+	a := assert.New(t)
+
+	utc := time.UTC
+	now := time.Date(2015, 2, 17, 4, 35, 0, 0, utc)
+
+	profiler := &Profiler{
+		now: func() time.Time {
+			return now
+		},
+		mutex:    &sync.Mutex{},
+		profiles: []Profile{},
+	}
+	// It's now possible to manipulate the internal now of the Profiler
+
+	a.EqInt(len(profiler.All()), 0)
+
+	finisher := profiler.Record("metricA")
+	start, now := now, time.Date(2015, 2, 17, 6, 35, 0, 0, utc)
+	finisher()
+
+	list := profiler.All()
+	a.EqInt(len(list), 1)
+	a.EqString(list[0].Name(), "metricA")
+	if list[0].Start() != start {
+		t.Fatalf("expected to start at %+v but started at %+v", start, list[0].Start())
+	}
+	if list[0].Finish() != now {
+		t.Fatalf("expected to finish at %+v but finished at %+v", now, list[0].Finish())
+	}
+
+	// Changing the value of `now` shouldn't change the list.
+	old, now := now, time.Date(2015, 3, 4, 6, 35, 0, 0, utc)
+
+	list = profiler.All()
+	a.EqInt(len(list), 1)
+	a.EqString(list[0].Name(), "metricA")
+	if list[0].Start() != start {
+		t.Fatalf("expected to start at %+v but started at %+v", start, list[0].Start())
+	}
+	if list[0].Finish() != old {
+		t.Fatalf("expected to finish at %+v but finished at %+v", old, list[0].Finish())
+	}
+
+	count := 2000
+	wait := make(chan int)
+	for i := 0; i < count; i++ {
+		go func(i int) {
+			profiler.Record(fmt.Sprintf("metric_%d", i))()
+			wait <- i
+		}(i)
+	}
+	for i := 0; i < count; i++ {
+		<-wait
+	}
+	list = profiler.All()
+	a.EqInt(len(list), count+1)
+}

--- a/inspect/profile_test.go
+++ b/inspect/profile_test.go
@@ -68,16 +68,16 @@ func TestProfilerSimple(t *testing.T) {
 	}
 
 	count := 2000
-	wait := make(chan int)
+
+	var wait sync.WaitGroup
+	wait.Add(count)
 	for i := 0; i < count; i++ {
 		go func(i int) {
 			profiler.Record(fmt.Sprintf("metric_%d", i))()
-			wait <- i
+			wait.Done()
 		}(i)
 	}
-	for i := 0; i < count; i++ {
-		<-wait
-	}
+	wait.Wait()
 	list = profiler.All()
 	a.EqInt(len(list), count+1)
 }

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -17,9 +17,9 @@ package main
 import (
 	"flag"
 
+	"github.com/square/metrics/api"
 	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/api/backend/blueflood"
-	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/query"
 	"github.com/square/metrics/ui"
@@ -31,12 +31,14 @@ func main() {
 
 	config := common.LoadConfig()
 
-	// TODO: create profiler
-	profiler := (*inspect.Profiler)(nil)
-
 	apiInstance := common.NewAPI(config.API)
-	blueflood := backend.ProfilingBackend{blueflood.NewBlueflood(config.Blueflood)}
-	backend := backend.NewSequentialMultiBackend(blueflood)
 
-	ui.Main(config.UIConfig, query.ExecutionContext{API: apiInstance, Backend: backend, FetchLimit: 1000, Profiler: profiler})
+	blueflood := api.ProfilingBackend{
+		Backend: blueflood.NewBlueflood(config.Blueflood),
+	}
+	backend := api.ProfilingMultiBackend{
+		MultiBackend: backend.NewSequentialMultiBackend(blueflood),
+	}
+
+	ui.Main(config.UIConfig, query.ExecutionContext{API: apiInstance, Backend: backend, FetchLimit: 1000})
 }

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/api/backend/blueflood"
+	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/query"
 	"github.com/square/metrics/ui"
@@ -30,9 +31,12 @@ func main() {
 
 	config := common.LoadConfig()
 
+	// TODO: create profiler
+	profiler := (*inspect.Profiler)(nil)
+
 	apiInstance := common.NewAPI(config.API)
-	blueflood := blueflood.NewBlueflood(config.Blueflood)
+	blueflood := backend.ProfilingBackend{blueflood.NewBlueflood(config.Blueflood)}
 	backend := backend.NewSequentialMultiBackend(blueflood)
 
-	ui.Main(config.UIConfig, query.ExecutionContext{API: apiInstance, Backend: backend, FetchLimit: 1000})
+	ui.Main(config.UIConfig, query.ExecutionContext{API: apiInstance, Backend: backend, FetchLimit: 1000, Profiler: profiler})
 }

--- a/query/command.go
+++ b/query/command.go
@@ -176,7 +176,7 @@ func (cmd ProfilingCommand) Name() string {
 }
 
 func (cmd ProfilingCommand) Execute(context ExecutionContext) (interface{}, error) {
-	defer cmd.Profiler.Record(fmt.Sprintf("%s.Execute", cmd.Name()))
+	defer cmd.Profiler.Record(fmt.Sprintf("%s.Execute", cmd.Name()))()
 	context.API = api.ProfilingAPI{
 		Profiler: cmd.Profiler,
 		API:      context.API,

--- a/query/command.go
+++ b/query/command.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
 )
 
 // ExecutionContext is the context supplied when invoking a command.
@@ -28,6 +29,7 @@ type ExecutionContext struct {
 	API        api.API          // the api
 	FetchLimit int              // the maximum number of fetches
 	Timeout    time.Duration
+	Profiler   *inspect.Profiler
 }
 
 // Command is the final result of the parsing.
@@ -124,6 +126,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		SampleMethod: cmd.context.SampleMethod,
 		Timerange:    timerange,
 		Cancellable:  cancellable,
+		Profiler:     context.Profiler,
 	}
 	if hasTimeout {
 		timeout := time.After(context.Timeout)
@@ -152,4 +155,17 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 
 func (cmd *SelectCommand) Name() string {
 	return "select"
+}
+
+type ProfilingCommand struct {
+	Command Command
+}
+
+func (cmd ProfilingCommand) Name() string {
+	return cmd.Command.Name()
+}
+
+func (cmd ProfilingCommand) Execute(context ExecutionContext) (interface{}, error) {
+	defer context.Profiler.Add(fmt.Sprintf("%sCommand.Execute", cmd.Name()))
+	return cmd.Command.Execute(context)
 }

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -85,7 +85,7 @@ func TestCommand_Describe(t *testing.T) {
 			continue
 		}
 		command := rawCommand.(*DescribeCommand)
-		rawResult, _ := command.Execute(ExecutionContext{nil, test.backend, 1000, 0})
+		rawResult, _ := command.Execute(ExecutionContext{Backend: nil, API: test.backend, FetchLimit: 1000, Timeout: 0})
 		parsedResult := rawResult.([]string)
 		a.EqInt(len(parsedResult), test.length)
 	}
@@ -218,10 +218,10 @@ func TestCommand_Select(t *testing.T) {
 		}
 		command := rawCommand.(*SelectCommand)
 		rawResult, err := command.Execute(ExecutionContext{
-			backend.NewSequentialMultiBackend(fakeBackend),
-			fakeApi,
-			1000,
-			10 * time.Millisecond,
+			Backend:    backend.NewSequentialMultiBackend(fakeBackend),
+			API:        fakeApi,
+			FetchLimit: 1000,
+			Timeout:    10 * time.Millisecond,
 		})
 		if err != nil {
 			if !test.expectError {
@@ -253,7 +253,7 @@ func TestCommand_Select(t *testing.T) {
 		t.Fatalf("Unexpected error while parsing")
 		return
 	}
-	context := ExecutionContext{backend.NewSequentialMultiBackend(fakeBackend), fakeApi, 3, 0}
+	context := ExecutionContext{Backend: backend.NewSequentialMultiBackend(fakeBackend), API: fakeApi, FetchLimit: 3, Timeout: 0}
 	_, err = command.Execute(context)
 	if err != nil {
 		t.Fatalf("expected success with limit 3 but got err = %s", err.Error())
@@ -331,7 +331,7 @@ func TestNaming(t *testing.T) {
 			return
 		}
 		command := rawCommand.(*SelectCommand)
-		rawResult, err := command.Execute(ExecutionContext{fakeBackend, fakeApi, 1000, 0})
+		rawResult, err := command.Execute(ExecutionContext{Backend: fakeBackend, API: fakeApi, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue

--- a/query/expression.go
+++ b/query/expression.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/query/aggregate"
 )
 
@@ -71,6 +72,7 @@ type EvaluationContext struct {
 	Predicate    api.Predicate    // Predicate to apply to TagSets prior to fetching
 	FetchLimit   fetchCounter     // A limit on the number of fetches which may be performed
 	Cancellable  api.Cancellable
+	Profiler     *inspect.Profiler // Profiler collects data about query execution.
 }
 
 // fetchCounter is used to count the number of fetches remaining in a thread-safe manner.
@@ -152,6 +154,7 @@ func (expr *metricFetchExpression) Evaluate(context EvaluationContext) (value, e
 			context.Timerange,
 			context.API,
 			context.Cancellable,
+			context.Profiler,
 		},
 	)
 

--- a/query/expression.go
+++ b/query/expression.go
@@ -72,7 +72,7 @@ type EvaluationContext struct {
 	Predicate    api.Predicate    // Predicate to apply to TagSets prior to fetching
 	FetchLimit   fetchCounter     // A limit on the number of fetches which may be performed
 	Cancellable  api.Cancellable
-	Profiler     *inspect.Profiler // Profiler collects data about query execution.
+	Profiler     *inspect.Profiler
 }
 
 // fetchCounter is used to count the number of fetches remaining in a thread-safe manner.

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -88,7 +88,15 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := EvaluationContext{backend.NewSequentialMultiBackend(FakeBackend{}), nil, api.Timerange{}, api.SampleMean, nil, NewFetchCounter(1000), api.NewCancellable()}
+	emptyContext := EvaluationContext{
+		MultiBackend: backend.NewSequentialMultiBackend(FakeBackend{}),
+		API:          nil,
+		Timerange:    api.Timerange{},
+		SampleMethod: api.SampleMean,
+		Predicate:    nil,
+		FetchLimit:   NewFetchCounter(1000),
+		Cancellable:  api.NewCancellable(),
+	}
 	for _, test := range []struct {
 		context              EvaluationContext
 		functionName         string

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -1,0 +1,210 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"testing"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/api/backend"
+)
+
+type fakeAPI struct {
+	tagSets map[string][]api.TagSet
+}
+
+func (a fakeAPI) AddMetric(metric api.TaggedMetric) error {
+	// NOTHING
+	return nil
+}
+
+func (a fakeAPI) RemoveMetric(metric api.TaggedMetric) error {
+	// NOTHING
+	return nil
+}
+
+func (a fakeAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
+	return api.GraphiteMetric(metric.MetricKey), nil
+}
+
+func (a fakeAPI) ToTaggedName(metric api.GraphiteMetric) (api.TaggedMetric, error) {
+	return api.TaggedMetric{
+		MetricKey: api.MetricKey(metric),
+		TagSet:    api.NewTagSet(),
+	}, nil
+}
+
+func (a fakeAPI) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error) {
+	return a.tagSets[string(metricKey)], nil
+}
+
+func (a fakeAPI) GetAllMetrics() ([]api.MetricKey, error) {
+	list := []api.MetricKey{}
+	for metric := range a.tagSets {
+		list = append(list, api.MetricKey(metric))
+	}
+	return list, nil
+}
+
+func (a fakeAPI) GetMetricsForTag(tagKey, tagValue string) ([]api.MetricKey, error) {
+	list := []api.MetricKey{}
+MetricLoop:
+	for metric, tagsets := range a.tagSets {
+		for _, tagset := range tagsets {
+			for key, val := range tagset {
+				if key == tagKey && val == tagValue {
+					list = append(list, api.MetricKey(metric))
+					continue MetricLoop
+				}
+			}
+		}
+	}
+	return list, nil
+}
+
+type fakeBackend struct {
+}
+
+func (f fakeBackend) FetchSingleSeries(request api.FetchSeriesRequest) (api.Timeseries, error) {
+	return api.Timeseries{}, nil
+}
+
+func TestProfilerIntegration(t *testing.T) {
+	myAPI := fakeAPI{
+		tagSets: map[string][]api.TagSet{"A": []api.TagSet{
+			{"x": "1", "y": "2"},
+			{"x": "2", "y": "2"},
+			{"x": "3", "y": "1"},
+		},
+			"B": []api.TagSet{
+				{"q": "foo"},
+				{"q": "bar"},
+			},
+			"C": []api.TagSet{
+				{"c": "1"},
+				{"c": "2"},
+				{"c": "3"},
+				{"c": "4"},
+				{"c": "5"},
+				{"c": "6"},
+			},
+		},
+	}
+	myBackend := api.ProfilingBackend{fakeBackend{}}
+	multiBackend := api.ProfilingMultiBackend{backend.NewSequentialMultiBackend(myBackend)}
+
+	testCases := []struct {
+		query    string
+		expected map[string]int
+	}{
+		{
+			query: "describe all",
+			expected: map[string]int{
+				"describe all.Execute": 1,
+				"api.GetAllMetrics":    1,
+			},
+		},
+		{
+			query: "select A from 0 to 0",
+			expected: map[string]int{
+				"select.Execute":      1,
+				"fetchMultipleSeries": 1,
+				"api.GetAllTags":      1,
+				"fetchSingleSeries":   3,
+			},
+		},
+		{
+			query: "select A+A from 0 to 0",
+			expected: map[string]int{
+				"select.Execute":      1,
+				"fetchMultipleSeries": 2,
+				"api.GetAllTags":      2,
+				"fetchSingleSeries":   6,
+			},
+		},
+		{
+			query: "select A+2 from 0 to 0",
+			expected: map[string]int{
+				"select.Execute":      1,
+				"fetchMultipleSeries": 1,
+				"api.GetAllTags":      1,
+				"fetchSingleSeries":   3,
+			},
+		},
+		{
+			query: "select A where y = '2' from 0 to 0",
+			expected: map[string]int{
+				"select.Execute":      1,
+				"fetchMultipleSeries": 1,
+				"api.GetAllTags":      1,
+				"fetchSingleSeries":   2,
+			},
+		},
+		{
+			query: "describe A",
+			expected: map[string]int{
+				"describe.Execute": 1,
+				"api.GetAllTags":   1,
+			},
+		},
+		{
+			query: "describe metrics where y='2'",
+			expected: map[string]int{
+				"describe metrics.Execute": 1,
+				"api.GetMetricsForTag":     1,
+			},
+		},
+		{
+			query: "describe all",
+			expected: map[string]int{
+				"describe all.Execute": 1,
+				"api.GetAllMetrics":    1,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		cmd, err := Parse(test.query)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		profilingCommand, profiler := NewProfilingCommand(cmd)
+
+		_, err = profilingCommand.Execute(ExecutionContext{
+			Backend:    multiBackend,
+			API:        myAPI,
+			FetchLimit: 10000,
+			Timeout:    time.Second * 4,
+		})
+
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		list := profiler.All()
+		counts := map[string]int{}
+		for _, node := range list {
+			counts[node.Name()]++
+		}
+		for name, count := range counts {
+			if test.expected[name] != count {
+				t.Errorf("Expected %+v but got %+v (from %+v)", test.expected, counts, list)
+				break
+			}
+		}
+
+	}
+
+}

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -179,7 +179,8 @@ func TestProfilerIntegration(t *testing.T) {
 	for _, test := range testCases {
 		cmd, err := Parse(test.query)
 		if err != nil {
-			t.Fatal(err.Error())
+			t.Error(err.Error())
+			continue
 		}
 		profilingCommand, profiler := NewProfilingCommand(cmd)
 

--- a/query/parser.go
+++ b/query/parser.go
@@ -158,7 +158,7 @@ func Parse(query string) (Command, error) {
 		// after parsing has finished, there should be a command available.
 		return nil, AssertionError{"No command"}
 	}
-	return ProfilingCommand{p.command}, nil
+	return p.command, nil
 }
 
 // Error functions

--- a/query/parser.go
+++ b/query/parser.go
@@ -158,7 +158,7 @@ func Parse(query string) (Command, error) {
 		// after parsing has finished, there should be a command available.
 		return nil, AssertionError{"No command"}
 	}
-	return p.command, nil
+	return ProfilingCommand{p.command}, nil
 }
 
 // Error functions

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/log"
 	_ "github.com/square/metrics/main/static" // ensure that the static files are included.
 	"github.com/square/metrics/query"
@@ -33,7 +33,8 @@ type Config struct {
 }
 
 type QueryHandler struct {
-	context query.ExecutionContext
+	profiler *inspect.Profiler
+	context  query.ExecutionContext
 }
 
 type Response struct {
@@ -79,11 +80,17 @@ func (q QueryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 
+	cmd, profiler := query.NewProfilingCommand(cmd)
 	result, err := cmd.Execute(q.context)
 	if err != nil {
 		errorResponse(writer, http.StatusInternalServerError, err)
 		return
 	}
+
+	// profiler holds all the profiling data from this execution.
+
+	log.Infof("Profiler results: %+v", profiler.All())
+
 	bodyResponse(writer, result, cmd.Name())
 }
 
@@ -101,13 +108,7 @@ func (h StaticHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reque
 
 func NewMux(config Config, context query.ExecutionContext) *http.ServeMux {
 	// Wrap the given API and Backend in their Profiling counterparts.
-	context.API = api.ProfilingAPI{
-		API:      context.API,
-		Profiler: context.Profiler,
-	}
-	context.Backend = api.ProfilingMultiBackend{
-		MultiBackend: context.Backend,
-	}
+
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/query", QueryHandler{
 		context: context,

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/square/metrics/api"
 	"github.com/square/metrics/log"
 	_ "github.com/square/metrics/main/static" // ensure that the static files are included.
 	"github.com/square/metrics/query"
@@ -99,6 +100,14 @@ func (h StaticHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reque
 }
 
 func NewMux(config Config, context query.ExecutionContext) *http.ServeMux {
+	// Wrap the given API and Backend in their Profiling counterparts.
+	context.API = api.ProfilingAPI{
+		API:      context.API,
+		Profiler: context.Profiler,
+	}
+	context.Backend = api.ProfilingMultiBackend{
+		MultiBackend: context.Backend,
+	}
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/query", QueryHandler{
 		context: context,


### PR DESCRIPTION
`EvaluationContext` and `Fetch*Request` are given a `Profiler` field of type `*inspect.Profiler` which collects metrics about the evaluation of each command.

The interface for the `Profiler` is a method `func (p *Profiler) Add(name string) func()` which returns a function that adds a profiling metric from the whose `start` is the time of the first call, and whose `finish` is the time of the returned function's call, storing it in `name`.

Typical usage is: 
```
defer request.Profiler.Add("FetchSingleRequest")
```

There is no need to check for a `nil` pointer before doing this call. If the pointer is `nil`, the `.Add` method has no effect.

If it's necessary to time a function that is invoked (rather than modifying the function to do the profiling itself), then you can do the following (for example);

```
toGraphiteNameDone := request.Profiler.Add("api.ToGraphiteName")
graphiteName, err := request.API.ToGraphiteName(request.Metric)
toGraphiteNameDone()
```

However, Backends and APIs do not need to invoke these. Instead, use the wrappers `api.ProfilingAPI`, `api.ProfilingBackend`, `api.ProfilingMultiBackend`, and `query.ProfilingCommand`.

TODO: tests



