### PR TITLE
Rework errors and durations

### DIFF
--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -76,7 +76,7 @@ var MovingAverage = function.MetricFunction{
 
 		newContext := context
 		timerange := context.Timerange
-		newContext.Timerange, err = api.NewTimerange(timerange.Start()-int64(limit-1)*timerange.Resolution(), timerange.End(), timerange.Resolution())
+		newContext.Timerange, err = api.NewSnappedTimerange(timerange.Start()-int64(limit-1)*timerange.Resolution(), timerange.End(), timerange.Resolution())
 		if err != nil {
 			return nil, err
 		}

--- a/function/value.go
+++ b/function/value.go
@@ -43,6 +43,10 @@ func (e conversionError) Error() string {
 	return fmt.Sprintf("cannot convert %+v (type %s) to type %s", e.value, e.from, e.to)
 }
 
+func (e conversionError) TokenName() string {
+	return fmt.Sprintf("%+v (type %s)", e.value, e.from)
+}
+
 // A seriesListValue is a value which holds a SeriesList
 type SeriesListValue api.SeriesList
 

--- a/function/value.go
+++ b/function/value.go
@@ -34,13 +34,13 @@ type Value interface {
 }
 
 type conversionError struct {
-	from  string
-	to    string
-	value interface{}
+	from  string // the original data type
+	to    string // the type that attempted to convert to
+	value string // a short string representation of the value
 }
 
 func (e conversionError) Error() string {
-	return fmt.Sprintf("cannot convert %+v (type %s) to type %s", e.value, e.from, e.to)
+	return fmt.Sprintf("cannot convert %s (type %s) to type %s", e.value, e.from, e.to)
 }
 
 func (e conversionError) TokenName() string {
@@ -110,7 +110,7 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 }
 
 func (value ScalarValue) ToString() (string, error) {
-	return "", conversionError{"scalar", "string", value}
+	return "", conversionError{"scalar", "string", fmt.Sprintf("%f", value)}
 }
 
 func (value ScalarValue) ToScalar() (float64, error) {
@@ -118,7 +118,7 @@ func (value ScalarValue) ToScalar() (float64, error) {
 }
 
 func (value ScalarValue) ToDuration() (time.Duration, error) {
-	return 0, conversionError{"scalar", "duration", value}
+	return 0, conversionError{"scalar", "duration", fmt.Sprintf("%f", value)}
 }
 
 func (value ScalarValue) GetName() string {
@@ -135,15 +135,15 @@ func NewDurationValue(name string, duration time.Duration) DurationValue {
 }
 
 func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, conversionError{"duration", "SeriesList", fmt.Sprintf("%dms", value.duration)}
+	return api.SeriesList{}, conversionError{"duration", "SeriesList", value.name}
 }
 
 func (value DurationValue) ToString() (string, error) {
-	return "", conversionError{"duration", "string", fmt.Sprintf("%dms", value.name)}
+	return "", conversionError{"duration", "string", value.name}
 }
 
 func (value DurationValue) ToScalar() (float64, error) {
-	return 0, conversionError{"duration", "scalar", fmt.Sprintf("%dms", value.name)}
+	return 0, conversionError{"duration", "scalar", value.name}
 }
 
 func (value DurationValue) ToDuration() (time.Duration, error) {

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -122,8 +122,8 @@ func TestCommand_Select(t *testing.T) {
 		expectError bool
 		expected    api.SeriesList
 	}{
-		{"select does_not_exist from 0 to 120 resolution '30ms'", true, api.SeriesList{}},
-		{"select series_1 from 0 to 120 resolution '30ms'", false, api.SeriesList{
+		{"select does_not_exist from 0 to 120 resolution 30ms", true, api.SeriesList{}},
+		{"select series_1 from 0 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{1, 2, 3, 4, 5},
 				api.ParseTagSet("dc=west"),
@@ -131,7 +131,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "series_1",
 		}},
-		{"select series_timeout from 0 to 120 resolution '30ms'", true, api.SeriesList{}},
+		{"select series_timeout from 0 to 120 resolution 30ms", true, api.SeriesList{}},
 		{"select series_1 + 1 from 0 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4, 5, 6},
@@ -140,7 +140,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "",
 		}},
-		{"select series_1 * 2 from 0 to 120 resolution '30ms'", false, api.SeriesList{
+		{"select series_1 * 2 from 0 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 4, 6, 8, 10},
 				api.ParseTagSet("dc=west"),
@@ -164,7 +164,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: testTimerange,
 			Name:      "series_2",
 		}},
-		{"select series_1 from 0 to 60 resolution '30ms'", false, api.SeriesList{
+		{"select series_1 from 0 to 60 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{1, 2, 3},
 				api.ParseTagSet("dc=west"),
@@ -172,7 +172,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select transform.timeshift(series_1,'31ms') from 0 to 60 resolution 30ms", false, api.SeriesList{
+		{"select transform.timeshift(series_1,31ms) from 0 to 60 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -180,7 +180,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select transform.timeshift(series_1,'62ms') from 0 to 60 resolution '30ms'", false, api.SeriesList{
+		{"select transform.timeshift(series_1,62ms) from 0 to 60 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{3, 4, 5},
 				api.ParseTagSet("dc=west"),
@@ -188,7 +188,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select transform.timeshift(series_1,'29ms') from 0 to 60 resolution '30ms'", false, api.SeriesList{
+		{"select transform.timeshift(series_1,29ms) from 0 to 60 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -196,7 +196,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}},
-		{"select transform.timeshift(series_1,'-31ms') from 60 to 120 resolution '30ms'", false, api.SeriesList{
+		{"select transform.timeshift(series_1,-31ms) from 60 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -204,7 +204,7 @@ func TestCommand_Select(t *testing.T) {
 			Timerange: lateTimerange,
 			Name:      "series_1",
 		}},
-		{"select transform.timeshift(series_1,'-29ms') from 60 to 120 resolution '30ms'", false, api.SeriesList{
+		{"select transform.timeshift(series_1,-29ms) from 60 to 120 resolution 30ms", false, api.SeriesList{
 			Series: []api.Timeseries{{
 				[]float64{2, 3, 4},
 				api.ParseTagSet("dc=west"),
@@ -444,7 +444,7 @@ func TestCommand_Select(t *testing.T) {
 	}
 
 	// Test that the limit is correct
-	command, err := Parse("select series_1, series_2 from 0 to 120 resolution '30ms'")
+	command, err := Parse("select series_1, series_2 from 0 to 120 resolution 30ms")
 	if err != nil {
 		t.Fatalf("Unexpected error while parsing")
 		return
@@ -461,7 +461,7 @@ func TestCommand_Select(t *testing.T) {
 		t.Fatalf("expected failure with limit = 2")
 		return
 	}
-	command, err = Parse("select series2 from 0 to 120 resolution '30ms'")
+	command, err = Parse("select series2 from 0 to 120 resolution 30ms")
 	if err != nil {
 		t.Fatalf("Unexpected error while parsing")
 		return
@@ -520,7 +520,7 @@ func TestNaming(t *testing.T) {
 			expected: "hello",
 		},
 		{
-			query:    "select transform.moving_average(series_2, '2h') from 0 to 0",
+			query:    "select transform.moving_average(series_2, 2h) from 0 to 0",
 			expected: "transform.moving_average(series_2, 2h)",
 		},
 		{

--- a/query/expression.go
+++ b/query/expression.go
@@ -26,7 +26,7 @@ import (
 // ===============
 
 func (expr durationExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return function.DurationValue(expr.duration), nil
+	return function.NewDurationValue(expr.name, expr.duration), nil
 }
 
 func (expr scalarExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {

--- a/query/node.go
+++ b/query/node.go
@@ -69,6 +69,7 @@ type regexMatcher struct {
 
 // durationExpression represents a duration (in ms).
 type durationExpression struct {
+	name     string
 	duration time.Duration // milliseconds
 }
 

--- a/query/parser.go
+++ b/query/parser.go
@@ -670,7 +670,7 @@ func (p *Parser) addAndPredicate() {
 
 func (p *Parser) addDurationNode(value string) {
 	duration, err := function.StringToDuration(value)
-	p.pushNode(&durationExpression{duration})
+	p.pushNode(&durationExpression{value, duration})
 	if err != nil {
 		p.flagSyntaxError(SyntaxError{
 			token:   value,

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -19,6 +19,7 @@ package query
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/api/backend"
@@ -55,7 +56,7 @@ func TestMovingAverage(t *testing.T) {
 		groupBy:      []string{},
 		arguments: []function.Expression{
 			&metricFetchExpression{"series", api.TruePredicate},
-			stringExpression{"300ms"},
+			durationExpression{"300ms", 300 * time.Millisecond},
 		},
 	}
 


### PR DESCRIPTION
Errors are made somewhat more structured.

* Instances of `errors.New()` are replaced by typed implementing the `ExecutionError` interface (which also has a `.TokenName()`).
* String => Duration implicit casts are no longer allowed. This causes errors to have closer to parsing, rather than execution, and makes the language more consistent. Strings are now only used to refer to tag values (or tags keys with `tag.drop`/`tag.set`) and absolute timestamps.