### PR TITLE
better syntax error

### DIFF
--- a/query/parser.go
+++ b/query/parser.go
@@ -786,7 +786,7 @@ func makePrettyLine(parser *Parser, token token32, translations textPositionMap)
 		symbolBegin = 0
 	}
 	if translations[begin].line == translations[end].line {
-		// error occurs within a single line - print the entire line.
+		// single-line error - print the entire line and draw carets under the token.
 		length := translations[end].symbol - translations[begin].symbol
 		if length <= 0 {
 			length = 1
@@ -794,7 +794,7 @@ func makePrettyLine(parser *Parser, token token32, translations textPositionMap)
 		underline := strings.Repeat(" ", symbolBegin) + strings.Repeat("^", length)
 		return line, underline
 	} else {
-		// error occurs within a single line - print the entire line.
+		// multi-line error - print the firsst line and draw carets under the token until the line finishes.
 		length := lineEnd - lineStart - translations[begin].symbol - 1
 		if length <= 0 {
 			length = 1

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -146,11 +146,13 @@ var selects = []string{
 
 // these queries should fail with a syntax error.
 var syntaxErrorQuery = []string{
-	"select ( from 0 to 0",
-	"select ) from 0 to 0",
 	"describe ( from 0 to 0",
 	"describe in from 0 to 0",
-	"describe invalid_regex where key matches 'ab[' from 0 to 0",
+	"describe invalid_regex where key matches 'ab['",
+	"describe invalid_property \nwhere key matches 'ab' from 0 to 0",
+	"select 'a\nac\nabc",
+	"select ( from 0 to 0",
+	"select ) from 0 to 0",
 	"select x invalid_property 0 from 0 to 0",
 	"select x sampleby 0 from 0 to 0",
 	"select x sample 0 from 0 to 0",
@@ -194,6 +196,7 @@ func TestParse_syntaxError(t *testing.T) {
 			t.Errorf("[%s] should have failed to parse", row)
 		} else if _, ok := err.(SyntaxErrors); !ok {
 			t.Logf("[%s] Expected SyntaxErrors, got: %s", row, err.Error())
+			err.Error() // test that it does not panic.
 		}
 	}
 }


### PR DESCRIPTION
* Removed ANSI formatting.
* Instead of just printing out the substring where the error has occurred, the entire line is printed (with cursors under it).
* remove duplicate errors & unknown errors (reduce the noise level a bit).

a sample error looks like this:
```
	query_test.go:201: parse error near [ID_START] (line 2 symbol 9 - line 2 symbol 10):
		where key matches 'ab' from 0 to 0
		        ^
		parse error near [ID_SEGMENT] (line 2 symbol 7 - line 2 symbol 10):
		where key matches 'ab' from 0 to 0
		      ^^^
		parse error near [CHAR] (line 2 symbol 21 - line 2 symbol 22):
		where key matches 'ab' from 0 to 0
		                    ^
		parse error near [QUOTE_SINGLE] (line 2 symbol 22 - line 2 symbol 23):
		where key matches 'ab' from 0 to 0
		                     ^
		parse error near [Action44] (line 2 symbol 23 - line 2 symbol 23):
		where key matches 'ab' from 0 to 0
		                      ^
		parse error near [tagMatcher] (line 2 symbol 7 - line 2 symbol 23):
		where key matches 'ab' from 0 to 0
		      ^^^^^^^^^^^^^^^^
		parse error near [predicateClause] (line 1 symbol 26 - line 2 symbol 23):
		describe invalid_property 
		                         ^
		parse error near [SPACE] (line 2 symbol 23 - line 2 symbol 24):
		where key matches 'ab' from 0 to 0
		                      ^
```