### PR TITLE
Remove SeriesListValue for simplicity

### DIFF
--- a/EXPRESSIONS.md
+++ b/EXPRESSIONS.md
@@ -89,16 +89,16 @@ Some examples:
 Expressions and literals in MQE evaluate to one of 5 types of *values*. Value types are checked for correctness when functions are evaluated.
 Only the `SeriesList` type is a legal result in a `select` query.
 
-### `SeriesListValue`
+### `SeriesList`
 
-A `SeriesListValue` is a collection of series; the `SeriesList` as a whole has a `Timerange` (start, end, interval) which applies to every series inside it.
+A `SeriesList` is a collection of series; the `SeriesList` as a whole has a `Timerange` (start, end, interval) which applies to every series inside it.
 Each series individually has a collection of tag (key, value) pairs and a sequence of sampled metric values associated to it.
 
 They cannot be implictly converted into any other type.
 
 ### `NumberValue`
 
-`NumberValue`s come from numeric literals. They are implictly converted to `SeriesListValue` containing a single, tagless series having constant value whenever a `SeriesList` is expected.
+`NumberValue`s come from numeric literals. They are implictly converted to `SeriesList` containing a single, tagless series having constant value whenever a `SeriesList` is expected.
 
 They cannot be implictly converted into any type other than `SeriesList`.
 

--- a/api/types.go
+++ b/api/types.go
@@ -315,6 +315,8 @@ func (sm SampleMethod) String() string {
 }
 
 // SeriesList is a list of time series sharing the same time range.
+// this struct must satisfy the `function.Value` interface. However, a type assertion
+// cannot be held here due to a circular import.
 type SeriesList struct {
 	Series    []Timeseries `json:"series"`
 	Timerange Timerange    `json:"timerange"`

--- a/api/types.go
+++ b/api/types.go
@@ -331,3 +331,37 @@ func (list SeriesList) isValid() bool {
 	}
 	return true // validation is now successful.
 }
+
+func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
+	return list, nil
+}
+
+func (list SeriesList) ToString() (string, error) {
+	return "", ConversionError{"SeriesList", "string", fmt.Sprintf("serieslist[%s]", list.Name)}
+}
+
+func (list SeriesList) ToScalar() (float64, error) {
+	return 0, ConversionError{"SeriesList", "scalar", fmt.Sprintf("serieslist[%s]", list.Name)}
+}
+
+func (list SeriesList) ToDuration() (time.Duration, error) {
+	return 0, ConversionError{"SeriesList", "duration", fmt.Sprintf("serieslist[%s]", list.Name)}
+}
+
+func (list SeriesList) GetName() string {
+	return list.Name
+}
+
+type ConversionError struct {
+	From  string // the original data type
+	To    string // the type that attempted to convert to
+	Value string // a short string representation of the value
+}
+
+func (e ConversionError) Error() string {
+	return fmt.Sprintf("cannot convert %s (type %s) to type %s", e.Value, e.From, e.To)
+}
+
+func (e ConversionError) TokenName() string {
+	return fmt.Sprintf("%+v (type %s)", e.Value, e.From)
+}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -163,7 +163,7 @@ func NewFilter(name string, summary func([]float64) float64, ascending bool) fun
 			}
 			result := filter.FilterBy(list, count, summary, ascending)
 			result.Name = fmt.Sprintf("%s(%s, %d)", name, value.GetName(), count)
-			return function.SeriesListValue(result), nil
+			return result, nil
 		},
 	}
 }
@@ -207,7 +207,7 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 			}
 			result := filter.FilterRecentBy(list, count, summary, ascending, duration)
 			result.Name = fmt.Sprintf("%s(%s, %d)", name, value.GetName(), count)
-			return function.SeriesListValue(result), nil
+			return result, nil
 		},
 	}
 }
@@ -243,7 +243,7 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 				}
 				result.Name = fmt.Sprintf("%s(%s %s by %s)", name, value.GetName(), verbName, strings.Join(groupNames, ", "))
 			}
-			return function.SeriesListValue(result), nil
+			return result, nil
 		},
 	}
 }
@@ -283,7 +283,7 @@ func NewTransform(name string, parameterCount int, transformer func([]float64, [
 			} else {
 				result.Name = fmt.Sprintf("%s(%s)", name, listValue.GetName())
 			}
-			return function.SeriesListValue(result), nil
+			return result, nil
 		},
 	}
 }
@@ -325,11 +325,11 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 				result[i] = api.Timeseries{array, row.TagSet}
 			}
 
-			return function.SeriesListValue(api.SeriesList{
+			return api.SeriesList{
 				Series:    result,
 				Timerange: context.Timerange,
 				Name:      fmt.Sprintf("(%s %s %s)", leftValue.GetName(), op, rightValue.GetName()),
-			}), nil
+			}, nil
 		},
 	}
 }

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -91,7 +91,7 @@ var DropFunction = function.MetricFunction{
 			return nil, err
 		}
 		// Drop the tag from the list.
-		return function.SeriesListValue(DropTag(list, dropTag)), nil
+		return DropTag(list, dropTag), nil
 	},
 }
 
@@ -126,6 +126,6 @@ var SetFunction = function.MetricFunction{
 			return nil, err
 		}
 		// Set the tag for the list:
-		return function.SeriesListValue(SetTag(list, tag, set)), nil
+		return SetTag(list, tag, set), nil
 	},
 }

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -44,7 +44,7 @@ var Timeshift = function.MetricFunction{
 			return nil, err
 		}
 
