### PR TITLE
adding profiler.flush

### DIFF
--- a/inspect/profile.go
+++ b/inspect/profile.go
@@ -49,7 +49,7 @@ func (p *Profiler) Record(name string) func() {
 	}
 }
 
-// CloseAndCollect returns the list of profiles collected thus far, while closing the internal channel employed for threadsafety.
+// All retrieves all the profiling information collected by the profiler.
 func (p *Profiler) All() []Profile {
 	if p == nil {
 		// If the profiler instance doesn't exist, then don't attempt to operate on it.
@@ -58,6 +58,18 @@ func (p *Profiler) All() []Profile {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	return p.profiles
+}
+
+// All retrieves all the profiling information collected by the profiler.
+func (p *Profiler) Flush() []Profile {
+	if p == nil {
+		return []Profile{}
+	}
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	result := p.profiles
+	p.profiles = []Profile{}
+	return result
 }
 
 // A profile is a single data point collected by the profiler.

--- a/inspect/profile_test.go
+++ b/inspect/profile_test.go
@@ -80,4 +80,8 @@ func TestProfilerSimple(t *testing.T) {
 	wait.Wait()
 	list = profiler.All()
 	a.EqInt(len(list), count+1)
+	flushed := profiler.Flush()
+	a.EqInt(len(flushed), count+1)
+	flushed = profiler.Flush()
+	a.EqInt(len(flushed), 0)
 }


### PR DESCRIPTION
Adding the `Flush()` method - this is used to ensure that we can use `ProfilingAPI` in square's codebase to profile `API` that is not part of command - i.e. kafka consumers inserting metrics.