### PR TITLE
Part 1 of extracting function out of `query`

### DIFF
--- a/function/aggregate/aggregate.go
+++ b/function/aggregate/aggregate.go
@@ -83,7 +83,7 @@ func filterNaN(array []float64) []float64 {
 }
 
 // The sum aggregator returns the mean of the given array
-func AggregateSum(array []float64) float64 {
+func Sum(array []float64) float64 {
 	array = filterNaN(array)
 	sum := 0.0
 	for _, v := range array {
@@ -93,7 +93,7 @@ func AggregateSum(array []float64) float64 {
 }
 
 // The mean aggregator returns the mean of the given array
-func AggregateMean(array []float64) float64 {
+func Mean(array []float64) float64 {
 	array = filterNaN(array)
 	if len(array) == 0 {
 		// The mean of an empty list is not well-defined
@@ -107,7 +107,7 @@ func AggregateMean(array []float64) float64 {
 }
 
 // The minimum aggregator returns the minimum
-func AggregateMin(array []float64) float64 {
+func Min(array []float64) float64 {
 	array = filterNaN(array)
 	if len(array) == 0 {
 		// The minimum of an empty list is not well-defined
@@ -121,7 +121,7 @@ func AggregateMin(array []float64) float64 {
 }
 
 // The maximum aggregator returns the maximum
-func AggregateMax(array []float64) float64 {
+func Max(array []float64) float64 {
 	array = filterNaN(array)
 	if len(array) == 0 {
 		// The maximum of an empty list is not well-defined

--- a/function/aggregate/aggregate_test.go
+++ b/function/aggregate/aggregate_test.go
@@ -185,19 +185,19 @@ func Test_applyAggregation(t *testing.T) {
 		Expected   []float64
 	}{
 		{
-			AggregateSum,
+			Sum,
 			[]float64{3, 2, 8, 11},
 		},
 		{
-			AggregateMean,
+			Mean,
 			[]float64{3.0 / 4.0, 2.0 / 4.0, 8.0 / 4.0, 11.0 / 4.0},
 		},
 		{
-			AggregateMax,
+			Max,
 			[]float64{4, 2, 4, 4},
 		},
 		{
-			AggregateMin,
+			Min,
 			[]float64{-1, -1, 0, 2},
 		},
 	}
@@ -306,7 +306,7 @@ func Test_AggregateBy(t *testing.T) {
 	}{
 		{
 			[]string{"env"},
-			AggregateSum,
+			Sum,
 			[]api.Timeseries{
 				api.Timeseries{
 					Values: []float64{1, 11, 3},
@@ -324,7 +324,7 @@ func Test_AggregateBy(t *testing.T) {
 		},
 		{
 			[]string{"dc"},
-			AggregateMax,
+			Max,
 			[]api.Timeseries{
 				api.Timeseries{
 					Values: []float64{0, 2, 2},
@@ -348,7 +348,7 @@ func Test_AggregateBy(t *testing.T) {
 		},
 		{
 			[]string{"dc", "env"},
-			AggregateMean,
+			Mean,
 			[]api.Timeseries{
 				api.Timeseries{
 					Values: []float64{0, 1, 2},
@@ -389,7 +389,7 @@ func Test_AggregateBy(t *testing.T) {
 		},
 		{
 			[]string{},
-			AggregateSum,
+			Sum,
 			[]api.Timeseries{
 				api.Timeseries{
 					Values: []float64{5, 16, 9},

--- a/function/expression.go
+++ b/function/expression.go
@@ -1,0 +1,56 @@
+package function
+
+import (
+	"sync/atomic"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
+)
+
+// EvaluationContext is the central piece of logic, providing
+// helper funcions & varaibles to evaluate a given piece of
+// metrics query.
+// * Contains Backend object, which can be used to fetch data
+// from the backend system.s
+// * Contains current timerange being queried for - this can be
+// changed by say, application of time shift function.
+type EvaluationContext struct {
+	MultiBackend api.MultiBackend // Backend to fetch data from
+	API          api.API          // Api to obtain metadata from
+	Timerange    api.Timerange    // Timerange to fetch data from
+	SampleMethod api.SampleMethod // SampleMethod to use when up/downsampling to match the requested resolution
+	Predicate    api.Predicate    // Predicate to apply to TagSets prior to fetching
+	FetchLimit   FetchCounter     // A limit on the number of fetches which may be performed
+	Cancellable  api.Cancellable
+	Profiler     *inspect.Profiler
+}
+
+// fetchCounter is used to count the number of fetches remaining in a thread-safe manner.
+type FetchCounter struct {
+	count *int32
+}
+
+func NewFetchCounter(n int) FetchCounter {
+	n32 := int32(n)
+	return FetchCounter{
+		count: &n32,
+	}
+}
+
+// Consume decrements the internal counter and returns whether the result is at least 0.
+// It does so in a threadsafe manner.
+func (c FetchCounter) Consume(n int) bool {
+	return atomic.AddInt32(c.count, -int32(n)) >= 0
+}
+
+// Expression is a piece of code, which can be evaluated in a given
+// EvaluationContext. EvaluationContext must never be changed in an Evalute().
+//
+// The contract of Expressions is that leaf nodes must sample a resulting
+// timeseries according to the resolution specified in its EvaluationContext's
+// Timerange. Internal nodes may assume that results from evaluating child
+// Expressions correspond to the timerange in the current EvaluationContext.
+type Expression interface {
+	// Evaluate the given expression.
+	Evaluate(context EvaluationContext) (Value, error)
+}

--- a/function/filter/filter.go
+++ b/function/filter/filter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package query
+package filter
 
 import (
 	"math"

--- a/function/filter/filter_test.go
+++ b/function/filter/filter_test.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package query
+package filter
 
 import (
 	"testing"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/assert"
-	"github.com/square/metrics/query/aggregate"
+	"github.com/square/metrics/function/aggregate"
 )
 
 func TestFilter(t *testing.T) {
@@ -68,87 +68,87 @@ func TestFilter(t *testing.T) {
 		expect  []string
 	}{
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  true,
 			count:   6,
 			expect:  []string{"A", "B", "C", "D"},
 		},
 
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  false,
 			count:   6,
 			expect:  []string{"A", "B", "C", "D"},
 		},
 
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  true,
 			count:   4,
 			expect:  []string{"A", "B", "C", "D"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  true,
 			count:   3,
 			expect:  []string{"A", "B", "C"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  true,
 			count:   2,
 			expect:  []string{"A", "B"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  true,
 			count:   1,
 			expect:  []string{"B"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  false,
 			count:   4,
 			expect:  []string{"A", "B", "C", "D"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  false,
 			count:   3,
 			expect:  []string{"A", "C", "D"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  false,
 			count:   2,
 			expect:  []string{"C", "D"},
 		},
 		{
-			summary: aggregate.AggregateSum,
+			summary: aggregate.Sum,
 			lowest:  false,
 			count:   1,
 			expect:  []string{"D"},
 		},
 		{
-			summary: aggregate.AggregateMax,
+			summary: aggregate.Max,
 			lowest:  false,
 			count:   1,
 			expect:  []string{"C"},
 		},
 		{
-			summary: aggregate.AggregateMax,
+			summary: aggregate.Max,
 			lowest:  false,
 			count:   2,
 			expect:  []string{"C", "D"},
 		},
 		{
-			summary: aggregate.AggregateMin,
+			summary: aggregate.Min,
 			lowest:  false,
 			count:   2,
 			expect:  []string{"A", "D"},
 		},
 		{
-			summary: aggregate.AggregateMin,
+			summary: aggregate.Min,
 			lowest:  false,
 			count:   3,
 			expect:  []string{"A", "C", "D"},

--- a/function/join/join.go
+++ b/function/join/join.go
@@ -12,36 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package query
+package join
 
 import (
 	"github.com/square/metrics/api"
 )
 
-type joinRow struct {
+type JoinRow struct {
 	TagSet api.TagSet       // The tagSet is used to improve performance, or, possibly in the future, for later queries
-	Row    []api.Timeseries // The Row consists of all Timeseries which got collected into this joinRow
+	Row    []api.Timeseries // The Row consists of all Timeseries which got collected into this JoinRow
 }
 
-type joinResult struct {
-	Rows []joinRow
+type JoinResult struct {
+	Rows []JoinRow
 }
 
 // This method takes a partial joinrow, and evaluates the validity of appending `series` to it.
 // If this is possible, return the new series and true; otherwise return false for "ok"
-func extendRow(row joinRow, series api.Timeseries) (joinRow, bool) {
+func extendRow(row JoinRow, series api.Timeseries) (JoinRow, bool) {
 	for key, newValue := range series.TagSet {
 		oldValue, ok := map[string]string(row.TagSet)[key]
 		if ok && newValue != oldValue {
 			// If this occurs, then the candidate member (series) and the rest of the row are in
 			// conflict about `key`, since they assign it different values. If this occurs, then
 			// it is not possible to assign any key here.
-			return joinRow{}, false
+			return JoinRow{}, false
 		}
 	}
 	// if this point has been reached, then it is possible to extend the row without conflict
 	newTagSet := api.NewTagSet()
-	result := joinRow{newTagSet, append(row.Row, series)}
+	result := JoinRow{newTagSet, append(row.Row, series)}
 	for key, newValue := range series.TagSet {
 		newTagSet[key] = newValue
 	}
@@ -52,18 +52,18 @@ func extendRow(row joinRow, series api.Timeseries) (joinRow, bool) {
 }
 
 // join generates a cartesian product of the given series lists, and then returns rows where the tags are matching.
-func join(lists []api.SeriesList) joinResult {
+func Join(lists []api.SeriesList) JoinResult {
 	// place an empty row inside the results list first
 	// this row will be used to build up all others
-	emptyRow := joinRow{api.NewTagSet(), []api.Timeseries{}}
-	results := []joinRow{emptyRow}
+	emptyRow := JoinRow{api.NewTagSet(), []api.Timeseries{}}
+	results := []JoinRow{emptyRow}
 
 	// The `results` list is given an inductive definition:
 	// at the end of the `i`th iteration of the outer loop,
 	// `results` corresponds to the join of the first `i` seriesLists given as input
 
 	for _, list := range lists {
-		next := []joinRow{}
+		next := []JoinRow{}
 		// `next` is gradually accumulated into the final join of the first `i` (iteration) seriesLists
 		// results already contains the join of the the first (i-1)th series
 		for _, series := range list.Series {
@@ -86,5 +86,5 @@ func join(lists []api.SeriesList) joinResult {
 	// at this stage, iteration has continued over the entire set of lists,
 	// so `results` contains the join of all of the lists.
 
-	return joinResult{Rows: results}
+	return JoinResult{Rows: results}
 }

--- a/function/join/join_test.go
+++ b/function/join/join_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package query
+package join
 
 import (
 	"testing"
@@ -74,7 +74,7 @@ var testCases = []struct {
 
 func Test_join_ResultSizes(t *testing.T) {
 	for i, testCase := range testCases {
-		result := join(testCase.joinArgument)
+		result := Join(testCase.joinArgument)
 		if len(result.Rows) != testCase.expectedLength {
 			t.Errorf("join testcase %d results in %d; expected %d", i, len(result.Rows), testCase.expectedLength)
 			t.Errorf("testcase: %+v", testCase.joinArgument)

--- a/function/value.go
+++ b/function/value.go
@@ -46,12 +46,15 @@ type SeriesListValue api.SeriesList
 func (value SeriesListValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
 	return api.SeriesList(value), nil
 }
+
 func (value SeriesListValue) ToString() (string, error) {
 	return "", conversionError{"SeriesList", "string"}
 }
+
 func (value SeriesListValue) ToScalar() (float64, error) {
 	return 0, conversionError{"SeriesList", "scalar"}
 }
+
 func (value SeriesListValue) GetName() string {
 	return api.SeriesList(value).Name
 }
@@ -62,12 +65,15 @@ type StringValue string
 func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
 	return api.SeriesList{}, conversionError{"string", "SeriesList"}
 }
+
 func (value StringValue) ToString() (string, error) {
 	return string(value), nil
 }
+
 func (value StringValue) ToScalar() (float64, error) {
 	return 0, conversionError{"string", "scalar"}
 }
+
 func (value StringValue) GetName() string {
 	return string(value)
 }
@@ -87,12 +93,15 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 		Timerange: timerange,
 	}, nil
 }
+
 func (value ScalarValue) ToString() (string, error) {
 	return "", conversionError{"scalar", "string"}
 }
+
 func (value ScalarValue) ToScalar() (float64, error) {
 	return float64(value), nil
 }
+
 func (value ScalarValue) GetName() string {
 	return fmt.Sprintf("%g", value)
 }

--- a/function/value_test.go
+++ b/function/value_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package query
+package function
 
 import (
 	"testing"
@@ -20,7 +20,7 @@ import (
 
 func TestToDuration(t *testing.T) {
 	helper := func(given string, expected int64) {
-		actual, err := toDuration(stringValue(given))
+		actual, err := ToDuration(StringValue(given))
 		if err != nil || actual != expected {
 			t.Fatalf("Expected %s to produce %d but got %d", given, expected, actual)
 		}

--- a/query/command.go
+++ b/query/command.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/function"
 	"github.com/square/metrics/inspect"
 )
 
@@ -61,7 +62,7 @@ type DescribeMetricsCommand struct {
 // It actually performs the query against the underlying metrics system.
 type SelectCommand struct {
 	predicate   api.Predicate
-	expressions []Expression
+	expressions []function.Expression
 	context     *evaluationContextNode
 }
 
@@ -118,9 +119,9 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 	}
 
 	defer close(cancellable.Done()) // broadcast the finish - this ensures that the future work is cancelled.
-	evaluationContext := EvaluationContext{
+	evaluationContext := function.EvaluationContext{
 		API:          context.API,
-		FetchLimit:   NewFetchCounter(context.FetchLimit),
+		FetchLimit:   function.NewFetchCounter(context.FetchLimit),
 		MultiBackend: context.Backend,
 		Predicate:    cmd.predicate,
 		SampleMethod: cmd.context.SampleMethod,

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/api/backend"
 	"github.com/square/metrics/assert"
+	"github.com/square/metrics/function"
 	"github.com/square/metrics/mocks"
 )
 
@@ -228,8 +229,8 @@ func TestCommand_Select(t *testing.T) {
 				a.Errorf("Unexpected error while executing: %s", err.Error())
 			}
 		} else {
-			casted := rawResult.([]value)
-			actual, _ := casted[0].toSeriesList(api.Timerange{})
+			casted := rawResult.([]function.Value)
+			actual, _ := casted[0].ToSeriesList(api.Timerange{})
 			a.EqInt(len(actual.Series), len(expected.Series))
 			if len(actual.Series) == len(expected.Series) {
 				for i := 0; i < len(expected.Series); i++ {
@@ -339,12 +340,12 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]value)
+		seriesListList, ok := rawResult.([]function.Value)
 		if !ok || len(seriesListList) != 1 {
 			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
 			continue
 		}
-		actual := api.SeriesList(seriesListList[0].(seriesListValue)).Name
+		actual := api.SeriesList(seriesListList[0].(function.SeriesListValue)).Name
 		if actual != test.expected {
 			t.Errorf("Expected `%s` but got `%s` for query `%s`", test.expected, actual, test.query)
 			continue

--- a/query/node.go
+++ b/query/node.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/function"
 )
 
 // PrintNode prints the given node.
@@ -85,7 +86,7 @@ type metricFetchExpression struct {
 // This includes aggregate functions and arithmetic operators.
 type functionExpression struct {
 	functionName string
-	arguments    []Expression
+	arguments    []function.Expression
 	groupBy      []string
 }
 
@@ -118,7 +119,7 @@ type operatorLiteral struct {
 }
 
 type expressionList struct {
-	expressions []Expression
+	expressions []function.Expression
 }
 
 type groupByList struct {


### PR DESCRIPTION
This is part 1 - I got sick of doing this work - so i'm putting it here.

value, expression, and EvaluationContext are all pulled out to `function` class - it mostly contains types & aggregate functions that are used by functions. Next todo items are:

* pulling transformations out (not hard, but tests have some dependency on nodes).
* pulling function registration out.