### PR TITLE
Query history shown in right column

### DIFF
--- a/main/static/index.html
+++ b/main/static/index.html
@@ -18,6 +18,11 @@
         <label class="col-sm-2 control-label">Query</label>
         <div class="col-sm-10">
           <textarea id="query-input" ng-model="inputModel.query" class="form-control queryinput"></textarea>
+          <div class="history-box">
+            <div ng-repeat="oldQuery in queryHistory" class="history-row">
+             {{ oldQuery }} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras rhoncus sodales iaculis. Vivamus volutpat leo eget quam tempus venenatis. Vivamus non auctor felis.
+            </div>
+          </div>
         </div>
       </div>
       <div class="form-group">

--- a/main/static/index.html
+++ b/main/static/index.html
@@ -19,8 +19,8 @@
         <div class="col-sm-10">
           <textarea id="query-input" ng-model="inputModel.query" class="form-control queryinput"></textarea>
           <div class="history-box">
-            <div ng-repeat="oldQuery in queryHistory" class="history-row">
-             {{ oldQuery }} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras rhoncus sodales iaculis. Vivamus volutpat leo eget quam tempus venenatis. Vivamus non auctor felis.
+            <div ng-repeat="query in queryHistory track by $index" class="history-row" ng-click = "historySelect(query)">
+             {{ query }}
             </div>
           </div>
         </div>

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -300,6 +300,8 @@ module.controller("mainCtrl", function(
   $profilingEnabled
   ) {
 
+  $scope.queryHistory = [];
+
   // Store the $inputModel so that the view can change it through inputs.
   $scope.inputModel = $inputModel;
 

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -331,10 +331,11 @@ module.controller("mainCtrl", function(
     $inputModel.renderType = queries["renderType"] || "line";
     $inputModel.profile = queries["profile"] === "true";
     // Add the query to the history, if it hasn't been seen before and it's non-empty
-    if ($inputModel.query.trim() !== "" && $scope.queryHistory.indexOf($inputModel.query.trim()) === -1) {
-      $scope.queryHistory.push($inputModel.query.trim());
+    var trimmedQuery = $inputModel.query.trim();
+    if (trimmedQuery !== "" && $scope.queryHistory.indexOf(trimmedQuery) === -1) {
+      $scope.queryHistory.push(trimmedQuery);
     }
-    if ($inputModel.query) {
+    if (trimmedQuery) {
       $launchRequest({
         profile: $inputModel.profile,
         query:   $inputModel.query

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -206,7 +206,7 @@ module.factory("$receiveSelect", function(
     var options = {
       legend:    {position: "bottom"},
       title:     $location.search()["title"],
-      chartArea: {left: "5%", width:"90%", top: "5%", height: "90%"}
+      chartArea: {left: "5%", width:"90%", top: "5%", height: "85%"}
     }
     if ($inputModel.renderType === "line") {
       $mainChart.chart = new google.visualization.LineChart($mainChart.dom);
@@ -277,8 +277,8 @@ module.factory("$receive", function($mainChart, $timelineChart, $receiveSelect, 
   return function(object) {
     clearChart($mainChart);
     clearChart($timelineChart);
-    $receiveSelect(object, $mainChart);
-    $receiveProfile(object, $timelineChart);
+    $receiveSelect(object);
+    $receiveProfile(object);
   };
 });
 

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -330,6 +330,10 @@ module.controller("mainCtrl", function(
     $inputModel.query = queries["query"] || "";
     $inputModel.renderType = queries["renderType"] || "line";
     $inputModel.profile = queries["profile"] === "true";
+    // Add the query to the history, if it hasn't been seen before and it's non-empty
+    if ($inputModel.query.trim() !== "" && $scope.queryHistory.indexOf($inputModel.query.trim()) === -1) {
+      $scope.queryHistory.push($inputModel.query.trim());
+    }
     if ($inputModel.query) {
       $launchRequest({
         profile: $inputModel.profile,
@@ -339,6 +343,10 @@ module.controller("mainCtrl", function(
       });
     }
   });
+
+  $scope.historySelect = function(query) {
+    $inputModel.query = query;
+  }
 
   // true if the output should be tabular.
   $scope.isTabular = function() {

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -33,7 +33,7 @@ textarea.queryinput {
 #chart-div {
   background:#EEE;
   width:100%;
-  height:300px;
+  height:500px;
 }
 
 .autocom-tooltip-box {

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -53,32 +53,48 @@ textarea.queryinput {
   height:500px;
 }
 
+/* Query History CSS */
 .history-box {
   position:absolute;
   left: 100%;
   top: 0;
   width: 100px;
-  height: 500px;
+  height: 250px;
+  z-index: 100;
+}
+
+.history-row:nth-child(even) {
+  background: #F0F0F0;
+}
+.history-row:nth-child(odd) {
+  background: #F5F5F5;
 }
 
 .history-row {
-  background: #EEE;
-  height: 1.5em;
+  border-top: 1px solid #DDD;
+  border-left: 1px solid #DDD;
+  border-right: 1px solid #DDD;
+  font-family: Consolas, monospace;
+  padding: 3px;
   /* move as far right as possible, but expand to the left */
   position:relative;
   float:right;
   right: 0;
+  -webkit-transition:max-width 2s;
   width: 100%;
+  min-width: 100%;
   /* hide text that goes off the edge */
   white-space: nowrap;
   overflow: hidden;
+
+
 }
 
 .history-row:hover {
   /* highlight color */
-  background: #DDD;
+  background: #CDF;
   /* change to cursor pointer */
   cursor: pointer;
   /* expand width */
-  width: 800px;
+  width: auto;
 }

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -86,8 +86,6 @@ textarea.queryinput {
   /* hide text that goes off the edge */
   white-space: nowrap;
   overflow: hidden;
-
-
 }
 
 .history-row:hover {

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -52,3 +52,33 @@ textarea.queryinput {
   width:100%;
   height:500px;
 }
+
+.history-box {
+  position:absolute;
+  left: 100%;
+  top: 0;
+  width: 100px;
+  height: 500px;
+}
+
+.history-row {
+  background: #EEE;
+  height: 1.5em;
+  /* move as far right as possible, but expand to the left */
+  position:relative;
+  float:right;
+  right: 0;
+  width: 100%;
+  /* hide text that goes off the edge */
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.history-row:hover {
+  /* highlight color */
+  background: #DDD;
+  /* change to cursor pointer */
+  cursor: pointer;
+  /* expand width */
+  width: 800px;
+}


### PR DESCRIPTION
This PR adds HTML/JS/CSS for a query history box at the right side of the query window.

The first few characters of every query can be seen - hovering over the box shows the remainder. Clicking on a row fills the input area with that query.

Also, fixed issues with legend appearance + made the chart larger (vertically)

@jeeyoungk @achow 