### PR TITLE
More Functions - Bounding transforms and counting aggregates

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -96,7 +96,7 @@ func (assert Assert) EqFloatArray(actual, expected []float64, epsilon float64) {
 			}
 		} else {
 			delta := actual[i] - expected[i]
-			if math.IsNaN(delta) || delta > epsilon {
+			if math.IsNaN(delta) || math.Abs(delta) > epsilon {
 				assert.withCaller("Expected=%+v, actual=%+v", expected, actual)
 				return
 			}

--- a/function/aggregate/aggregate.go
+++ b/function/aggregate/aggregate.go
@@ -134,6 +134,16 @@ func Max(array []float64) float64 {
 	return max
 }
 
+// Total returns the number of values in the given list.
+func Total(array []float64) float64 {
+	return float64(len(array))
+}
+
+// Count returns the number of non-NaN values in the givne list.
+func Count(array []float64) float64 {
+	return float64(len(filterNaN(array)))
+}
+
 // applyAggregation takes an aggregation function ( [float64] => float64 ) and applies it to a given list of Timeseries
 // the list must be non-empty, or an error is returned
 func applyAggregation(group group, aggregator func([]float64) float64) api.Timeseries {

--- a/function/aggregate/aggregate_test.go
+++ b/function/aggregate/aggregate_test.go
@@ -397,6 +397,62 @@ func Test_AggregateBy(t *testing.T) {
 				},
 			},
 		},
+		{
+			[]string{},
+			Total,
+			[]api.Timeseries{
+				{
+					Values: []float64{8, 8, 8},
+					TagSet: map[string]string{},
+				},
+			},
+		},
+		{
+			[]string{"dc"},
+			Total,
+			[]api.Timeseries{
+				{
+					Values: []float64{4, 4, 4},
+					TagSet: map[string]string{"dc": "A"},
+				},
+				{
+					Values: []float64{3, 3, 3},
+					TagSet: map[string]string{"dc": "B"},
+				},
+				{
+					Values: []float64{1, 1, 1},
+					TagSet: map[string]string{"dc": "C"},
+				},
+			},
+		},
+		{
+			[]string{},
+			Count,
+			[]api.Timeseries{
+				{
+					Values: []float64{6, 7, 6},
+					TagSet: map[string]string{},
+				},
+			},
+		},
+		{
+			[]string{"dc"},
+			Count,
+			[]api.Timeseries{
+				{
+					Values: []float64{3, 3, 3},
+					TagSet: map[string]string{"dc": "A"},
+				},
+				{
+					Values: []float64{2, 3, 2},
+					TagSet: map[string]string{"dc": "B"},
+				},
+				{
+					Values: []float64{1, 1, 1},
+					TagSet: map[string]string{"dc": "C"},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range aggregatedTests {

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -39,6 +39,8 @@ func init() {
 	MustRegister(NewAggregate("aggregate.min", aggregate.Min))
 	MustRegister(NewAggregate("aggregate.mean", aggregate.Mean))
 	MustRegister(NewAggregate("aggregate.sum", aggregate.Sum))
+	MustRegister(NewAggregate("aggregate.total", aggregate.Total))
+	MustRegister(NewAggregate("aggregate.count", aggregate.Count))
 	// Transformations
 	MustRegister(NewTransform("transform.derivative", 0, transform.Derivative))
 	MustRegister(NewTransform("transform.integral", 0, transform.Integral))
@@ -48,6 +50,9 @@ func init() {
 	MustRegister(NewTransform("transform.abs", 0, transform.MapMaker(math.Abs)))
 	MustRegister(NewTransform("transform.log", 0, transform.MapMaker(math.Log10)))
 	MustRegister(NewTransform("transform.nan_keep_last", 0, transform.NaNKeepLast))
+	MustRegister(NewTransform("transform.bound", 2, transform.Bound))
+	MustRegister(NewTransform("transform.lower_bound", 1, transform.LowerBound))
+	MustRegister(NewTransform("transform.upper_bound", 1, transform.UpperBound))
 	// Filter
 	MustRegister(NewFilter("filter.highest_mean", aggregate.Mean, false))
 	MustRegister(NewFilter("filter.lowest_mean", aggregate.Mean, true))

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -17,6 +17,7 @@
 package transform
 
 import (
+	"errors"
 	"math"
 
 	"github.com/square/metrics/api"
@@ -152,6 +153,64 @@ func NaNKeepLast(values []float64, parameters []function.Value, scale float64) (
 		result[i] = values[i]
 		if math.IsNaN(result[i]) && i > 0 {
 			result[i] = result[i-1]
+		}
+	}
+	return result, nil
+}
+
+// Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
+func Bound(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+	lowerBound, err := parameters[0].ToScalar()
+	if err != nil {
+		return nil, err
+	}
+	upperBound, err := parameters[1].ToScalar()
+	if err != nil {
+		return nil, err
+	}
+	if lowerBound > upperBound {
+		return nil, errors.New("the upper bound must be at least the lower bound")
+	}
+	result := make([]float64, len(values))
+	for i := range result {
+		result[i] = values[i]
+		if result[i] < lowerBound {
+			result[i] = lowerBound
+		}
+		if result[i] > upperBound {
+			result[i] = upperBound
+		}
+	}
+	return result, nil
+}
+
+// LowerBound replaces values that fall below the given bound with the lower bound.
+func LowerBound(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+	lowerBound, err := parameters[0].ToScalar()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]float64, len(values))
+	for i := range result {
+		result[i] = values[i]
+		if result[i] < lowerBound {
+			result[i] = lowerBound
+		}
+	}
+	return result, nil
+}
+
+// UpperBound replaces values that fall below the given bound with the lower bound.
+func UpperBound(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+	upperBound, err := parameters[0].ToScalar()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]float64, len(values))
+	for i := range result {
+		result[i] = values[i]
+		if result[i] > upperBound {
+			result[i] = upperBound
 		}
 	}
 	return result, nil

--- a/function/transform/transformation_test.go
+++ b/function/transform/transformation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/assert"
 	"github.com/square/metrics/function"
 )
 
@@ -201,6 +202,119 @@ func TestApplyTransform(t *testing.T) {
 					t.Errorf("Expected values for series %s to be %+v but are %+v", name, expected, series.Values)
 					break
 				}
+			}
+		}
+	}
+}
+
+func TestApplyBound(t *testing.T) {
+	a := assert.New(t)
+	testTimerange, err := api.NewTimerange(758400000, 758400000+30000*5, 30000)
+	//{2, nan, nan, nan, 3, 3},
+	if err != nil {
+		t.Fatal("invalid timerange used for testcase")
+		return
+	}
+	list := api.SeriesList{
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4, 5, 6},
+				TagSet: api.TagSet{
+					"name": "A",
+				},
+			},
+			{
+				Values: []float64{5, 5, 3, -7, math.NaN(), -20},
+				TagSet: api.TagSet{
+					"name": "B",
+				},
+			},
+			{
+				Values: []float64{math.NaN(), 100, 90, 0, 0, 3},
+				TagSet: api.TagSet{
+					"name": "C",
+				},
+			},
+		},
+		Timerange: testTimerange,
+		Name:      "test",
+	}
+	tests := []struct {
+		lower       float64
+		upper       float64
+		expectBound map[string][]float64
+		expectLower map[string][]float64
+		expectUpper map[string][]float64
+	}{
+		{
+			lower: 2,
+			upper: 5,
+			expectBound: map[string][]float64{
+				"A": {2, 2, 3, 4, 5, 5},
+				"B": {5, 5, 3, 2, math.NaN(), 2},
+				"C": {math.NaN(), 5, 5, 2, 2, 3},
+			},
+			expectLower: map[string][]float64{
+				"A": {2, 2, 3, 4, 5, 6},
+				"B": {5, 5, 3, 2, math.NaN(), 2},
+				"C": {math.NaN(), 100, 90, 2, 2, 3},
+			},
+			expectUpper: map[string][]float64{
+				"A": {1, 2, 3, 4, 5, 5},
+				"B": {5, 5, 3, -7, math.NaN(), -20},
+				"C": {math.NaN(), 5, 5, 0, 0, 3},
+			},
+		},
+		{
+			lower: -10,
+			upper: 40,
+			expectBound: map[string][]float64{
+				"A": {1, 2, 3, 4, 5, 6},
+				"B": {5, 5, 3, -7, math.NaN(), -10},
+				"C": {math.NaN(), 40, 40, 0, 0, 3},
+			},
+			expectLower: map[string][]float64{
+				"A": {1, 2, 3, 4, 5, 6},
+				"B": {5, 5, 3, -7, math.NaN(), -10},
+				"C": {math.NaN(), 100, 90, 0, 0, 3},
+			},
+			expectUpper: map[string][]float64{
+				"A": {1, 2, 3, 4, 5, 6},
+				"B": {5, 5, 3, -7, math.NaN(), -20},
+				"C": {math.NaN(), 40, 40, 0, 0, 3},
+			},
+		},
+	}
+	for _, test := range tests {
+		bounders := []struct {
+			bounder  func(values []float64, parameters []function.Value, scale float64) ([]float64, error)
+			params   []function.Value
+			expected map[string][]float64
+			name     string
+		}{
+			{bounder: Bound, params: []function.Value{function.ScalarValue(test.lower), function.ScalarValue(test.upper)}, expected: test.expectBound, name: "bound"},
+			{bounder: LowerBound, params: []function.Value{function.ScalarValue(test.lower)}, expected: test.expectLower, name: "lower"},
+			{bounder: UpperBound, params: []function.Value{function.ScalarValue(test.upper)}, expected: test.expectUpper, name: "upper"},
+		}
+		for _, bounder := range bounders {
+			bounded, err := ApplyTransform(list, bounder.bounder, bounder.params)
+			if err != nil {
+				t.Errorf(err.Error())
+				continue
+			}
+			if len(bounded.Series) != len(list.Series) {
+				t.Errorf("Expected to get %d results but got %d in %+v", len(list.Series), len(bounded.Series), bounded)
+				continue
+			}
+			// Next, check they're all unique and such
+			alreadyUsed := map[string]bool{}
+			for _, series := range bounded.Series {
+				if alreadyUsed[series.TagSet["name"]] {
+					t.Fatalf("Repeating name `%s`", series.TagSet["name"])
+				}
+				alreadyUsed[series.TagSet["name"]] = true
+				// Next, verify that it's what we expect
+				a.EqFloatArray(series.Values, bounder.expected[series.TagSet["name"]], 3e-7)
 			}
 		}
 	}

--- a/function/transform/transformation_test.go
+++ b/function/transform/transformation_test.go
@@ -318,6 +318,12 @@ func TestApplyBound(t *testing.T) {
 			}
 		}
 	}
+	if _, err = ApplyTransform(list, Bound, []function.Value{function.ScalarValue(18), function.ScalarValue(17)}); err == nil {
+		t.Fatalf("Expected error on invalid bounds")
+	}
+	if _, err = ApplyTransform(list, Bound, []function.Value{function.ScalarValue(-17), function.ScalarValue(-18)}); err == nil {
+		t.Fatalf("Expected error on invalid bounds")
+	}
 }
 
 func TestApplyTransformNaN(t *testing.T) {


### PR DESCRIPTION
* `aggregate.total` tells how many timeseries are in the serieslist (or group)
* `aggregate.count` tells us how many values aren't `NaN`
* `transform.bound(low, high)` lets us place bounds on functions (they'll be clamped to the edges)
* `transform.lower_bound(low)` lets us place a lower bound
* `transform.upper_bound(high)` lets us place a higher bound

Also fixes a bug in `assert.EqFloatArray` (sign of `delta` was being ignored, so some differences would have gone unnoticed. No tests failed after correcting this behavior).