### PR TITLE
Add elaborative examples to transformation function documentation

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -157,7 +157,7 @@ Transformation functions modify each series in a given serieslist independently.
 * `transform.integral`
 * `transform.rate`
 * `transform.cumulative`
-* `transform.default`
+* `transform.nan_fill`
 * `transform.abs`
 * `transform.nan_keep_last`
 
@@ -241,22 +241,22 @@ The query `transform.cumulative( request_counter )` results in:
 | (A1)      | transform.cumulative(request_counter) | app: ui     | 30  55  75     |
 | (A2)      | transform.cumulative(request_counter) | app: server | 120 254 404    |
 
-##### `transform.default(list, value)`
+##### `transform.nan_fill(list, value)`
 
 This function takes an extra number parameter. Any occurrence of `NaN` in any series in the list will be replaced by `value`.
 
-Consider the query `transform.default(latency, 1000)`. If `latency` is detailed as below:
+Consider the query `transform.nan_fill(latency, 1000)`. If `latency` is detailed as below:
 
 | (series†) | metric name | tags        | series values |
 |:---------:|:-----------:|:-----------:|:-------------:|
 | (A1)      | latency     | app: ui     | 80  24   15   |
 | (A2)      | latency     | app: server | 70  NaN  NaN  |
 
-Then `transform.default(latency, 1000)` produces this result:
+Then `transform.nan_fill(latency, 1000)` produces this result:
 
 | (series†) | metric name                | tags        | series values  |
 |:---------:|:--------------------------:|:-----------:|:--------------:|
-| (A1)      | transform.default(latency) | app: ui     | 80  24    15   |
+| (A1)      | transform.nan_fill(latency) | app: ui     | 80  24    15   |
 | (A2)      | transform.defailt(latency) | app: server | 70  1000  1000 |
 
 ##### `transform.abs(list)`
@@ -280,7 +280,7 @@ Then the query `transform.abs(offset)` results in:
 ##### `transform.nan_keep_last(list)`
 
 This function replaces any `NaN` value with the last non-`NaN` value before it. For data which is very sparse, this can make graphs more readable.
-Initial `NaN`s are left alone. If these need to be eliminated also, consider using `transform.default` on the result.
+Initial `NaN`s are left alone. If these need to be eliminated also, consider using `transform.nan_fill` on the result.
 
 Consider the metric `responses`:
 

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -30,15 +30,15 @@ We evaluate `latency.method` and `latency.connection` and find the following tim
 
 | (series†) | metric name    | tags                    | series values |
 |:---------:|:--------------:|:-----------------------:|:-------------:|
-| (A1)      | latency.method | [app: ui, env: staging] | 1 1 1         |
-| (A2)      | latency.method | [app: ui, host: h0    ] | 2 2 2         |
+| (A1)      | latency.method | [app: ui, env: staging] | `1 1 1`       |
+| (A2)      | latency.method | [app: ui, host: h0    ] | `2 2 2`       |
 
 We evaluate `latency.connection` and find that the result is the following list of two timeseries:
 
 | (series†) | metric name        | tags                       | series values |
 |:---------:|:------------------:|:--------------------------:|:-------------:|
-| (B1)      | latency.connection | [app: ui,     method: rpc] | 3 3 3         |
-| (B2)      | latency.connection | [app: server, method: rpc] | 4 4 4         |
+| (B1)      | latency.connection | [app: ui,     method: rpc] | `3 3 3`       |
+| (B2)      | latency.connection | [app: server, method: rpc] | `4 4 4`       |
 
 † The series identifiers are purely illustrative - internally, individual timeseries are identified solely by their metric name and tags.
 
@@ -51,8 +51,8 @@ Therefore the following result is reached:
 
 | (series†) | metric name                         | tags                                               | series values |
 |:---------:|:-----------------------------------:|:--------------------------------------------------:|:-------------:|
-| (A1)+(B1) | latency.method + latency.connection | [app: ui,     env: staging,           method: rpc] | 4 4 4         |
-| (A2)+(B1) | latency.method + latency.connection | [app: server,               host: h0, method: rpc] | 5 5 5         |
+| (A1)+(B1) | latency.method + latency.connection | [app: ui,     env: staging,           method: rpc] | `4 4 4`       |
+| (A2)+(B1) | latency.method + latency.connection | [app: server,               host: h0, method: rpc] | `5 5 5`       |
 
 Important things to note:
 
