### PR TITLE
Implementing a parallel execute

### DIFF
--- a/query/command.go
+++ b/query/command.go
@@ -169,7 +169,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		results := make(chan interface{})
 		errors := make(chan error)
 		go func() {
-			result, err := evaluateExpressions(evaluationContext, cmd.expressions)
+			result, err := function.EvaluateMany(evaluationContext, cmd.expressions)
 			if err != nil {
 				errors <- err
 			} else {
@@ -186,7 +186,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 			return nil, err
 		}
 	} else {
-		values, err := evaluateExpressions(evaluationContext, cmd.expressions)
+		values, err := function.EvaluateMany(evaluationContext, cmd.expressions)
 		if err != nil {
 			return nil, err
 		}

--- a/query/expression.go
+++ b/query/expression.go
@@ -109,22 +109,3 @@ func applyPredicates(tagSets []api.TagSet, predicate api.Predicate) []api.TagSet
 	}
 	return output
 }
-
-// evaluateExpressions evaluates all provided Expressions in the
-// EvaluationContext. If any evaluations error, evaluateExpressions will
-// propagate that error. The resulting SeriesLists will be in an order
-// corresponding to the provided Expresesions.
-func evaluateExpressions(context function.EvaluationContext, expressions []function.Expression) ([]function.Value, error) {
-	if len(expressions) == 0 {
-		return []function.Value{}, nil
-	}
-	results := make([]function.Value, len(expressions))
-	for i, expr := range expressions {
-		result, err := expr.Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		results[i] = result
-	}
-	return results, nil
-}


### PR DESCRIPTION
There are few cases where we want to evaluate subexpressions in
parallel. This PR abstracts out that logic so that it can be used in
different places, including:

* binary operators.
* top-level command evaluation.