### PR TITLE
Short, tabular display for 'describe' queries

### DIFF
--- a/main/static/index.html
+++ b/main/static/index.html
@@ -71,9 +71,15 @@
 
     <div>
       <div class="col-xs-12">
-        <table ng-show="isTabular()" class="table table-striped">
+        <table ng-show="isTabular() && queryResult.name != 'describe'" class="table table-striped">
           <tr ng-repeat="row in queryResult.body"><td>{{row}}</td></tr>
         </table>
+        <div ng-show="isTabular() && queryResult.name == 'describe'">
+          <table ng-repeat="(key, list) in queryResult.body" class="table table-striped table-column">
+            <tr><th>{{key}}</th></tr>
+            <tr ng-repeat="value in list"><td>{{value}}</td></tr>
+          </table>
+        </div>
         <div>{{ (queryResult || "").trim() }}</div>
       </div>
     </div>

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -367,10 +367,8 @@ module.controller("mainCtrl", function(
       return "rendered";
     }
   };
-  scope = $scope;
   updateEmbed()
 });
-var scope;
 
 module.controller("embedCtrl", function($location, $scope, $launchedQueries, $chartWaiting, $launchRequest, $inputModel, $profilingEnabled){
   $scope.queryResult = "";

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -367,8 +367,10 @@ module.controller("mainCtrl", function(
       return "rendered";
     }
   };
+  scope = $scope;
   updateEmbed()
 });
+var scope;
 
 module.controller("embedCtrl", function($location, $scope, $launchedQueries, $chartWaiting, $launchRequest, $inputModel, $profilingEnabled){
   $scope.queryResult = "";

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -30,6 +30,23 @@ textarea.queryinput {
   white-space: pre;
 }
 
+.table-column {
+  display: inline-block;
+  margin-right: 10px;
+  float: left;
+  width: auto;
+  min-width: 100px;
+  border-left: 1px solid #DDD;
+  border-right: 1px solid #DDD;
+  border-bottom: 1px solid #DDD;
+  border-radius: 2px;
+}
+
+.table-column tr, .table-column tbody, .table-column td, .table-column th {
+  display:block;
+}
+
+
 #chart-div {
   background:#EEE;
   width:100%;

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -65,20 +65,20 @@ func TestCommand_Describe(t *testing.T) {
 	fakeApi.AddPair(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=staging,host=d")}, emptyGraphiteName)
 
 	for _, test := range []struct {
-		query   string
-		backend api.API
-		length  int // expected length of the result.
+		query    string
+		backend  api.API
+		expected map[string][]string
 	}{
-		{"describe series_0", fakeApi, 4},
-		{"describe`series_0`", fakeApi, 4},
-		{"describe series_0 where dc='west'", fakeApi, 2},
-		{"describe`series_0`where(dc='west')", fakeApi, 2},
-		{"describe series_0 where dc='west' or env = 'production'", fakeApi, 3},
-		{"describe series_0 where`dc`='west'or`env`='production'", fakeApi, 3},
-		{"describe series_0 where dc='west' or env = 'production' and doesnotexist = ''", fakeApi, 2},
-		{"describe series_0 where env = 'production' and doesnotexist = '' or dc = 'west'", fakeApi, 2},
-		{"describe series_0 where (dc='west' or env = 'production') and doesnotexist = ''", fakeApi, 0},
-		{"describe series_0 where(dc='west' or env = 'production')and`doesnotexist` = ''", fakeApi, 0},
+		{"describe series_0", fakeApi, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
+		{"describe`series_0`", fakeApi, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
+		{"describe series_0 where dc='west'", fakeApi, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe`series_0`where(dc='west')", fakeApi, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where dc='west' or env = 'production'", fakeApi, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
+		{"describe series_0 where`dc`='west'or`env`='production'", fakeApi, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
+		{"describe series_0 where dc='west' or env = 'production' and doesnotexist = ''", fakeApi, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where env = 'production' and doesnotexist = '' or dc = 'west'", fakeApi, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where (dc='west' or env = 'production') and doesnotexist = ''", fakeApi, map[string][]string{}},
+		{"describe series_0 where(dc='west' or env = 'production')and`doesnotexist` = ''", fakeApi, map[string][]string{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		command, err := Parse(test.query)
@@ -86,10 +86,10 @@ func TestCommand_Describe(t *testing.T) {
 			a.Errorf("Unexpected error while parsing")
 			continue
 		}
+
 		a.EqString(command.Name(), "describe")
 		rawResult, _ := command.Execute(ExecutionContext{Backend: nil, API: test.backend, FetchLimit: 1000, Timeout: 0})
-		parsedResult := rawResult.([]string)
-		a.EqInt(len(parsedResult), test.length)
+		a.Eq(rawResult, test.expected)
 	}
 }
 


### PR DESCRIPTION
Instead of listing every tagset for a given metric, the server computes a `map[string] []string` that it sends to the client, mapping each `key` to a list of associated `value`s.

The results are displayed in a series of tables (`display: inline-block; float: left`) with a small margin between them.