### PR TITLE
Natural Sort for Strings

### DIFF
--- a/query/command.go
+++ b/query/command.go
@@ -23,6 +23,7 @@ import (
 	"github.com/square/metrics/function"
 	"github.com/square/metrics/function/registry"
 	"github.com/square/metrics/inspect"
+	"github.com/square/metrics/query/natural_sort"
 )
 
 // ExecutionContext is the context supplied when invoking a command.
@@ -77,7 +78,7 @@ func (cmd *DescribeCommand) Execute(context ExecutionContext) (interface{}, erro
 			output = append(output, tag.Serialize())
 		}
 	}
-	sort.Strings(output)
+	natural_sort.Sort(output)
 	return output, nil
 }
 func (cmd *DescribeCommand) Name() string {

--- a/query/natural_sort/natural.go
+++ b/query/natural_sort/natural.go
@@ -51,9 +51,14 @@ func Less(strA string, strB string) bool {
 			continue
 		}
 		if runeA != runeB {
+			if unicode.ToLower(runeA) == unicode.ToLower(runeB) {
+				return unicode.IsLower(runeB)
+			}
 			// Compare their lowercase versions (so that A < a < B < b; instead of ASCII A < B < a < b)
 			return unicode.ToLower(runeA) < unicode.ToLower(runeB)
 		}
+		iA++
+		iB++
 	}
 	return len(runesA) < len(runesB)
 }

--- a/query/natural_sort/natural.go
+++ b/query/natural_sort/natural.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natural_sort
+
+import (
+	"sort"
+	"unicode"
+)
+
+// naturalStringLess returns true when `a` is less than `b`:
+// "apples" < "Apples" < "cats1" < "cats2" < "cats10" < "cats20" < "cats100" < "dogs"
+func Less(strA string, strB string) bool {
+	runesA, runesB := []rune(strA), []rune(strB)
+	iA, iB := 0, 0
+	for iA < len(runesA) && iB < len(runesB) {
+		runeA, runeB := runesA[iA], runesB[iB]
+		if unicode.IsDigit(runeA) != unicode.IsDigit(runeB) {
+			return unicode.IsDigit(runeA)
+		}
+		if unicode.IsDigit(runeA) {
+			// Then both are digits
+			eA, eB := iA, iB
+			for eA < len(runesA) && unicode.IsDigit(runesA[eA]) {
+				eA++
+			}
+			for eB < len(runesB) && unicode.IsDigit(runesB[eB]) {
+				eB++
+			}
+			digitsA, digitsB := runesA[iA:eA], runesB[iB:eB]
+			// Check if A is shorter (and therefore smaller) than B
+			if len(digitsA) != len(digitsB) {
+				return len(digitsA) < len(digitsB)
+			}
+			// Otherwise, just use regular string comparisons (if they're different)
+			if string(digitsA) != string(digitsB) {
+				return string(digitsA) < string(digitsB)
+			}
+			iA, iB = eA, eB
+			continue
+		}
+		if runeA != runeB {
+			// Compare their lowercase versions (so that A < a < B < b; instead of ASCII A < B < a < b)
+			return unicode.ToLower(runeA) < unicode.ToLower(runeB)
+		}
+	}
+	return len(runesA) < len(runesB)
+}
+
+type naturalStrings []string
+
+func (a naturalStrings) Len() int {
+	return len([]string(a))
+}
+
+func (a naturalStrings) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+func (a naturalStrings) Less(i, j int) bool {
+	return Less(a[i], a[j])
+}
+
+func Sort(array []string) {
+	sort.Sort(naturalStrings(array))
+}

--- a/query/natural_sort/natural_test.go
+++ b/query/natural_sort/natural_test.go
@@ -52,6 +52,7 @@ func TestRandom(t *testing.T) {
 	a.Eq(test, expected)
 	for i := 0; i < 1000; i++ {
 		testShuffle(test)
+		a := a.Contextf("input: %+v", test)
 		Sort(test)
 		a.Eq(test, expected)
 	}

--- a/query/natural_sort/natural_test.go
+++ b/query/natural_sort/natural_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natural_sort
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/square/metrics/assert"
+)
+
+func TestNaturalSort(t *testing.T) {
+	a := assert.New(t)
+	expected := []string{"Apple", "apple", "file2", "file22", "file90", "file99", "file100", "Zoo", "zoo"}
+	tests := [][]string{
+		{"Apple", "apple", "file2", "file90", "file99", "file100", "Zoo", "zoo", "file22"},
+		{"Zoo", "Apple", "apple", "file100", "file2", "file90", "file99", "zoo", "file22"},
+		{"file2", "file90", "apple", "Zoo", "file100", "file22", "file99", "zoo", "Apple"},
+	}
+	Sort([]string{}) // check that no panic occurs
+	for _, test := range tests {
+		Sort(test)
+		a.Eq(test, expected)
+	}
+}
+
+func testShuffle(array []string) {
+	for len(array) != 0 {
+		swapIndex := rand.Intn(len(array))
+		array[0], array[swapIndex] = array[swapIndex], array[0]
+		array = array[1:]
+	}
+}
+
+func TestRandom(t *testing.T) {
+	a := assert.New(t)
+	expected := []string{"Apple", "apple", "file2", "file22", "file90", "file99", "file100", "Zoo", "zoo"}
+	test := []string{"Apple", "apple", "file2", "file22", "file90", "file99", "file100", "Zoo", "zoo"}
+	Sort(test)
+	a.Eq(test, expected)
+	for i := 0; i < 1000; i++ {
+		testShuffle(test)
+		Sort(test)
+		a.Eq(test, expected)
+	}
+}


### PR DESCRIPTION
Defining this is a bit ridiculous. The point is to provide a better sorting experience for users. Lexicographical sorting (with ASCII order) isn't really what a human would expect. For example:

Apple < Zoo < apple < file100 < file2 < file90 < file99 < zoo

This package `natural_sort` defines a function `natural_sort.Sort(array []string)` that sorts its arguments in a natural order:

Apple < apple < file2 < file90 < file99 < file100 < Zoo < zoo

For reference, see:
https://en.wikipedia.org/wiki/Natural_sort_order
http://blog.codinghorror.com/sorting-for-humans-natural-sort-order/