### PR TITLE
Tag Functions (Drop / Set)

### DIFF
--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/square/metrics/function/aggregate"
 	"github.com/square/metrics/function/filter"
 	"github.com/square/metrics/function/join"
+	"github.com/square/metrics/function/tag"
 	"github.com/square/metrics/function/transform"
 )
 
@@ -64,6 +65,9 @@ func init() {
 	MustRegister(transform.Timeshift)
 	MustRegister(transform.Alias)
 	MustRegister(transform.MovingAverage)
+	// Tags
+	MustRegister(tag.DropFunction)
+	MustRegister(tag.SetFunction)
 }
 
 // StandardRegistry of a functions available in MQE.

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag
+
+import (
+	"github.com/square/metrics/api"
+)
+
+// dropTagSeries returns a copy of the timeseries where the given `dropTag` has been removed from its TagSet.
+func dropTagSeries(series api.Timeseries, dropTag string) api.Timeseries {
+	tagSet := api.NewTagSet()
+	for tag, val := range series.TagSet {
+		tagSet[tag] = val
+	}
+	delete(tagSet, dropTag)
+	series.TagSet = tagSet
+	return series
+}
+
+// DropTag returns a copy of the series list where the given `tag` has been removed from all timeseries.
+func DropTag(list api.SeriesList, tag string) api.SeriesList {
+	series := make([]api.Timeseries, len(list.Series))
+	for i := range series {
+		series[i] = dropTagSeries(list.Series[i], tag)
+	}
+	return api.SeriesList{
+		series,
+		list.Timerange,
+		list.Name,
+	}
+}
+
+// setTagSeries returns a copy of the timeseries where the given `newTag` has been set to `newValue`, or added if it wasn't present.
+func setTagSeries(series api.Timeseries, newTag string, newValue string) api.Timeseries {
+	tagSet := api.NewTagSet()
+	for tag, val := range series.TagSet {
+		tagSet[tag] = val
+	}
+	tagSet[newTag] = newValue
+	series.TagSet = tagSet
+	return series
+}
+
+// SetTag returns a copy of the series list where `tag` has been assigned to `value` for every timeseries in the list.
+func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
+	series := make([]api.Timeseries, len(list.Series))
+	for i := range series {
+		series[i] = setTagSeries(list.Series[i], tag, value)
+	}
+	return api.SeriesList{
+		series,
+		list.Timerange,
+		list.Name,
+	}
+}

