### PR TITLE
Add configurable limit on resolution slots

### DIFF
--- a/query/command.go
+++ b/query/command.go
@@ -33,6 +33,7 @@ type ExecutionContext struct {
 	Timeout    time.Duration     // optional
 	Profiler   *inspect.Profiler // optional
 	Registry   function.Registry // optional
+	SlotLimit  int               // optional (0 => default 1000)
 }
 
 // Command is the final result of the parsing.
@@ -111,6 +112,21 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 	timerange, err := api.NewSnappedTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
 	if err != nil {
 		return nil, err
+	}
+	slotLimit := context.SlotLimit
+	defaultLimit := 1000
+	if slotLimit == 0 {
+		slotLimit = defaultLimit // the default limit
+	}
+	if timerange.Slots() > slotLimit {
+		var limitMessage string
+		if context.SlotLimit == 0 {
+			limitMessage = "the default limit %d (no limit has been configured)"
+		} else {
+			limitMessage = "the configured limit %d"
+		}
+		limitMessage = fmt.Sprintf(limitMessage, slotLimit)
+		return nil, fmt.Errorf("Requested number of data points (%d) exceeds %s", timerange.Slots(), limitMessage)
 	}
 	hasTimeout := context.Timeout != 0
 	var cancellable api.Cancellable

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -404,6 +404,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}},
+		{"select series_1 from -1000d to now resolution 30s", true, api.SeriesList{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		expected := test.expected


### PR DESCRIPTION
Default: 1000 slots (8.3 hours at 30s resolution).

It can be configured through the `ExecutionContext`.

Note: this is only based on the original query for timeseries.

* Asking for many expressions: `select X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X from -8h to now` will select and return 17280 points
* `transform.moving_average` expands the search range, so `select transform.moving_average(X, 10d) from -1h to now` will select 28000 points of data, but only return the last 120 of these.