### PR TITLE
FilterRecent

### DIFF
--- a/function/filter/filter.go
+++ b/function/filter/filter.go
@@ -17,6 +17,7 @@ package filter
 import (
 	"math"
 	"sort"
+	"time"
 
 	"github.com/square/metrics/api"
 )
@@ -65,6 +66,40 @@ func FilterBy(list api.SeriesList, count int, summary func([]float64) float64, l
 	for i := range array.index {
 		array.index[i] = i
 		array.value[i] = summary(list.Series[i].Values)
+	}
+	sort.Sort(array)
+
+	series := make([]api.Timeseries, count)
+	for i := range series {
+		series[i] = list.Series[array.index[i]]
+	}
+
+	return api.SeriesList{
+		Series:    series,
+		Timerange: list.Timerange,
+	}
+}
+
+func FilterRecentBy(list api.SeriesList, count int, summary func([]float64) float64, lowest bool, duration time.Duration) api.SeriesList {
+	if len(list.Series) < count {
+		// No need to change anything.
+		return list
+	}
+	array := newFilterList(len(list.Series), lowest)
+
+	// The number of elements to include
+	elements := int(int64(duration/time.Millisecond) / list.Timerange.Resolution())
+	if elements < 1 {
+		elements = 1
+	}
+	if elements > list.Timerange.Slots() {
+		elements = list.Timerange.Slots()
+	}
+	for i := range array.index {
+		array.index[i] = i
+		values := list.Series[i].Values
+		// Include only the last `elements`.
+		array.value[i] = summary(values[len(values)-elements:])
 	}
 	sort.Sort(array)
 

--- a/function/filter/filter.go
+++ b/function/filter/filter.go
@@ -59,8 +59,8 @@ func newFilterList(size int, ascending bool) filterList {
 // They're chosen by sorting by `summary` in `ascending` or descending order.
 func FilterBy(list api.SeriesList, count int, summary func([]float64) float64, lowest bool) api.SeriesList {
 	if len(list.Series) < count {
-		// No need to change if there's already fewer.
-		return list
+		// Limit the count to the number of available series
+		count = len(list.Series)
 	}
 	array := newFilterList(len(list.Series), lowest)
 	for i := range array.index {
@@ -82,8 +82,7 @@ func FilterBy(list api.SeriesList, count int, summary func([]float64) float64, l
 
 func FilterRecentBy(list api.SeriesList, count int, summary func([]float64) float64, lowest bool, duration time.Duration) api.SeriesList {
 	if len(list.Series) < count {
-		// No need to change anything.
-		return list
+		count = len(list.Series) // Limit the count to the number of available series
 	}
 	array := newFilterList(len(list.Series), lowest)
 

--- a/function/filter/filter_test.go
+++ b/function/filter/filter_test.go
@@ -16,6 +16,7 @@ package filter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/assert"
@@ -178,6 +179,111 @@ func TestFilter(t *testing.T) {
 				t.Fatalf("TagSets %+v aren't expected; %+v are", filtered.Series, test.expect)
 			}
 			names[s.TagSet["name"]] = false // Use up the name so that a seocnd Series can't also use it.
+		}
+	}
+}
+
+func TestFilterRecent(t *testing.T) {
+	timerange, err := api.NewTimerange(1300, 2000, 100)
+	a := assert.New(t)
+	a.CheckError(err)
+	series := []api.Timeseries{
+		{
+			Values: []float64{0, 1, 1, 0, 8, 8, 9, 8},
+			TagSet: api.TagSet{"name": "A"},
+		},
+		{
+			Values: []float64{-5, -6, -3, -4, 5, 6, 7, 8},
+			TagSet: api.TagSet{"name": "B"},
+		},
+		{
+			Values: []float64{7, 7, 6, 7, 3, 2, 1, 1},
+			TagSet: api.TagSet{"name": "C"},
+		},
+		{
+			Values: []float64{6, 5, 5, 5, 2, 2, 3, 3},
+			TagSet: api.TagSet{"name": "D"},
+		},
+	}
+	list := api.SeriesList{
+		Series:    series,
+		Timerange: timerange,
+	}
+	seriesMap := map[string]api.Timeseries{"A": series[0], "B": series[1], "C": series[2], "D": series[3]}
+	tests := []struct {
+		summary  func([]float64) float64
+		lowest   bool
+		count    int
+		duration time.Duration
+		expect   []string
+	}{
+		{
+			summary:  aggregate.Max,
+			lowest:   false,
+			count:    50,
+			duration: time.Millisecond * 450, // Four points
+			expect:   []string{"A", "B", "C", "D"},
+		},
+		{
+			summary:  aggregate.Min,
+			lowest:   true,
+			count:    5,
+			duration: time.Millisecond * 450, // Four points
+			expect:   []string{"A", "B", "C", "D"},
+		},
+		{
+			summary:  aggregate.Mean,
+			lowest:   false,
+			count:    4,
+			duration: time.Millisecond * 450, // Four points
+			expect:   []string{"A", "B", "C", "D"},
+		},
+		{
+			summary:  aggregate.Max,
+			lowest:   false,
+			count:    2,
+			duration: time.Millisecond * 450, // Four points
+			expect:   []string{"A", "B"},
+		},
+		{
+			summary:  aggregate.Max,
+			lowest:   true,
+			count:    2,
+			duration: time.Millisecond * 450, // Four points
+			expect:   []string{"C", "D"},
+		},
+		{
+			summary:  aggregate.Sum,
+			lowest:   true,
+			count:    1,
+			duration: time.Millisecond * 9000, // All points
+			expect:   []string{"B"},
+		},
+		{
+			summary:  aggregate.Sum,
+			lowest:   false,
+			count:    1,
+			duration: time.Millisecond * 9000, // All points
+			expect:   []string{"A"},
+		},
+	}
+	for _, test := range tests {
+		filtered := FilterRecentBy(list, test.count, test.summary, test.lowest, test.duration)
+		// Verify that they're all unique and expected and unchanged
+		a.EqInt(len(filtered.Series), len(test.expect))
+		// Next, verify that the names are the same.
+		correct := map[string]bool{}
+		for _, name := range test.expect {
+			correct[name] = true
+		}
+		for _, series := range filtered.Series {
+			name := series.TagSet["name"]
+			if !correct[name] {
+				t.Errorf("Expected %+v but got %+v", test.expect, filtered.Series)
+				break
+			}
+			correct[name] = false // Delete it so that there can be no repeats.
+			a.EqFloatArray(series.Values, seriesMap[name].Values, 1e-7)
 		}
 	}
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -169,7 +169,7 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 		Name:         name,
 		MinArguments: 3,
 		MaxArguments: 3,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups []string) (function.Value, error) {
+		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 			value, err := arguments[0].Evaluate(context)
 			if err != nil {
 				return nil, err

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -296,18 +296,20 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}},
-		{"select series_3 | filter.recent_lowest_max(70, 30ms) from 0 to 120 resolution 30ms", true, api.SeriesList{
-			{
-				[]float64{1, 1, 1, 4, 4},
-				api.ParseTagSet("dc=west"),
-			},
-			{
-				[]float64{3, 3, 3, 3, 3},
-				api.ParseTagSet("dc=north"),
-			},
-			{
-				[]float64{5, 5, 5, 2, 2},
-				api.ParseTagSet("dc=east"),
+		{"select series_3 | filter.recent_highest_max(70, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
 			},
 		}},
 		{"select series_3 | filter.recent_lowest_max(2, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -35,6 +35,7 @@ func (f fakeApiBackend) FetchSingleSeries(request api.FetchSeriesRequest) (api.T
 	metricMap := map[api.MetricKey][]api.Timeseries{
 		"series_1": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}},
 		"series_2": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}, {[]float64{3, 0, 3, 6, 2}, api.ParseTagSet("dc=east")}},
+		"series_3": {{[]float64{1, 1, 1, 4, 4}, api.ParseTagSet("dc=west")}, {[]float64{5, 5, 5, 2, 2}, api.ParseTagSet("dc=east")}, {[]float64{3, 3, 3, 3, 3}, api.ParseTagSet("dc=north")}},
 	}
 	if string(request.Metric.MetricKey) == "series_timeout" {
 		<-make(chan struct{}) // block forever
@@ -98,6 +99,9 @@ func TestCommand_Select(t *testing.T) {
 	fakeApi.AddPair(api.TaggedMetric{"series_1", api.ParseTagSet("dc=west")}, emptyGraphiteName)
 	fakeApi.AddPair(api.TaggedMetric{"series_2", api.ParseTagSet("dc=east")}, emptyGraphiteName)
 	fakeApi.AddPair(api.TaggedMetric{"series_2", api.ParseTagSet("dc=west")}, emptyGraphiteName)
+	fakeApi.AddPair(api.TaggedMetric{"series_3", api.ParseTagSet("dc=west")}, emptyGraphiteName)
+	fakeApi.AddPair(api.TaggedMetric{"series_3", api.ParseTagSet("dc=east")}, emptyGraphiteName)
+	fakeApi.AddPair(api.TaggedMetric{"series_3", api.ParseTagSet("dc=north")}, emptyGraphiteName)
 	fakeApi.AddPair(api.TaggedMetric{"series_timeout", api.ParseTagSet("dc=west")}, emptyGraphiteName)
 	var fakeBackend fakeApiBackend
 	testTimerange, err := api.NewTimerange(0, 120, 30)
@@ -207,6 +211,198 @@ func TestCommand_Select(t *testing.T) {
 			}},
 			Timerange: lateTimerange,
 			Name:      "series_1",
+		}},
+		{"select series_3 from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_highest_max(3, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_highest_max(2, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_highest_max(1, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(3, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(4, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(70, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(2, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(1, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_highest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_highest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_highest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+				{
+					[]float64{5, 5, 5, 2, 2},
+					api.ParseTagSet("dc=east"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
+				},
+			},
+		}},
+		{"select series_3 | filter.recent_lowest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
+			Series: []api.Timeseries{
+				{
+					[]float64{3, 3, 3, 3, 3},
+					api.ParseTagSet("dc=north"),
+				},
+			},
 		}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -283,33 +283,31 @@ func TestCommand_Select(t *testing.T) {
 		{"select series_3 | filter.recent_lowest_max(4, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
-				},
-				{
 					[]float64{5, 5, 5, 2, 2},
 					api.ParseTagSet("dc=east"),
 				},
 				{
 					[]float64{3, 3, 3, 3, 3},
 					api.ParseTagSet("dc=north"),
+				},
+				{
+					[]float64{1, 1, 1, 4, 4},
+					api.ParseTagSet("dc=west"),
 				},
 			},
 		}},
-		{"select series_3 | filter.recent_lowest_max(70, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{
-			Series: []api.Timeseries{
-				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
-				},
-				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
-				},
-				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
-				},
+		{"select series_3 | filter.recent_lowest_max(70, 30ms) from 0 to 120 resolution 30ms", true, api.SeriesList{
+			{
+				[]float64{1, 1, 1, 4, 4},
+				api.ParseTagSet("dc=west"),
+			},
+			{
+				[]float64{3, 3, 3, 3, 3},
+				api.ParseTagSet("dc=north"),
+			},
+			{
+				[]float64{5, 5, 5, 2, 2},
+				api.ParseTagSet("dc=east"),
 			},
 		}},
 		{"select series_3 | filter.recent_lowest_max(2, 30ms) from 0 to 120 resolution 30ms", false, api.SeriesList{


### PR DESCRIPTION
This PR defines a series of functions `filter.recent_*` which act similarly to `filter.*`.

Their purpose is to filter based on recent activity, rather than on total activity. For example:

`select filter.recent_highest_max( cpu, 5, 1d ) from -2w to now`

will show CPU usage for 5 hosts over the past 2 weeks, choosing these hosts by their activity only in the last day.