@@ -68,25 +68,25 @@ Consider the query `latency.method + latency.connection` over the following data
 
 | (series†) | metric name        | tags                         | series values |
 |:---------:|:------------------:|:----------------------------:|:-------------:|
-| (A1)      | latency.method     | app: ui,     env: staging    | 1 2 1         |
-| (A2)      | latency.method     | app: ui,     env: production | 3 3 3         |
-| (A3)      | latency.method     | app: server, env: production | 0 0 1         |
+| (A1)      | latency.method     | app: ui,     env: staging    | `1 2 1`       |
+| (A2)      | latency.method     | app: ui,     env: production | `3 3 3`       |
+| (A3)      | latency.method     | app: server, env: production | `0 0 1`       |
 |           |                    |                              |               |
-| (B1)      | latency.connection | app: ui,     method: rpc     | 0 0 4         |
-| (B2)      | latency.connection | app: ui,     method: http    | 1 1 1         |
-| (B3)      | latency.connection | app: server, method: rpc     | 2 1 0         |
-| (B4)      | latency.connection | app: server, method: http    | 3 2 3         |
+| (B1)      | latency.connection | app: ui,     method: rpc     | `0 0 4`       |
+| (B2)      | latency.connection | app: ui,     method: http    | `1 1 1`       |
+| (B3)      | latency.connection | app: server, method: rpc     | `2 1 0`       |
+| (B4)      | latency.connection | app: server, method: http    | `3 2 3`       |
 
 The query results in a list of 6 timeseries:
 
 | (series†) | metric name                         | tags                                       | series values |
 |:---------:|:-----------------------------------:|:------------------------------------------:|:-------------:|
-| (A1)+(B1) | latency.method + latency.connection | app: ui,     env: staging,    method: rpc  | 1 2 5         |
-| (A1)+(B2) | latency.method + latency.connection | app: ui,     env: staging,    method: http | 2 3 2         |
-| (A2)+(B1) | latency.method + latency.connection | app: ui,     env: production, method: rpc  | 3 3 7         |
-| (A2)+(B2) | latency.method + latency.connection | app: ui,     env: production, method: http | 4 4 4         |
-| (A3)+(B3) | latency.method + latency.connection | app: server, env: production, method: rpc  | 2 1 1         |
-| (A3)+(B4) | latency.method + latency.connection | app: server, env: production, method: http | 3 2 4         |
+| (A1)+(B1) | latency.method + latency.connection | app: ui,     env: staging,    method: rpc  | `1 2 5`       |
+| (A1)+(B2) | latency.method + latency.connection | app: ui,     env: staging,    method: http | `2 3 2`       |
+| (A2)+(B1) | latency.method + latency.connection | app: ui,     env: production, method: rpc  | `3 3 7`       |
+| (A2)+(B2) | latency.method + latency.connection | app: ui,     env: production, method: http | `4 4 4`       |
+| (A3)+(B3) | latency.method + latency.connection | app: server, env: production, method: rpc  | `2 1 1`       |
+| (A3)+(B4) | latency.method + latency.connection | app: server, env: production, method: http | `3 2 4`       |
 
 ## Aggregation Functions
 
@@ -103,31 +103,31 @@ For example, given a series list produced by `latency`:
 
 | (series†) | metric name | tags                         | series values |
 |:---------:|:-----------:|:----------------------------:|:-------------:|
-| (A1)      | latency     | app: ui,     env: staging    | 1 2 1         |
-| (A2)      | latency     | app: ui,     env: production | 3 3 3         |
-| (A3)      | latency     | app: server, env: staging    | 0 0 1         |
-| (A4)      | latency     | app: server, env: production | 2 2 0         |
+| (A1)      | latency     | app: ui,     env: staging    | `1 2 1`       |
+| (A2)      | latency     | app: ui,     env: production | `3 3 3`       |
+| (A3)      | latency     | app: server, env: staging    | `0 0 1`       |
+| (A4)      | latency     | app: server, env: production | `2 2 0`       |
 
 Querying `aggregate.sum( latency )` computes the following result, a list of a single series:
 
 | (series†)         | metric name            | tags      | series values |
 |:-----------------:|:----------------------:|:---------:|:-------------:|
-|(A1)+(A2)+(A3)+(A4)| aggregate.sum(latency) | (no tags) | 6 7 5         |
+|(A1)+(A2)+(A3)+(A4)| aggregate.sum(latency) | (no tags) | `6 7 5`       |
 
 Aggregators in general treat missing data (internally represented as `NaN`) as though it were not present. For example, consider the following:
 
 | (series†) | metric name | tags                         | series values |
 |:---------:|:-----------:|:----------------------------:|:-------------:|