-		if seriesValue, ok := result.(function.SeriesListValue); ok {
+		if seriesValue, ok := result.(api.SeriesList); ok {
 			seriesValue.Timerange = context.Timerange
 			seriesValue.Name = fmt.Sprintf("transform.timeshift(%s,%s)", result.GetName(), value.GetName())
 			return seriesValue, nil
@@ -125,7 +125,7 @@ var MovingAverage = function.MetricFunction{
 			list.Series[index].Values = results
 		}
 		list.Name = fmt.Sprintf("transform.moving_average(%s, %s)", listValue.GetName(), sizeValue.GetName())
-		return function.SeriesListValue(list), nil
+		return list, nil
 	},
 }
 
@@ -151,6 +151,6 @@ var Alias = function.MetricFunction{
 			return nil, err
 		}
 		list.Name = name
-		return function.SeriesListValue(list), nil
+		return list, nil
 	},
 }

--- a/function/value.go
+++ b/function/value.go
@@ -33,48 +33,11 @@ type Value interface {
 	GetName() string
 }
 
-type conversionError struct {
-	from  string // the original data type
-	to    string // the type that attempted to convert to
-	value string // a short string representation of the value
-}
-
-func (e conversionError) Error() string {
-	return fmt.Sprintf("cannot convert %s (type %s) to type %s", e.value, e.from, e.to)
-}
-
-func (e conversionError) TokenName() string {
-	return fmt.Sprintf("%+v (type %s)", e.value, e.from)
-}
-
-// A seriesListValue is a value which holds a SeriesList
-type SeriesListValue api.SeriesList
-
-func (value SeriesListValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList(value), nil
-}
-
-func (value SeriesListValue) ToString() (string, error) {
-	return "", conversionError{"SeriesList", "string", fmt.Sprintf("serieslist[%s]", value.Name)}
-}
-
-func (value SeriesListValue) ToScalar() (float64, error) {
-	return 0, conversionError{"SeriesList", "scalar", fmt.Sprintf("serieslist[%s]", value.Name)}
-}
-
-func (value SeriesListValue) ToDuration() (time.Duration, error) {
-	return 0, conversionError{"SeriesList", "duration", fmt.Sprintf("serieslist[%s]", value.Name)}
-}
-
-func (value SeriesListValue) GetName() string {
-	return api.SeriesList(value).Name
-}
-
 // A stringValue holds a string
 type StringValue string
 
 func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, conversionError{"string", "SeriesList", fmt.Sprintf("%q", value)}
+	return api.SeriesList{}, api.ConversionError{"string", "SeriesList", fmt.Sprintf("%q", value)}
 }
 
 func (value StringValue) ToString() (string, error) {
@@ -82,11 +45,11 @@ func (value StringValue) ToString() (string, error) {
 }
 
 func (value StringValue) ToScalar() (float64, error) {
-	return 0, conversionError{"string", "scalar", fmt.Sprintf("%q", value)}
+	return 0, api.ConversionError{"string", "scalar", fmt.Sprintf("%q", value)}
 }
 
 func (value StringValue) ToDuration() (time.Duration, error) {
-	return 0, conversionError{"string", "duration", fmt.Sprintf("%q", value)}
+	return 0, api.ConversionError{"string", "duration", fmt.Sprintf("%q", value)}
 }
 
 func (value StringValue) GetName() string {
@@ -110,7 +73,7 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 }
 
 func (value ScalarValue) ToString() (string, error) {
-	return "", conversionError{"scalar", "string", fmt.Sprintf("%f", value)}
+	return "", api.ConversionError{"scalar", "string", fmt.Sprintf("%f", value)}
 }
 
 func (value ScalarValue) ToScalar() (float64, error) {
@@ -118,7 +81,7 @@ func (value ScalarValue) ToScalar() (float64, error) {
 }
 
 func (value ScalarValue) ToDuration() (time.Duration, error) {
-	return 0, conversionError{"scalar", "duration", fmt.Sprintf("%f", value)}
+	return 0, api.ConversionError{"scalar", "duration", fmt.Sprintf("%f", value)}
 }
 
 func (value ScalarValue) GetName() string {
@@ -135,15 +98,15 @@ func NewDurationValue(name string, duration time.Duration) DurationValue {
 }
 
 func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, conversionError{"duration", "SeriesList", value.name}
+	return api.SeriesList{}, api.ConversionError{"duration", "SeriesList", value.name}
 }
 
 func (value DurationValue) ToString() (string, error) {
-	return "", conversionError{"duration", "string", value.name}
+	return "", api.ConversionError{"duration", "string", value.name}
 }
 
 func (value DurationValue) ToScalar() (float64, error) {
-	return 0, conversionError{"duration", "scalar", value.name}
+	return 0, api.ConversionError{"duration", "scalar", value.name}
 }
 
 func (value DurationValue) ToDuration() (time.Duration, error) {

--- a/query/expression.go
+++ b/query/expression.go
@@ -85,7 +85,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 
 	serieslist.Name = expr.metricName
 
-	return function.SeriesListValue(serieslist), nil
+	return serieslist, nil
 }
 
 func (expr *functionExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -33,10 +33,10 @@ type LiteralExpression struct {
 }
 
 func (expr *LiteralExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return function.SeriesListValue(api.SeriesList{
+	return api.SeriesList{
 		Series:    []api.Timeseries{api.Timeseries{expr.Values, api.NewTagSet()}},
 		Timerange: api.Timerange{},
-	}), nil
+	}, nil
 }
 
 type LiteralSeriesExpression struct {
@@ -44,7 +44,7 @@ type LiteralSeriesExpression struct {
 }
 
 func (expr *LiteralSeriesExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return function.SeriesListValue(expr.list), nil
+	return expr.list, nil
 }
 
 func Test_ScalarExpression(t *testing.T) {


### PR DESCRIPTION
Instead of making a wrapper type in the `function` package, it is much
simpler to implement the type methods in the `api` package. Otherwise,
we have to ensure that all implementing functions need to cast the
result to SeriesListValue.