### PR TITLE
fixing parser syntax error panic

### DIFF
--- a/query/parser.go
+++ b/query/parser.go
@@ -771,15 +771,18 @@ func customParseError(parser *Parser) string {
 }
 
 func makePrettyLine(parser *Parser, token token32, translations textPositionMap) (string, string) {
+	N := len(parser.Buffer)
 	begin, end := int(token.begin), int(token.end)
 	lineStart := begin - translations[begin].symbol + 1
 	lineEnd := lineStart
-	for i := lineStart; i < len(parser.Buffer) && parser.Buffer[i] != '\n'; i++ {
+	for i := lineStart; i < N && parser.Buffer[i] != '\n'; i++ {
 		lineEnd = i
 	}
-	if parser.Buffer[lineEnd] != '\n' {
+	if lineEnd < N && parser.Buffer[lineEnd] != '\n' {
 		lineEnd = lineEnd + 1
 	}
+	lineStart = min(N-1, lineStart)
+	lineEnd = min(N-1, lineEnd)
 	line := parser.Buffer[lineStart:lineEnd]
 	symbolBegin := translations[begin].symbol - 1
 	if symbolBegin < 0 {
@@ -802,6 +805,13 @@ func makePrettyLine(parser *Parser, token token32, translations textPositionMap)
 		underline := strings.Repeat(" ", symbolBegin) + strings.Repeat("^", length)
 		return line, underline
 	}
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
 }
 
 // utility type variables

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -153,6 +153,7 @@ var selects = []string{
 // these queries should fail with a syntax error.
 var syntaxErrorQuery = []string{
 	"describe ( from 0 to 0",
+	"describe in",
 	"describe in from 0 to 0",
 	"describe invalid_regex where key matches 'ab['",
 	"describe invalid_property \nwhere key matches 'ab' from 0 to 0",


### PR DESCRIPTION
if a syntax error occurs end-of-line, then it used to cause the parser to panic