-| (A1)      | latency     | app: ui,     env: staging    | 8   NaN 2     |
-| (A2)      | latency     | app: ui,     env: production | 8   6   NaN   |
-| (A3)      | latency     | app: server, env: staging    | NaN 9   NaN   |
-| (A4)      | latency     | app: server, env: production | 8   3   8     |
+| (A1)      | latency     | app: ui,     env: staging    | `8   NaN 2  ` |
+| (A2)      | latency     | app: ui,     env: production | `8   6   NaN` |
+| (A3)      | latency     | app: server, env: staging    | `NaN 9   NaN` |
+| (A4)      | latency     | app: server, env: production | `8   3   8  ` |
 
 The result of `aggregate.mean` is:
 
 | (series†)         | metric name            | tags      | series values |
 |:-----------------:|:----------------------:|:---------:|:-------------:|
-|(A1)+(A2)+(A3)+(A4)| aggregate.sum(latency) | (no tags) | 8 6 5         |
+|(A1)+(A2)+(A3)+(A4)| aggregate.sum(latency) | (no tags) | `8 6 5`       |
 
 Aggregations can be grouped by individual tags. The series in the resulting series list preserve those tags which their group used.
 
@@ -135,17 +135,17 @@ Consider the metric `latency`:
 
 | (series†) | metric name | tags                         | series values |
 |:---------:|:-----------:|:----------------------------:|:-------------:|
-| (A1)      | latency     | app: ui,     env: staging    | 1 2 1         |
-| (A2)      | latency     | app: ui,     env: production | 3 3 3         |
-| (A3)      | latency     | app: server, env: staging    | 0 0 1         |
-| (A4)      | latency     | app: server, env: production | 2 2 0         |
+| (A1)      | latency     | app: ui,     env: staging    | `1 2 1`       |
+| (A2)      | latency     | app: ui,     env: production | `3 3 3`       |
+| (A3)      | latency     | app: server, env: staging    | `0 0 1`       |
+| (A4)      | latency     | app: server, env: production | `2 2 0`       |
 
 If we want to find the total latency per-app then we can run `aggregate.sum(latency group by app)`. We get the following result:
 
 | (series†) | metric name                         | tags        | series values |
 |:---------:|:-----------------------------------:|:-----------:|:-------------:|
-|(A1)+(A2)  | aggregate.sum(latency group by app) | app: ui     | 4 5 4         |
-|(A3)+(A4)  | aggregate.sum(latency group by app) | app: server | 2 2 1         |
+|(A1)+(A2)  | aggregate.sum(latency group by app) | app: ui     | `4 5 4`       |
+|(A3)+(A4)  | aggregate.sum(latency group by app) | app: server | `2 2 1`       |
 
 Note that only those tags which you list in the `group by` clause are preserved- even if all series in the group agree on a particular tag value, the tag will be omitted in the result.
 
@@ -170,15 +170,15 @@ Consider performing the query `transform.derivative( disk_usage )` with a resolu
 
 | (series†) | metric name | tags        | series values |
 |:---------:|:-----------:|:-----------:|:-------------:|
-| (A1)      | disk_usage  | app: ui     | 300  310  315 |
-| (A2)      | disk_usage  | app: server | 440  435  450 |
+| (A1)      | disk_usage  | app: ui     | `300 310 315` |
+| (A2)      | disk_usage  | app: server | `440 435 450` |
 
 The query `transform.deriative( disk_usage )` results in:
 
 | (series†) | metric name                      | tags        | series values |
 |:---------:|:--------------------------------:|:-----------:|:-------------:|
-| (A1)      | transform.derivative(disk_usage) | app: ui     | 0   1    0.5  |
-| (A2)      | transform.derivative(disk_usage) | app: server | 0  -0.5  1.5  |
+| (A1)      | transform.derivative(disk_usage) | app: ui     | `0  1   0.5`  |
+| (A2)      | transform.derivative(disk_usage) | app: server | `0 -0.5 1.5`  |
 
 ##### `transform.integral(list)`
 
@@ -192,15 +192,15 @@ Consider the query `transform.integral( request_rate )` with a resolution of 10 
 
 | (series†) | metric name  | tags        | series values |
 |:---------:|:------------:|:-----------:|:-------------:|