--- a/function/tag/tag_test.go
+++ b/function/tag/tag_test.go
@@ -1,0 +1,395 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag
+
+import (
+	"math"
+	"testing"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/assert"
+)
+
+func TestDropSeries(t *testing.T) {
+	a := assert.New(t)
+	testCases := []struct {
+		Series   api.Timeseries
+		Expected map[string]api.Timeseries
+	}{
+		{
+			Series: api.Timeseries{
+				Values: []float64{3, 5, 7, 6},
+				TagSet: api.TagSet{
+					"app": "metrics-indexer",
+					"dc":  "north",
+					"env": "production",
+				},
+			},
+			Expected: map[string]api.Timeseries{
+				"app": {
+					Values: []float64{3, 5, 7, 6},
+					TagSet: api.TagSet{
+						"dc":  "north",
+						"env": "production",
+					},
+				},
+				"dc": {
+					Values: []float64{3, 5, 7, 6},
+					TagSet: api.TagSet{
+						"app": "metrics-indexer",
+						"env": "production",
+					},
+				},
+				"env": {
+					Values: []float64{3, 5, 7, 6},
+					TagSet: api.TagSet{
+						"app": "metrics-indexer",
+						"dc":  "north",
+					},
+				},
+				"fake": {
+					Values: []float64{3, 5, 7, 6},
+					TagSet: api.TagSet{
+						"app": "metrics-indexer",
+						"dc":  "north",
+						"env": "production",
+					},
+				},
+			},
+		},
+		{
+			Series: api.Timeseries{
+				Values: []float64{1, 2, 3},
+				TagSet: api.TagSet{
+					"host": "q33",
+					"dc":   "south",
+				},
+			},
+			Expected: map[string]api.Timeseries{
+				"host": {
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{"dc": "south"},
+				},
+				"dc": {
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{"host": "q33"},
+				},
+				"env": {
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{"host": "q33", "dc": "south"},
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		for dropTag, expected := range test.Expected {
+			result := dropTagSeries(test.Series, dropTag)
+			a.EqFloatArray(result.Values, expected.Values, 1e-100)
+			if !result.TagSet.Equals(expected.TagSet) {
+				t.Errorf("failed to drop tag correctly: expected tagset %+v when dropping %s, but got %+v", expected.TagSet, dropTag, result.TagSet)
+			}
+		}
+	}
+}
+
+func TestDrop(t *testing.T) {
+	timerange, err := api.NewTimerange(1300, 1600, 100)
+	if err != nil {
+		t.Fatal("invalid timerange used in testcase")
+	}
+	list := api.SeriesList{
+		Timerange: timerange,
+		Name:      "ExampleTestSeries!",
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4},
+				TagSet: api.TagSet{
+					"name": "A",
+					"host": "q12",
+					"dc":   "east",
+				},
+			},
+			{
+				Values: []float64{6, 7, 3, 1},
+				TagSet: api.TagSet{
+					"name": "B",
+					"host": "r2",
+					"dc":   "north",
+				},
+			},
+			{
+				Values: []float64{2, 4, 6, 8},
+				TagSet: api.TagSet{
+					"name": "C",
+					"host": "q12",
+					"dc":   "south",
+				},
+			},
+			{
+				Values: []float64{5, math.NaN(), 2, math.NaN()},
+				TagSet: api.TagSet{
+					"name": "D",
+					"host": "q12",
+					"dc":   "south",
+				},
+			},
+		},
+	}
+	result := DropTag(list, "host")
+	expect := api.SeriesList{
+		Timerange: timerange,
+		Name:      "ExampleTestSeries!",
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4},
+				TagSet: api.TagSet{
+					"name": "A",
+					"dc":   "east",
+				},
+			},
+			{
+				Values: []float64{6, 7, 3, 1},
+				TagSet: api.TagSet{
+					"name": "B",
+					"dc":   "north",
+				},
+			},
+			{
+				Values: []float64{2, 4, 6, 8},
+				TagSet: api.TagSet{
+					"name": "C",
+					"dc":   "south",
+				},
+			},
+			{
+				Values: []float64{5, math.NaN(), 2, math.NaN()},
+				TagSet: api.TagSet{
+					"name": "D",
+					"dc":   "south",
+				},
+			},
+		},
+	}
+	// Verify that result == expect
+	a := assert.New(t)
+	a.EqString(result.Name, expect.Name)
+	a.Eq(result.Timerange, expect.Timerange)
+	a.EqInt(len(result.Series), len(expect.Series))
+	for i := range result.Series {
+		// Verify that the two are equal
+		seriesResult := result.Series[i]
+		seriesExpect := expect.Series[i]
+		a.EqFloatArray(seriesResult.Values, seriesExpect.Values, 1e-7)
+		if !seriesResult.TagSet.Equals(seriesExpect.TagSet) {
+			t.Errorf("Expected series %+v, but got %+v", seriesExpect, seriesResult)
+		}
+	}
+}
+
+func TestSetSeries(t *testing.T) {
+	a := assert.New(t)
+	newValues := []string{"new", "north", "production"}
+	for _, newValue := range newValues {
+		testCases := []struct {
+			Series   api.Timeseries
+			Expected map[string]api.Timeseries
+		}{
+			{
+				Series: api.Timeseries{
+					Values: []float64{3, 5, 7, 6},
+					TagSet: api.TagSet{
+						"app": "metrics-indexer",
+						"dc":  "north",
+						"env": "production",
+					},
+				},
+				Expected: map[string]api.Timeseries{
+					"app": {
+						Values: []float64{3, 5, 7, 6},
+						TagSet: api.TagSet{
+							"app": newValue,
+							"dc":  "north",
+							"env": "production",
+						},
+					},
+					"dc": {
+						Values: []float64{3, 5, 7, 6},
+						TagSet: api.TagSet{
+							"app": "metrics-indexer",
+							"dc":  newValue,
+							"env": "production",
+						},
+					},
+					"env": {
+						Values: []float64{3, 5, 7, 6},
+						TagSet: api.TagSet{
+							"app": "metrics-indexer",
+							"dc":  "north",
+							"env": newValue,
+						},
+					},
+					"fake": {
+						Values: []float64{3, 5, 7, 6},
+						TagSet: api.TagSet{
+							"app":  "metrics-indexer",
+							"dc":   "north",
+							"env":  "production",
+							"fake": newValue,
+						},
+					},
+				},
+			},
+			{
+				Series: api.Timeseries{
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{
+						"host": "q33",
+						"dc":   "south",
+					},
+				},
+				Expected: map[string]api.Timeseries{
+					"host": {
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{
+							"host": newValue,
+							"dc":   "south",
+						},
+					},
+					"dc": {
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{
+							"host": "q33",
+							"dc":   newValue,
+						},
+					},
+					"env": {
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{
+							"host": "q33",
+							"dc":   "south",
+							"env":  newValue,
+						},
+					},
+				},
+			},
+		}
+		for _, test := range testCases {
+			for newTag, expected := range test.Expected {
+				result := setTagSeries(test.Series, newTag, newValue)
+				a.EqFloatArray(result.Values, expected.Values, 1e-100)
+				if !result.TagSet.Equals(expected.TagSet) {
+					t.Errorf("failed to drop tag correctly: expected tagset %+v when set %s to %s, but got %+v", expected.TagSet, newTag, newValue, result.TagSet)
+				}
+			}
+		}
+	}
+}
+
+func TestSet(t *testing.T) {
+	timerange, err := api.NewTimerange(1300, 1600, 100)
+	if err != nil {
+		t.Fatal("invalid timerange used in testcase")
+	}
+	newValue := "east"
+	list := api.SeriesList{
+		Timerange: timerange,
+		Name:      "ExampleTestSeries!",
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4},
+				TagSet: api.TagSet{
+					"name": "A",
+					"host": "q12",
+				},
+			},
+			{
+				Values: []float64{6, 7, 3, 1},
+				TagSet: api.TagSet{
+					"name": "B",
+					"host": "r2",
+				},
+			},
+			{
+				Values: []float64{2, 4, 6, 8},
+				TagSet: api.TagSet{
+					"name": "C",
+					"host": "q12",
+					"dc":   "south",
+				},
+			},
+			{
+				Values: []float64{5, math.NaN(), 2, math.NaN()},
+				TagSet: api.TagSet{
+					"name": "D",
+					"host": "q12",
+					"dc":   "south",
+				},
+			},
+		},
+	}
+	result := SetTag(list, "dc", newValue)
+	expect := api.SeriesList{
+		Timerange: timerange,
+		Name:      "ExampleTestSeries!",
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4},
+				TagSet: api.TagSet{
+					"name": "A",
+					"host": "q12",
+					"dc":   "east",
+				},
+			},
+			{
+				Values: []float64{6, 7, 3, 1},
+				TagSet: api.TagSet{
+					"name": "B",
+					"host": "r2",
+					"dc":   "east",
+				},
+			},
+			{
+				Values: []float64{2, 4, 6, 8},
+				TagSet: api.TagSet{
+					"name": "C",
+					"host": "q12",
+					"dc":   "east",
+				},
+			},
+			{
+				Values: []float64{5, math.NaN(), 2, math.NaN()},
+				TagSet: api.TagSet{
+					"name": "D",
+					"host": "q12",
+					"dc":   "east",
+				},
+			},
+		},
+	}
+	// Verify that result == expect
+	a := assert.New(t)
+	a.EqString(result.Name, expect.Name)
+	a.Eq(result.Timerange, expect.Timerange)
+	a.EqInt(len(result.Series), len(expect.Series))
+	for i := range result.Series {
+		// Verify that the two are equal
+		seriesResult := result.Series[i]
+		seriesExpect := expect.Series[i]
+		a.EqFloatArray(seriesResult.Values, seriesExpect.Values, 1e-7)
+		if !seriesResult.TagSet.Equals(seriesExpect.TagSet) {
+			t.Errorf("Expected series %+v, but got %+v", seriesExpect, seriesResult)
+		}
+	}
+}

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -360,3 +360,76 @@ func TestNaming(t *testing.T) {
 	}
 
 }
