### PR TITLE
Fix bug in parsing duration literals

### DIFF
--- a/query/language.peg
+++ b/query/language.peg
@@ -290,7 +290,7 @@ NUMBER_FRACTION <- "." [0-9]+
 NUMBER_INTEGER  <- "-"? NUMBER_NATURAL
 NUMBER_EXP      <- "e" ("+" / "-")? [0-9]+
 
-DURATION <- NUMBER [a-z]+
+DURATION <- NUMBER [a-z]+ KEY
 
 # Syntactic elements
 # ==================

--- a/query/language.peg.go
+++ b/query/language.peg.go
@@ -2192,6 +2192,9 @@ func (p *Parser) Init() {
 							l201:
 								position, tokenIndex, depth = position201, tokenIndex201, depth201
 							}
+							if !_rules[ruleKEY]() {
+								goto l197
+							}
 							depth--
 							add(ruleDURATION, position199)
 						}
@@ -4904,7 +4907,7 @@ func (p *Parser) Init() {
 		nil,
 		/* 54 NUMBER_EXP <- <(('e' / 'E') ('+' / '-')? [0-9]+)> */
 		nil,
-		/* 55 DURATION <- <(NUMBER [a-z]+)> */
+		/* 55 DURATION <- <(NUMBER [a-z]+ KEY)> */
 		nil,
 		/* 56 PAREN_OPEN <- <'('> */
 		func() bool {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -162,6 +162,7 @@ var syntaxErrorQuery = []string{
 	"select f(3 groupby x) from 0 to 0",
 	"select c group by a from 0 to 0",
 	"select x[] from 0 to 0",
+	"select cpu | transform.moving_average(10qq) from 0 to 0",
 }
 
 func TestParse_success(t *testing.T) {


### PR DESCRIPTION
Requiring `KEY` to follow the duration suffix is necessary to parse everything correctly.