-| (A1)      | request_rate | app: ui     | 30  25  20    |
-| (A2)      | request_rate | app: server | 120 134 150   |
+| (A1)      | request_rate | app: ui     | `30  25  20 ` |
+| (A2)      | request_rate | app: server | `120 134 150` |
 
 The query `transform.integral( request_rate )` results in:
 
-| (series†) | metric name                      | tags        | series values  |
-|:---------:|:--------------------------------:|:-----------:|:--------------:|
-| (A1)      | transform.integral(request_rate) | app: ui     | 300  550  750  |
-| (A2)      | transform.integral(request_rate) | app: server | 1200 2540 4040 |
+| (series†) | metric name                      | tags        | series values    |
+|:---------:|:--------------------------------:|:-----------:|:----------------:|
+| (A1)      | transform.integral(request_rate) | app: ui     | `300  550  750`  |
+| (A2)      | transform.integral(request_rate) | app: server | `1200 2540 4040` |
 
 ##### `transform.rate(list)`
 
@@ -209,17 +209,17 @@ This transformation is most useful on counters. The resulting units are in `even
 
 Consider performing the query `transform.rate( disk_usage )` with a resolution of 10 seconds (30 seconds is the default resolution), where `disk_usage` is defined like this:
 
-| (series†) | metric name | tags        | series values |
-|:---------:|:-----------:|:-----------:|:-------------:|
-| (A1)      | disk_usage  | app: ui     | 300  310  315 |
-| (A2)      | disk_usage  | app: server | 440  435  450 |
+| (series†) | metric name | tags        | series values   |
+|:---------:|:-----------:|:-----------:|:---------------:|
+| (A1)      | disk_usage  | app: ui     | `300  310  315` |
+| (A2)      | disk_usage  | app: server | `440  435  450` |
 
 The query `transform.rate( disk_usage )` results in:
 
 | (series†) | metric name                | tags        | series values |
 |:---------:|:--------------------------:|:-----------:|:-------------:|
-| (A1)      | transform.rate(disk_usage) | app: ui     | 0  1  0.5     |
-| (A2)      | transform.rate(disk_usage) | app: server | 0  0  1.5     |
+| (A1)      | transform.rate(disk_usage) | app: ui     | `0  1  0.5`   |
+| (A2)      | transform.rate(disk_usage) | app: server | `0  0  1.5`   |
 
 ##### `transform.cumulative(list)`
 
@@ -231,15 +231,15 @@ Consider the query `transform.cumulative( request_counter )` with a resolution o
 
 | (series†) | metric name     | tags        | series values |
 |:---------:|:---------------:|:-----------:|:-------------:|
-| (A1)      | request_counter | app: ui     | 30  25  20    |
-| (A2)      | request_counter | app: server | 120 134 150   |
+| (A1)      | request_counter | app: ui     | `30  25  20 ` |
+| (A2)      | request_counter | app: server | `120 134 150` |
 
 The query `transform.cumulative( request_counter )` results in:
 
 | (series†) | metric name                           | tags        | series values  |
 |:---------:|:-------------------------------------:|:-----------:|:--------------:|
-| (A1)      | transform.cumulative(request_counter) | app: ui     | 30  55  75     |
-| (A2)      | transform.cumulative(request_counter) | app: server | 120 254 404    |
+| (A1)      | transform.cumulative(request_counter) | app: ui     | `30  55  75 `  |
+| (A2)      | transform.cumulative(request_counter) | app: server | `120 254 404`  |
 
 ##### `transform.nan_fill(list, value)`
 
@@ -249,15 +249,15 @@ Consider the query `transform.nan_fill(latency, 1000)`. If `latency` is detailed
 
 | (series†) | metric name | tags        | series values |
 |:---------:|:-----------:|:-----------:|:-------------:|
-| (A1)      | latency     | app: ui     | 80  24   15   |
-| (A2)      | latency     | app: server | 70  NaN  NaN  |
+| (A1)      | latency     | app: ui     | `80  24   15 `|
+| (A2)      | latency     | app: server | `70  NaN  NaN`|
 
 Then `transform.nan_fill(latency, 1000)` produces this result:
 
-| (series†) | metric name                | tags        | series values  |
-|:---------:|:--------------------------:|:-----------:|:--------------:|
-| (A1)      | transform.nan_fill(latency) | app: ui     | 80  24    15   |
-| (A2)      | transform.defailt(latency) | app: server | 70  1000  1000 |
+| (series†) | metric name                 | tags        | series values  |
+|:---------:|:---------------------------:|:-----------:|:--------------:|
+| (A1)      | transform.nan_fill(latency) | app: ui     | `80 24   15  ` |
+| (A2)      | transform.defailt(latency)  | app: server | `70 1000 1000` |
 
 ##### `transform.abs(list)`
 
@@ -267,15 +267,15 @@ Consider the query: `transform.abs(offset)` where `offset` is detailed as below:
 
 | (series†) | metric name | tags        | series values |
 |:---------:|:-----------:|:-----------:|:-------------:|
-| (A1)      | offset      | app: ui     | 30  0  -15    | 
-| (A2)      | offset      | app: server | 7   6  -3     |
+| (A1)      | offset      | app: ui     | `30  0  -15`  | 
+| (A2)      | offset      | app: server | `7   6  -3 `  |
 
 Then the query `transform.abs(offset)` results in:
 
 | (series†) | metric name           | tags        | series values |
 |:---------:|:---------------------:|:-----------:|:-------------:|
-| (A1)      | transform.abs(offset) | app: ui     | 30  0  15     | 
-| (A2)      | transform.abs(offset) | app: server | 7   6  3      |
+| (A1)      | transform.abs(offset) | app: ui     | `30  0  15`   | 
+| (A2)      | transform.abs(offset) | app: server | `7   6  3 `   |
 
 ##### `transform.nan_keep_last(list)`
 
@@ -284,17 +284,17 @@ Initial `NaN`s are left alone. If these need to be eliminated also, consider usi
 
 Consider the metric `responses`:
 
-| (series†) | metric name | tags        | series values             |
-|:---------:|:-----------:|:-----------:|:-------------------------:|
-| (A1)      | responses   | app: ui     | NaN NaN 3   NaN 7 Nan NaN | 
-| (A2)      | responses   | app: server | 2   3   NaN 5   3 NaN 1   |
+| (series†) | metric name | tags        | series values                     |
+|:---------:|:-----------:|:-----------:|:---------------------------------:|
+| (A1)      | responses   | app: ui     | `NaN  NaN  3    NaN  7  Nan  NaN` | 
+| (A2)      | responses   | app: server | `2    3    NaN  5    3  NaN  1  ` |
 
 Then the query `transform.nan_keep_last(responses)` produces the result:
 
-| (series†) | metric name                        | tags        | series values     |
-|:---------:|:----------------------------------:|:-----------:|:-----------------:|
-| (A1)      | transform.nan_keep_last(responses) | app: ui     | NaN NaN 3 3 7 7 7 | 
-| (A2)      | transform.nan_keep_last(responses) | app: server | 2   3   3 5 3 3 1 |
+| (series†) | metric name                        | tags        | series values       |
+|:---------:|:----------------------------------:|:-----------:|:-------------------:|
+| (A1)      | transform.nan_keep_last(responses) | app: ui     | `NaN NaN 3 3 7 7 7` | 
+| (A2)      | transform.nan_keep_last(responses) | app: server | `2   3   3 5 3 3 1` |
 
 ##### `transform.timeshift(list, offsetDuration)`
 

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -182,7 +182,7 @@ The query `transform.deriative( disk_usage )` results in:
 
 ##### `transform.integral(list)`
 
-This function computes a numerical integral for a given timeseries. Each value will be the sum of the values up to it (including itself), a left Riemann integral.
+This function computes a numerical integral for a given timeseries. Each value will be the sum of the values up to it (including itself).
 This quantity will be scaled, interpreting each value in the series as having units of `events / second`, and producing something with the units of `events`.
 If you do not want this behavior, use `transform.cumulative` instead, which does not have scaling behavior.
 

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -44,7 +44,7 @@ func init() {
 	MustRegister(NewTransform("transform.integral", 0, transform.Integral))
 	MustRegister(NewTransform("transform.rate", 0, transform.Rate))
 	MustRegister(NewTransform("transform.cumulative", 0, transform.Cumulative))
-	MustRegister(NewTransform("transform.default", 1, transform.Default))
+	MustRegister(NewTransform("transform.nan_fill", 1, transform.Default))
 	MustRegister(NewTransform("transform.abs", 0, transform.MapMaker(math.Abs)))
 	MustRegister(NewTransform("transform.log", 0, transform.MapMaker(math.Log10)))
 	MustRegister(NewTransform("transform.nan_keep_last", 0, transform.NaNKeepLast))


### PR DESCRIPTION
Documentation adds examples (with tables) to the documentation for transformation functions.