### PR TITLE
Select coerces results to type SeriesList

### DIFF
--- a/query/command.go
+++ b/query/command.go
@@ -157,7 +157,18 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 			return nil, err
 		}
 	} else {
-		return evaluateExpressions(evaluationContext, cmd.expressions)
+		values, err := evaluateExpressions(evaluationContext, cmd.expressions)
+		if err != nil {
+			return nil, err
+		}
+		lists := make([]api.SeriesList, len(values))
+		for i := range values {
+			lists[i], err = values[i].ToSeriesList(evaluationContext.Timerange)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return lists, nil
 	}
 }
 

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -543,12 +543,12 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]function.Value)
+		seriesListList, ok := rawResult.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
 			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
 			continue
 		}
-		actual := api.SeriesList(seriesListList[0].(function.SeriesListValue)).Name
+		actual := seriesListList[0].Name
 		if actual != test.expected {
 			t.Errorf("Expected `%s` but got `%s` for query `%s`", test.expected, actual, test.query)
 			continue
@@ -640,12 +640,12 @@ func TestTag(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]function.Value)
+		seriesListList, ok := rawResult.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
 			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
 			continue
 		}
-		list, err := seriesListList[0].ToSeriesList(api.Timerange{})
+		list := seriesListList[0]
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This allows you to graph (for example):

`select cpu, 100 from -10m to now` to get a straight line at 100. Certain queries, like `select 'string' from -10m to now` will now error (failing to convert string => series list) instead of silently succeeding with a useless result.