+
+func TestTagDrop(t *testing.T) {
+	fakeApi := mocks.NewFakeApi()
+	fakeBackend := backend.NewSequentialMultiBackend(fakeApiBackend{})
+	tests := []struct {
+		query    string
+		expected api.SeriesList
+	}{
+		{
+			query: "select series_2 | tag.drop('dc') from 0  to 120",
+			expected: api.SeriesList{
+				Series: []api.Timeseries{
+					{
+						Values: []float64{1, 2, 3, 4, 5},
+						TagSet: api.TagSet{},
+					},
+					{
+						Values: []float64{3, 0, 3, 6, 2},
+						TagSet: api.TagSet{},
+					},
+				},
+			},
+		},
+		{
+			query: "select series_2 | tag.drop('none') from 0  to 120",
+			expected: api.SeriesList{
+				Series: []api.Timeseries{
+					{
+						Values: []float64{1, 2, 3, 4, 5},
+						TagSet: api.TagSet{"dc": "west"},
+					},
+					{
+						Values: []float64{3, 0, 3, 6, 2},
+						TagSet: api.TagSet{"dc": "east"},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		command, err := Parse(test.query)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing")
+			return
+		}
+		if command.Name() != "select" {
+			t.Errorf("Expected select command but got %s", command.Name())
+			continue
+		}
+		rawResult, err := command.Execute(ExecutionContext{Backend: fakeBackend, API: fakeApi, FetchLimit: 1000, Timeout: 0})
+		if err != nil {
+			t.Errorf("Unexpected error while execution: %s", err.Error())
+			continue
+		}
+		seriesListList, ok := rawResult.([]function.Value)
+		if !ok || len(seriesListList) != 1 {
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			continue
+		}
+		list, err := seriesListList[0].ToSeriesList(api.Timerange{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		a := assert.New(t)
+		expectedSeries := test.expected.Series
+		for i, series := range list.Series {
+			a.EqFloatArray(series.Values, expectedSeries[i].Values, 1e-100)
+			if !series.TagSet.Equals(expectedSeries[i].TagSet) {
+				t.Errorf("expected tagset %+v but got %+v for series %d of query %s", expectedSeries[i].TagSet, series.TagSet, i, test.query)
+			}
+		}
+	}
+}

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -361,7 +361,7 @@ func TestNaming(t *testing.T) {
 
 }
 
-func TestTagDrop(t *testing.T) {
+func TestTag(t *testing.T) {
 	fakeApi := mocks.NewFakeApi()
 	fakeBackend := backend.NewSequentialMultiBackend(fakeApiBackend{})
 	tests := []struct {
@@ -394,6 +394,36 @@ func TestTagDrop(t *testing.T) {
 					{
 						Values: []float64{3, 0, 3, 6, 2},
 						TagSet: api.TagSet{"dc": "east"},
+					},
+				},
+			},
+		},
+		{
+			query: "select series_2 | tag.set('dc', 'north') from 0  to 120",
+			expected: api.SeriesList{
+				Series: []api.Timeseries{
+					{
+						Values: []float64{1, 2, 3, 4, 5},
+						TagSet: api.TagSet{"dc": "north"},
+					},
+					{
+						Values: []float64{3, 0, 3, 6, 2},
+						TagSet: api.TagSet{"dc": "north"},
+					},
+				},
+			},
+		},
+		{
+			query: "select series_2 | tag.set('none', 'north') from 0  to 120",
+			expected: api.SeriesList{
+				Series: []api.Timeseries{
+					{
+						Values: []float64{1, 2, 3, 4, 5},
+						TagSet: api.TagSet{"dc": "west", "none": "north"},
+					},
+					{
+						Values: []float64{3, 0, 3, 6, 2},
+						TagSet: api.TagSet{"dc": "east", "none": "north"},
 					},
 				},
 			},


### PR DESCRIPTION
Defines two new functions:

`tag.drop(serieslist, tag)` which will remove the tag from all series.

`tag.set(serieslist, tag, value)` which sets the tag for all series.