### PR TITLE
Unmatched Graphite Rules

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -62,8 +62,14 @@ type Config struct {
 	// Database configurations
 	// mostly cassandra configurations from
 	// https://github.com/gocql/gocql/blob/master/cluster.go
-	Hosts    []string `yaml:"hosts"`
-	Keyspace string   `yaml:"keyspace"`
+	Hosts    []string       `yaml:"hosts"`
+	Keyspace string         `yaml:"keyspace"`
+	Database DatabaseConfig `yaml:"database"`
+}
+
+// Configuration for the Database attached to the default API
+type DatabaseConfig struct {
+	GraphiteMetricTTL int `yaml:graphite_metric_ttl` // in seconds
 }
 
 // ProfilingAPI wraps an ordinary API and also records profiling metrics to a given Profiler object.

--- a/api/api.go
+++ b/api/api.go
@@ -56,6 +56,9 @@ type APIGraphiteStore interface {
 
 	// Get all the Graphite metrics
 	GetAllGraphiteMetrics() ([]GraphiteMetric, error)
+
+	// Checks whether (at runtime) the object actually is capable of performing these queries
+	SupportsGraphiteStore() bool
 }
 
 // Configuration is the struct that tells how to instantiate a new copy of an API.
@@ -118,4 +121,10 @@ func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
 	} else {
 		return nil, nil
 	}
+}
+func (api ProfilingAPI) SupportsGraphiteStore() bool {
+	if apiGraphite, ok := api.API.(APIGraphiteStore); ok {
+		return apiGraphite.SupportsGraphiteStore()
+	}
+	return false
 }

--- a/api/api.go
+++ b/api/api.go
@@ -47,6 +47,17 @@ type API interface {
 	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
 }
 
+type APIGraphiteStore interface {
+	// Embed the API interface
+	API
+
+	// Add a Graphite metric to the complete list (as needed)
+	AddGraphiteMetric(metric GraphiteMetric) error
+
+	// Get all the Graphite metrics
+	GetAllGraphiteMetrics() ([]GraphiteMetric, error)
+}
+
 // Configuration is the struct that tells how to instantiate a new copy of an API.
 type Config struct {
 	// Location of conversion rules. All *.yaml files in here will be loaded.
@@ -92,4 +103,19 @@ func (api ProfilingAPI) GetAllMetrics() ([]MetricKey, error) {
 func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error) {
 	defer api.Profiler.Record("api.GetMetricsForTag")()
 	return api.API.GetMetricsForTag(tagKey, tagValue)
+}
+func (api ProfilingAPI) AddGraphiteMetric(metric GraphiteMetric) error {
+	if apiGraphite, ok := api.API.(APIGraphiteStore); ok {
+		defer api.Profiler.Record("api.AddGraphiteMetric")()
+		return apiGraphite.AddGraphiteMetric(metric)
+	}
+	return nil
+}
+func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
+	if apiGraphite, ok := api.API.(APIGraphiteStore); ok {
+		defer api.Profiler.Record("api.GetAllGraphiteMetrics")()
+		return apiGraphite.GetAllGraphiteMetrics()
+	} else {
+		return nil, nil
+	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -111,9 +111,9 @@ const SpecialGraphiteName = "$graphite"
 
 func (api ProfilingAPI) AddGraphiteMetric(metric GraphiteMetric) error {
 	defer api.Profiler.Record("api.AddGraphiteMetric")()
-	return api.AddGraphiteMetric(metric)
+	return api.API.AddGraphiteMetric(metric)
 }
 func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
 	defer api.Profiler.Record("api.GetAllGraphiteMetrics")()
-	return api.GetAllGraphiteMetrics()
+	return api.API.GetAllGraphiteMetrics()
 }

--- a/api/api.go
+++ b/api/api.go
@@ -100,6 +100,9 @@ func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, 
 	defer api.Profiler.Record("api.GetMetricsForTag")()
 	return api.API.GetMetricsForTag(tagKey, tagValue)
 }
+
+const SpecialGraphiteName = "$graphite"
+
 func (api ProfilingAPI) AddGraphiteMetric(metric GraphiteMetric) error {
 	defer api.Profiler.Record("api.AddGraphiteMetric")()
 	return api.AddGraphiteMetric(metric)

--- a/api/api.go
+++ b/api/api.go
@@ -53,9 +53,6 @@ type GraphiteStore interface {
 
 	// Get all the Graphite metrics
 	GetAllGraphiteMetrics() ([]GraphiteMetric, error)
-
-	// Checks whether (at runtime) the object actually is capable of performing these queries
-	SupportsGraphiteStore() bool
 }
 
 // Configuration is the struct that tells how to instantiate a new copy of an API.
@@ -118,10 +115,4 @@ func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
 	} else {
 		return nil, nil
 	}
-}
-func (api ProfilingAPI) SupportsGraphiteStore() bool {
-	if apiGraphite, ok := api.API.(GraphiteStore); ok {
-		return apiGraphite.SupportsGraphiteStore()
-	}
-	return false
 }

--- a/api/api.go
+++ b/api/api.go
@@ -47,10 +47,7 @@ type API interface {
 	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
 }
 
-type APIGraphiteStore interface {
-	// Embed the API interface
-	API
-
+type GraphiteStore interface {
 	// Add a Graphite metric to the complete list (as needed)
 	AddGraphiteMetric(metric GraphiteMetric) error
 
@@ -108,14 +105,14 @@ func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, 
 	return api.API.GetMetricsForTag(tagKey, tagValue)
 }
 func (api ProfilingAPI) AddGraphiteMetric(metric GraphiteMetric) error {
-	if apiGraphite, ok := api.API.(APIGraphiteStore); ok {
+	if apiGraphite, ok := api.API.(GraphiteStore); ok {
 		defer api.Profiler.Record("api.AddGraphiteMetric")()
 		return apiGraphite.AddGraphiteMetric(metric)
 	}
 	return nil
 }
 func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
-	if apiGraphite, ok := api.API.(APIGraphiteStore); ok {
+	if apiGraphite, ok := api.API.(GraphiteStore); ok {
 		defer api.Profiler.Record("api.GetAllGraphiteMetrics")()
 		return apiGraphite.GetAllGraphiteMetrics()
 	} else {
@@ -123,7 +120,7 @@ func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
 	}
 }
 func (api ProfilingAPI) SupportsGraphiteStore() bool {
-	if apiGraphite, ok := api.API.(APIGraphiteStore); ok {
+	if apiGraphite, ok := api.API.(GraphiteStore); ok {
 		return apiGraphite.SupportsGraphiteStore()
 	}
 	return false

--- a/api/api.go
+++ b/api/api.go
@@ -45,9 +45,8 @@ type API interface {
 	// For a given tag key-value pair, obtain the list of all the MetricKeys
 	// associated with them.
 	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
-}
 
-type GraphiteStore interface {
+	// Allow the API to store and retrieve graphite metrics:
 	// Add a Graphite metric to the complete list (as needed)
 	AddGraphiteMetric(metric GraphiteMetric) error
 
@@ -102,17 +101,10 @@ func (api ProfilingAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, 
 	return api.API.GetMetricsForTag(tagKey, tagValue)
 }
 func (api ProfilingAPI) AddGraphiteMetric(metric GraphiteMetric) error {
-	if apiGraphite, ok := api.API.(GraphiteStore); ok {
-		defer api.Profiler.Record("api.AddGraphiteMetric")()
-		return apiGraphite.AddGraphiteMetric(metric)
-	}
-	return nil
+	defer api.Profiler.Record("api.AddGraphiteMetric")()
+	return api.AddGraphiteMetric(metric)
 }
 func (api ProfilingAPI) GetAllGraphiteMetrics() ([]GraphiteMetric, error) {
-	if apiGraphite, ok := api.API.(GraphiteStore); ok {
-		defer api.Profiler.Record("api.GetAllGraphiteMetrics")()
-		return apiGraphite.GetAllGraphiteMetrics()
-	} else {
-		return nil, nil
-	}
+	defer api.Profiler.Record("api.GetAllGraphiteMetrics")()
+	return api.GetAllGraphiteMetrics()
 }

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -45,8 +45,12 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 				// Nothing found
 				return api.TaggedMetric{}, false
 			}
+			metric = metric[len(value):]
 			tagset[tag] = value
 		}
+	}
+	if len(metric) != 0 {
+		// There's still unconsumed parts of the metric left
 		return api.TaggedMetric{}, false
 	}
 	return api.TaggedMetric{

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -59,18 +59,13 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 	}, true
 }
 
-func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
-	graphiteAPI, ok := API.(api.GraphiteStore)
-	if !ok {
-		// API is not able to fetch metrics
-		return nil
-	}
+func GetGraphiteMetrics(pattern string, API api.GraphiteStore) []api.TaggedMetric {
 	pieces := strings.Split(pattern, "%")
 	if len(pieces)%2 == 0 {
 		// The pattern is invalid since some % isn't closed
 		return nil
 	}
-	metrics, err := graphiteAPI.GetAllGraphiteMetrics()
+	metrics, err := API.GetAllGraphiteMetrics()
 	if err != nil {
 		// There was some issue with data
 		return nil

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -31,6 +31,9 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 	for i, piece := range pieces {
 		if i%2 == 0 {
 			// Literal. Compare and match
+			if len(piece) > len(metric) {
+				return api.TaggedMetric{}, false
+			}
 			if metric[0:len(piece)] != piece {
 				// Didn't match
 				return api.TaggedMetric{}, false

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -55,7 +55,7 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 
 func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
 	graphiteAPI, ok := API.(api.GraphiteStore)
-	if !ok || !graphiteAPI.SupportsGraphiteStore() {
+	if !ok {
 		// API is not able to fetch metrics
 		return nil
 	}

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -54,7 +54,7 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 }
 
 func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
-	graphiteAPI, ok := API.(api.APIGraphiteStore)
+	graphiteAPI, ok := API.(api.GraphiteStore)
 	if !ok || !graphiteAPI.SupportsGraphiteStore() {
 		// API is not able to fetch metrics
 		return nil

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -60,6 +60,10 @@ func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
 		return nil
 	}
 	pieces := strings.Split(pattern, "%")
+	if len(pieces)%2 == 0 {
+		// The pattern is invalid since some % isn't closed
+		return nil
+	}
 	metrics, err := graphiteAPI.GetAllGraphiteMetrics()
 	if err != nil {
 		// There was some issue with data

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -21,11 +21,13 @@ import (
 	"github.com/square/metrics/api"
 )
 
+const SpecialGraphiteName = "$graphite"
+
 var segmentRegex = regexp.MustCompile(`^[^.]*`)
 
 func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 	tagset := api.NewTagSet()
-	tagset["#graphite"] = metric
+	tagset[SpecialGraphiteName] = metric
 	for i, piece := range pieces {
 		if i%2 == 0 {
 			// Literal. Compare and match
@@ -48,7 +50,7 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 		return api.TaggedMetric{}, false
 	}
 	return api.TaggedMetric{
-		MetricKey: "#graphite",
+		MetricKey: SpecialGraphiteName,
 		TagSet:    tagset,
 	}, true
 }

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -28,18 +28,18 @@ func applyPattern(rule internal.Rule, metric string) (api.TaggedMetric, bool) {
 	return tagged, true
 }
 
-func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
+func GetGraphiteMetrics(pattern string, API api.API) ([]api.TaggedMetric, error) {
 	rule, err := internal.Compile(internal.RawRule{
 		Pattern:          pattern,
 		MetricKeyPattern: api.SpecialGraphiteName,
 	})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	metrics, err := API.GetAllGraphiteMetrics()
 	if err != nil {
 		// There was some issue with data
-		return nil
+		return nil, err
 	}
 	results := []api.TaggedMetric{}
 	for _, metric := range metrics {
@@ -48,5 +48,5 @@ func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
 			results = append(results, result)
 		}
 	}
-	return results
+	return results, nil
 }

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -29,10 +29,7 @@ func applyPattern(rule internal.Rule, metric string) (api.TaggedMetric, bool) {
 }
 
 func GetGraphiteMetrics(pattern string, API api.API) ([]api.TaggedMetric, error) {
-	rule, err := internal.Compile(internal.RawRule{
-		Pattern:          pattern,
-		MetricKeyPattern: api.SpecialGraphiteName,
-	})
+	rule, err := internal.CompileGraphiteRule(pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphite
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/square/metrics/api"
+)
+
+var segmentRegex = regexp.MustCompile(`^[^.]*`)
+
+func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
+	tagset := api.NewTagSet()
+	tagset["#graphite"] = metric
+	for i, piece := range pieces {
+		if i%2 == 0 {
+			// Literal. Compare and match
+			if metric[0:len(piece)] != piece {
+				// Didn't match
+				return api.TaggedMetric{}, false
+			}
+			// Chop this part off of the metric
+			metric = metric[len(piece):]
+		} else {
+			// It's a tag value
+			tag := piece
+			value := segmentRegex.FindString(metric)
+			if value == "" {
+				// Nothing found
+				return api.TaggedMetric{}, false
+			}
+			tagset[tag] = value
+		}
+		return api.TaggedMetric{}, false
+	}
+	return api.TaggedMetric{
+		MetricKey: "#graphite",
+		TagSet:    tagset,
+	}, true
+}
+
+func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
+	graphiteAPI, ok := API.(api.APIGraphiteStore)
+	if !ok || !graphiteAPI.SupportsGraphiteStore() {
+		// API is not able to fetch metrics
+		return nil
+	}
+	pieces := strings.Split(pattern, "%")
+	metrics, err := graphiteAPI.GetAllGraphiteMetrics()
+	if err != nil {
+		// There was some issue with data
+		return nil
+	}
+
+	results := []api.TaggedMetric{}
+	for _, metric := range metrics {
+		result, ok := applyPattern(pieces, string(metric))
+		if ok {
+			results = append(results, result)
+		}
+	}
+	return results
+}

--- a/function/graphite/graphite.go
+++ b/function/graphite/graphite.go
@@ -62,7 +62,7 @@ func applyPattern(pieces []string, metric string) (api.TaggedMetric, bool) {
 	}, true
 }
 
-func GetGraphiteMetrics(pattern string, API api.GraphiteStore) []api.TaggedMetric {
+func GetGraphiteMetrics(pattern string, API api.API) []api.TaggedMetric {
 	pieces := strings.Split(pattern, "%")
 	if len(pieces)%2 == 0 {
 		// The pattern is invalid since some % isn't closed

--- a/function/graphite/graphite_test.go
+++ b/function/graphite/graphite_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/internal"
-	//"github.com/square/metrics/mocks"
+	"github.com/square/metrics/mocks"
 )
 
 func TestApplyPattern(t *testing.T) {
@@ -119,29 +119,7 @@ func TestApplyPattern(t *testing.T) {
 }
 
 type testStore struct {
-	// mocks.FakeApi
-}
-
-func (t testStore) AddMetric(api.TaggedMetric) error {
-	return nil
-}
-func (t testStore) GetAllMetrics() ([]api.MetricKey, error) {
-	return nil, nil
-}
-func (t testStore) GetAllTags(api.MetricKey) ([]api.TagSet, error) {
-	return nil, nil
-}
-func (t testStore) GetMetricsForTag(string, string) ([]api.MetricKey, error) {
-	return nil, nil
-}
-func (t testStore) RemoveMetric(api.TaggedMetric) error {
-	return nil
-}
-func (t testStore) ToGraphiteName(api.TaggedMetric) (api.GraphiteMetric, error) {
-	return "", nil
-}
-func (t testStore) ToTaggedName(api.GraphiteMetric) (api.TaggedMetric, error) {
-	return api.TaggedMetric{}, nil
+	api.API
 }
 
 func (t testStore) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
@@ -163,7 +141,7 @@ func (t testStore) AddGraphiteMetric(metric api.GraphiteMetric) error {
 }
 
 func TestGetGraphiteMetrics(t *testing.T) {
-	store := testStore{}
+	store := testStore{&mocks.FakeApi{}}
 	tests := []struct {
 		pattern string
 		expect  []api.TagSet

--- a/function/graphite/graphite_test.go
+++ b/function/graphite/graphite_test.go
@@ -275,7 +275,10 @@ func TestGetGraphiteMetrics(t *testing.T) {
 		},
 	}
 	for testNumber, test := range tests {
-		result := GetGraphiteMetrics(test.pattern, store)
+		result, err := GetGraphiteMetrics(test.pattern, store)
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err.Error())
+		}
 		if len(test.expect) != len(result) {
 			t.Errorf("Test #%d: Expected %d but got %d results: %+v, %+v",
 				testNumber,

--- a/function/graphite/graphite_test.go
+++ b/function/graphite/graphite_test.go
@@ -1,0 +1,110 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphite
+
+import (
+	"testing"
+
+	"github.com/square/metrics/api"
+)
+
+func TestApplyPattern(t *testing.T) {
+	tests := []struct {
+		pieces  []string
+		metric  string
+		success bool
+		expect  api.TagSet
+	}{
+		{
+			pieces:  []string{"this.is.a.graphite.metric"},
+			metric:  "this.is.a.graphite.metric",
+			success: true,
+			expect:  api.TagSet{"$graphite": "this.is.a.graphite.metric"},
+		},
+		{
+			pieces:  []string{"this.is.a.graphite.metric"},
+			metric:  "this.is.a.different_graphite.metric",
+			success: false,
+		},
+		{
+			pieces:  []string{"this.is.a.graphite.metric"},
+			metric:  "this.is.a.different.graphite.metric",
+			success: false,
+		},
+		{
+			pieces:  []string{"this.is.a.graphite.metric"},
+			metric:  "this.is.a.graphite.metric.too",
+			success: false,
+		},
+		{
+			pieces:  []string{"this.is.a.graphite.metric"},
+			metric:  "this.is.a.graphite.metricQ",
+			success: false,
+		},
+		{
+			pieces:  []string{"this.is.a.", "something", ".metric"},
+			metric:  "this.is.a.graphite.metric",
+			success: true,
+			expect: api.TagSet{
+				"$graphite": "this.is.a.graphite.metric",
+				"something": "graphite",
+			},
+		},
+		{
+			pieces:  []string{"this.is.a.", "something", ".", "type", ""},
+			metric:  "this.is.a.graphite.metric",
+			success: true,
+			expect: api.TagSet{
+				"$graphite": "this.is.a.graphite.metric",
+				"something": "graphite",
+				"type":      "metric",
+			},
+		},
+		{
+			pieces:  []string{"", "word1", ".", "word2", ".", "word3", ".", "word4", ".", "word5", ""},
+			metric:  "this.is.a.graphite.metric",
+			success: true,
+			expect: api.TagSet{
+				"$graphite": "this.is.a.graphite.metric",
+				"word1":     "this",
+				"word2":     "is",
+				"word3":     "a",
+				"word4":     "graphite",
+				"word5":     "metric",
+			},
+		},
+		{
+			pieces:  []string{"", "app", ".", "datacenter", ".cpu.", "quantity", ""},
+			metric:  "metrics-query-engine.north.cpu.total",
+			success: true,
+			expect: api.TagSet{
+				"$graphite":  "metrics-query-engine.north.cpu.total",
+				"app":        "metrics-query-engine",
+				"datacenter": "north",
+				"quantity":   "total",
+			},
+		},
+	}
+	for i, test := range tests {
+		result, ok := applyPattern(test.pieces, test.metric)
+		if ok != test.success {
+			t.Errorf("Test i = %d, test = %+v: didn't expect ok = %t", i, test, ok)
+			continue
+		}
+		if !test.expect.Equals(result.TagSet) {
+			t.Errorf("Expected %+v but got %+v", test.expect, result)
+		}
+	}
+}

--- a/function/graphite/graphite_test.go
+++ b/function/graphite/graphite_test.go
@@ -112,6 +112,28 @@ func TestApplyPattern(t *testing.T) {
 type testStore struct {
 }
 
+func (t testStore) AddMetric(api.TaggedMetric) error {
+	return nil
+}
+func (t testStore) GetAllMetrics() ([]api.MetricKey, error) {
+	return nil, nil
+}
+func (t testStore) GetAllTags(api.MetricKey) ([]api.TagSet, error) {
+	return nil, nil
+}
+func (t testStore) GetMetricsForTag(string, string) ([]api.MetricKey, error) {
+	return nil, nil
+}
+func (t testStore) RemoveMetric(api.TaggedMetric) error {
+	return nil
+}
+func (t testStore) ToGraphiteName(api.TaggedMetric) (api.GraphiteMetric, error) {
+	return "", nil
+}
+func (t testStore) ToTaggedName(api.GraphiteMetric) (api.TaggedMetric, error) {
+	return api.TaggedMetric{}, nil
+}
+
 func (t testStore) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
 	return []api.GraphiteMetric{
 		"server.north.cpu.mean",

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -378,6 +378,16 @@ var graphiteSelect = function.MetricFunction{
 			// remove the intermediate "$graphite" tag from each series
 			delete(series.TagSet, graphite.SpecialGraphiteName)
 		}
+		if context.Predicate != nil {
+			// Apply this filter
+			filteredSeries := []api.Timeseries{}
+			for _, series := range serieslist.Series {
+				if context.Predicate.Apply(series.TagSet) {
+					filteredSeries = append(filteredSeries, series)
+				}
+			}
+			serieslist.Series = filteredSeries
+		}
 		serieslist.Name = graphite.SpecialGraphiteName
 		return serieslist, nil
 	},

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -351,7 +351,10 @@ var graphiteSelect = function.MetricFunction{
 		if err != nil {
 			return nil, err
 		}
-		metrics := graphite.GetGraphiteMetrics(graphitePattern, context.API)
+		metrics, err := graphite.GetGraphiteMetrics(graphitePattern, context.API)
+		if err != nil {
+			return nil, err
+		}
 		if len(metrics) == 0 {
 			return nil, fmt.Errorf("there are no graphite metrics matching your pattern", graphiteQuery)
 		}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -376,7 +376,7 @@ var graphiteSelect = function.MetricFunction{
 		}
 		for _, series := range serieslist.Series {
 			// remove the intermediate "$graphite" tag from each series
-			delete(series.TagSet, graphite.SpecialGraphiteName)
+			delete(series.TagSet, api.SpecialGraphiteName)
 		}
 		if context.Predicate != nil {
 			// Apply this filter
@@ -388,7 +388,7 @@ var graphiteSelect = function.MetricFunction{
 			}
 			serieslist.Series = filteredSeries
 		}
-		serieslist.Name = graphite.SpecialGraphiteName
+		serieslist.Name = api.SpecialGraphiteName
 		return serieslist, nil
 	},
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -362,6 +362,7 @@ var graphiteSelect = function.MetricFunction{
 		if context.Predicate != nil {
 			filtered := []api.TaggedMetric{}
 			for _, metric := range metrics {
+				metric.MetricKey = api.SpecialGraphiteName
 				if context.Predicate.Apply(metric.TagSet) {
 					filtered = append(filtered, metric)
 				}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -351,15 +351,11 @@ var graphiteSelect = function.MetricFunction{
 		if err != nil {
 			return nil, err
 		}
-		graphiteAPI, ok := context.API.(api.GraphiteStore)
-		if !ok {
-			return nil, fmt.Errorf("your API does not support graphite queries")
-		}
-		results := graphite.GetGraphiteMetrics(graphitePattern, graphiteAPI)
+		results := graphite.GetGraphiteMetrics(graphitePattern, context.API)
 		if len(results) == 0 {
 			return nil, fmt.Errorf("graphite query %s resulted in no graphite metrics", graphiteQuery)
 		}
-		ok = context.FetchLimit.Consume(len(results))
+		ok := context.FetchLimit.Consume(len(results))
 		if !ok {
 			return nil, function.NewLimitError("fetch limit exceeded: too many series to fetch",
 				context.FetchLimit.Current(),

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -351,11 +351,15 @@ var graphiteSelect = function.MetricFunction{
 		if err != nil {
 			return nil, err
 		}
-		results := graphite.GetGraphiteMetrics(graphitePattern, context.API)
+		graphiteAPI, ok := context.API.(api.GraphiteStore)
+		if !ok {
+			return nil, fmt.Errorf("your API does not support graphite queries")
+		}
+		results := graphite.GetGraphiteMetrics(graphitePattern, graphiteAPI)
 		if len(results) == 0 {
 			return nil, fmt.Errorf("graphite query %s resulted in no graphite metrics", graphiteQuery)
 		}
-		ok := context.FetchLimit.Consume(len(results))
+		ok = context.FetchLimit.Consume(len(results))
 		if !ok {
 			return nil, function.NewLimitError("fetch limit exceeded: too many series to fetch",
 				context.FetchLimit.Current(),

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -369,8 +369,8 @@ var graphiteSelect = function.MetricFunction{
 			return nil, err
 		}
 		for _, series := range serieslist.Series {
-			// remove the intermediate "#graphite" tag from each series
-			delete(series.TagSet, "#graphite")
+			// remove the intermediate "$graphite" tag from each series
+			delete(series.TagSet, graphite.SpecialGraphiteName)
 		}
 		return serieslist, nil
 	},

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -378,6 +378,7 @@ var graphiteSelect = function.MetricFunction{
 			// remove the intermediate "$graphite" tag from each series
 			delete(series.TagSet, graphite.SpecialGraphiteName)
 		}
+		serieslist.Name = graphite.SpecialGraphiteName
 		return serieslist, nil
 	},
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -355,6 +355,12 @@ var graphiteSelect = function.MetricFunction{
 		if len(results) == 0 {
 			return nil, fmt.Errorf("graphite query %s resulted in no graphite metrics", graphiteQuery)
 		}
+		ok := context.FetchLimit.Consume(len(results))
+		if !ok {
+			return nil, function.NewLimitError("fetch limit exceeded: too many series to fetch",
+				context.FetchLimit.Current(),
+				context.FetchLimit.Limit())
+		}
 		serieslist, err := context.MultiBackend.FetchMultipleSeries(
 			api.FetchMultipleRequest{
 				results,

--- a/internal/api.go
+++ b/internal/api.go
@@ -142,4 +142,3 @@ func (a *defaultAPI) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
 
 // ensure interface
 var _ api.API = (*defaultAPI)(nil)
-var _ api.GraphiteStore = (*defaultAPI)(nil)

--- a/internal/api.go
+++ b/internal/api.go
@@ -30,7 +30,7 @@ func NewAPI(config api.Config) (api.API, error) {
 	clusterConfig.Hosts = config.Hosts
 	clusterConfig.Keyspace = config.Keyspace
 	clusterConfig.Timeout = time.Second * 30
-	db, err := NewCassandraDatabase(clusterConfig, config.DatabaseConfig)
+	db, err := NewCassandraDatabase(clusterConfig, config.Database)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api.go
+++ b/internal/api.go
@@ -136,10 +136,6 @@ func (a *defaultAPI) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
 	}
 	return nil, nil
 }
-func (a *defaultAPI) SupportsGraphiteStore() bool {
-	_, ok := a.db.(DatabaseGraphiteStore)
-	return ok
-}
 
 // ensure interface
 var _ api.API = (*defaultAPI)(nil)

--- a/internal/api.go
+++ b/internal/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/function/graphite"
 )
 
 // API implementations.
@@ -110,8 +111,8 @@ func (a *defaultAPI) RemoveMetric(metric api.TaggedMetric) error {
 }
 
 func (a *defaultAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
-	if metric.MetricKey == "$graphite" {
-		return api.GraphiteMetric(metric.TagSet["$graphite"]), nil
+	if metric.MetricKey == graphite.SpecialGraphiteName {
+		return api.GraphiteMetric(metric.TagSet[graphite.SpecialGraphiteName]), nil
 	}
 	return a.ruleset.ToGraphiteName(metric)
 }

--- a/internal/api.go
+++ b/internal/api.go
@@ -30,7 +30,7 @@ func NewAPI(config api.Config) (api.API, error) {
 	clusterConfig.Hosts = config.Hosts
 	clusterConfig.Keyspace = config.Keyspace
 	clusterConfig.Timeout = time.Second * 30
-	db, err := NewCassandraDatabase(clusterConfig)
+	db, err := NewCassandraDatabase(clusterConfig, config.DatabaseConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api.go
+++ b/internal/api.go
@@ -110,8 +110,8 @@ func (a *defaultAPI) RemoveMetric(metric api.TaggedMetric) error {
 }
 
 func (a *defaultAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
-	if metric.MetricKey == "#graphite" {
-		return api.GraphiteMetric(metric.TagSet["#graphite"]), nil
+	if metric.MetricKey == "$graphite" {
+		return api.GraphiteMetric(metric.TagSet["$graphite"]), nil
 	}
 	return a.ruleset.ToGraphiteName(metric)
 }

--- a/internal/api.go
+++ b/internal/api.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/square/metrics/api"
-	"github.com/square/metrics/function/graphite"
 	"github.com/square/metrics/log"
 )
 
@@ -113,8 +112,8 @@ func (a *defaultAPI) RemoveMetric(metric api.TaggedMetric) error {
 }
 
 func (a *defaultAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
-	if metric.MetricKey == graphite.SpecialGraphiteName {
-		return api.GraphiteMetric(metric.TagSet[graphite.SpecialGraphiteName]), nil
+	if metric.MetricKey == api.SpecialGraphiteName {
+		return api.GraphiteMetric(metric.TagSet[api.SpecialGraphiteName]), nil
 	}
 	return a.ruleset.ToGraphiteName(metric)
 }

--- a/internal/api.go
+++ b/internal/api.go
@@ -110,6 +110,9 @@ func (a *defaultAPI) RemoveMetric(metric api.TaggedMetric) error {
 }
 
 func (a *defaultAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
+	if metric.MetricKey == "#graphite" {
+		return api.GraphiteMetric(metric.TagSet["#graphite"]), nil
+	}
 	return a.ruleset.ToGraphiteName(metric)
 }
 

--- a/internal/api.go
+++ b/internal/api.go
@@ -143,4 +143,4 @@ func (a *defaultAPI) SupportsGraphiteStore() bool {
 
 // ensure interface
 var _ api.API = (*defaultAPI)(nil)
-var _ api.APIGraphiteStore = (*defaultAPI)(nil)
+var _ api.GraphiteStore = (*defaultAPI)(nil)

--- a/internal/api.go
+++ b/internal/api.go
@@ -121,5 +121,23 @@ func (a *defaultAPI) ToTaggedName(metric api.GraphiteMetric) (api.TaggedMetric, 
 	return api.TaggedMetric{}, newNoMatch()
 }
 
+func (a *defaultAPI) AddGraphiteMetric(metric api.GraphiteMetric) error {
+	if graphiteDB, ok := a.db.(DatabaseGraphiteStore); ok {
+		return graphiteDB.AddGraphiteMetric(metric)
+	}
+	return nil
+}
+func (a *defaultAPI) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
+	if graphiteDB, ok := a.db.(DatabaseGraphiteStore); ok {
+		return graphiteDB.GetAllGraphiteMetrics()
+	}
+	return nil, nil
+}
+func (a *defaultAPI) SupportsGraphiteStore() bool {
+	_, ok := a.db.(DatabaseGraphiteStore)
+	return ok
+}
+
 // ensure interface
 var _ api.API = (*defaultAPI)(nil)
+var _ api.APIGraphiteStore = (*defaultAPI)(nil)

--- a/internal/api.go
+++ b/internal/api.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -130,13 +131,13 @@ func (a *defaultAPI) AddGraphiteMetric(metric api.GraphiteMetric) error {
 	if graphiteDB, ok := a.db.(DatabaseGraphiteStore); ok {
 		return graphiteDB.AddGraphiteMetric(metric)
 	}
-	return nil
+	return fmt.Errorf("database does not support the AddGraphiteMetric operator")
 }
 func (a *defaultAPI) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
 	if graphiteDB, ok := a.db.(DatabaseGraphiteStore); ok {
 		return graphiteDB.GetAllGraphiteMetrics()
 	}
-	return nil, nil
+	return nil, fmt.Errorf("database does not support the GetAllGraphiteMetrics operator")
 }
 
 // ensure interface

--- a/internal/cassandra.go
+++ b/internal/cassandra.go
@@ -42,9 +42,6 @@ type Database interface {
 }
 
 type DatabaseGraphiteStore interface {
-	// Embed the Database interface
-	Database
-
 	// Add a Graphite name to the database
 	AddGraphiteMetric(graphiteName api.GraphiteMetric) error
 	// Get all the Graphite names stored in the database
@@ -210,7 +207,8 @@ func (db *defaultDatabase) RemoveFromTagIndex(tagKey string, tagValue string, me
 
 func (db *defaultDatabase) AddGraphiteMetric(metric api.GraphiteMetric) error {
 	return db.session.Query(
-		"INSERT INTO graphite_names VALUES (graphite_name) VALUES (?) USING TTL 30000", // Slightly more than 8 hours TTL
+		"INSERT INTO graphite_names VALUES (shard, graphite_name) VALUES (?, ?) USING TTL 30000", // Slightly more than 8 hours TTL
+		0,
 		metric,
 	).Exec()
 }

--- a/internal/cassandra.go
+++ b/internal/cassandra.go
@@ -207,7 +207,7 @@ func (db *defaultDatabase) RemoveFromTagIndex(tagKey string, tagValue string, me
 
 func (db *defaultDatabase) AddGraphiteMetric(metric api.GraphiteMetric) error {
 	return db.session.Query(
-		"INSERT INTO graphite_names VALUES (shard, graphite_name) VALUES (?, ?) USING TTL 30000", // Slightly more than 8 hours TTL
+		"INSERT INTO graphite_names (shard, graphite_name) VALUES (?, ?) USING TTL 30000", // Slightly more than 8 hours TTL
 		0,
 		metric,
 	).Exec()

--- a/internal/cassandra.go
+++ b/internal/cassandra.go
@@ -207,7 +207,7 @@ func (db *defaultDatabase) RemoveFromTagIndex(tagKey string, tagValue string, me
 
 func (db *defaultDatabase) AddGraphiteMetric(metric api.GraphiteMetric) error {
 	return db.session.Query(
-		"INSERT INTO graphite_names (shard, graphite_name) VALUES (?, ?) USING TTL 30000", // Slightly more than 8 hours TTL
+		"INSERT INTO graphite_names (shard, graphite_name) VALUES (?, ?) USING TTL 90000", // Slightly more than 24 hours TTL
 		0,
 		metric,
 	).Exec()

--- a/internal/cassandra.go
+++ b/internal/cassandra.go
@@ -64,10 +64,14 @@ type defaultDatabase struct {
 }
 
 // NewCassandraDatabase creates an instance of database, backed by Cassandra.
-func NewCassandraDatabase(clusterConfig *gocql.ClusterConfig) (Database, error) {
+func NewCassandraDatabase(clusterConfig *gocql.ClusterConfig, databaseConfig api.DatabaseConfig) (Database, error) {
 	session, err := clusterConfig.CreateSession()
 	if err != nil {
 		return nil, err
+	}
+	graphiteMetricTTL := databaseConfig.GraphiteMetricTTL
+	if graphiteMetricTTL == 0 {
+		graphiteMetricTTL = 90000 // slightly more than 24 hours as a default
 	}
 	return &defaultDatabase{
 		session:           session,
@@ -75,7 +79,7 @@ func NewCassandraDatabase(clusterConfig *gocql.ClusterConfig) (Database, error) 
 		allMetricsMutex:   &sync.Mutex{},
 		tagIndexCache:     make(map[tagIndexCacheKey]bool),
 		tagIndexMutex:     &sync.Mutex{},
-		graphiteMetricTTL: 90000, // Slightly more than 24 hours TTL
+		graphiteMetricTTL: graphiteMetricTTL,
 	}, nil
 }
 

--- a/internal/rules.go
+++ b/internal/rules.go
@@ -53,6 +53,21 @@ type RuleSet struct {
 	rules []Rule
 }
 
+func CompileGraphiteRule(pattern string) (Rule, error) {
+	graphitePatternTags := extractTags(pattern)
+	if graphitePatternTags == nil {
+		return Rule{}, newInvalidPattern(pattern)
+	}
+	regex := (&RawRule{}).toRegexp(pattern)
+	return Rule{
+		raw:                  RawRule{},
+		graphitePatternRegex: regex,
+		graphitePatternTags:  graphitePatternTags,
+		metricKeyTags:        []string{},
+		// metricKeyRegex: neglect this
+	}, nil
+}
+
 // Compile a given RawRule into a regex and exposed tagset.
 // error is an instance of RuleError.
 func Compile(rule RawRule) (Rule, error) {
@@ -61,7 +76,7 @@ func Compile(rule RawRule) (Rule, error) {
 	}
 	graphitePatternTags := extractTags(rule.Pattern)
 	if graphitePatternTags == nil {
-		return Rule{}, newInvalidPattern(rule.MetricKeyPattern)
+		return Rule{}, newInvalidPattern(rule.Pattern)
 	}
 	metricKeyTags := extractTags(string(rule.MetricKeyPattern))
 	if !isSubset(metricKeyTags, graphitePatternTags) {

--- a/internal/rules.go
+++ b/internal/rules.go
@@ -76,7 +76,7 @@ func Compile(rule RawRule) (Rule, error) {
 	}
 	graphitePatternTags := extractTags(rule.Pattern)
 	if graphitePatternTags == nil {
-		return Rule{}, newInvalidPattern(rule.Pattern)
+		return Rule{}, newInvalidPattern(rule.MetricKeyPattern)
 	}
 	metricKeyTags := extractTags(string(rule.MetricKeyPattern))
 	if !isSubset(metricKeyTags, graphitePatternTags) {

--- a/mocks/api.go
+++ b/mocks/api.go
@@ -29,6 +29,7 @@ type FakeApi struct {
 		key   string
 		value string
 	}][]api.MetricKey
+	graphiteList []api.GraphiteMetric
 }
 
 func NewFakeApi() *FakeApi {
@@ -50,6 +51,8 @@ func (fa *FakeApi) AddPair(tm api.TaggedMetric, gm api.GraphiteMetric) {
 	} else {
 		fa.metricTagSets[tm.MetricKey] = append(metricTagSets, tm.TagSet)
 	}
+
+	fa.graphiteList = append(fa.graphiteList, gm)
 }
 
 func (fa *FakeApi) AddMetric(metric api.TaggedMetric) error {
@@ -102,4 +105,13 @@ func (fa *FakeApi) AddMetricsForTag(key string, value string, metric string) {
 
 func (fa *FakeApi) GetMetricsForTag(tagKey, tagValue string) ([]api.MetricKey, error) {
 	return nil, errors.New("Implement me")
+}
+
+// Makes the FakeApi into graphite metric storage
+func (fa *FakeApi) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
+	return fa.graphiteList, nil
+}
+func (fa *FakeApi) AddGraphiteMetric(metric api.GraphiteMetric) error {
+	fa.graphiteList = append(fa.graphiteList, metric)
+	return nil
 }

--- a/query/command_graphite_test.go
+++ b/query/command_graphite_test.go
@@ -1,0 +1,373 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration test for the query execution.
+package query
+
+import (
+	"testing"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/api/backend"
+	"github.com/square/metrics/assert"
+)
+
+type fakeGraphiteAPI struct {
+}
+
+func (a fakeGraphiteAPI) AddMetric(metric api.TaggedMetric) error {
+	return nil
+}
+
+func (a fakeGraphiteAPI) RemoveMetric(metric api.TaggedMetric) error {
+	return nil
+}
+
+func (a fakeGraphiteAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
+	if graphiteMetric, ok := metric.TagSet["$graphite"]; ok {
+		return api.GraphiteMetric(graphiteMetric), nil
+	}
+	panic("ToGraphiteName invoked on fakeGraphiteAPI without a $graphite tag")
+}
+
+func (a fakeGraphiteAPI) ToTaggedName(metric api.GraphiteMetric) (api.TaggedMetric, error) {
+	panic("ToTaggedName invoked on fakeGraphiteAPI")
+}
+
+func (a fakeGraphiteAPI) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error) {
+	return nil, nil
+}
+
+func (a fakeGraphiteAPI) GetAllMetrics() ([]api.MetricKey, error) {
+	return nil, nil
+}
+
+func (a fakeGraphiteAPI) GetMetricsForTag(tagKey, tagValue string) ([]api.MetricKey, error) {
+	return nil, nil
+}
+
+func (a fakeGraphiteAPI) AddGraphiteMetric(api.GraphiteMetric) error {
+	return nil
+}
+func (a fakeGraphiteAPI) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
+	metrics := make([]api.GraphiteMetric, 0, len(graphiteMap))
+	for metric := range graphiteMap {
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}
+
+type fakeGraphiteBackend struct {
+}
+
+var graphiteMap = map[api.GraphiteMetric][]float64{
+	"server.north.cpu.mean":   {1, 2, 3},
+	"server.north.cpu.median": {4, 5, 6},
+	"server.south.cpu.mean":   {7, 8, 9},
+	"server.south.cpu.median": {2, 4, 8},
+	"proxy.south.cpu.mean":    {1, 1, 1},
+	"proxy.south.cpu.median":  {2, 2, 2},
+	"latency.host45.http":     {3, 3, 3},
+	"latency.host68.http":     {4, 4, 4},
+	"latency.host68.rpc":      {5, 5, 5},
+	"latency.host22.rpc":      {6, 6, 6},
+}
+
+func (b fakeGraphiteBackend) FetchSingleSeries(f api.FetchSeriesRequest) (api.Timeseries, error) {
+	graphiteName, err := f.API.ToGraphiteName(f.Metric)
+	if err != nil {
+		return api.Timeseries{}, err
+	}
+	return api.Timeseries{TagSet: f.Metric.TagSet, Values: graphiteMap[graphiteName]}, nil
+}
+
+func TestGraphite(t *testing.T) {
+	fakeAPI := fakeGraphiteAPI{}
+	fakeBackend := backend.NewSequentialMultiBackend(fakeGraphiteBackend{})
+	tests := []struct {
+		query    string
+		expected []api.Timeseries
+	}{
+		{
+			query: "graphite('server.north.cpu.mean') from -10m to now",
+			expected: []api.Timeseries{
+				{
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{},
+				},
+			},
+		},
+		{
+			query: "graphite('server.north.cpu.%quantity%') from -10m to now",
+			expected: []api.Timeseries{
+				{
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{
+						"quantity": "mean",
+					},
+				},
+				{
+					Values: []float64{4, 5, 6},
+					TagSet: api.TagSet{
+						"quantity": "median",
+					},
+				},
+			},
+		},
+		{
+			query: "graphite('%app%.%dc%.cpu.%quantity%') from -10m to now",
+			expected: []api.Timeseries{
+				{
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{
+						"app":      "server",
+						"dc":       "north",
+						"quantity": "mean",
+					},
+				},
+				{
+					Values: []float64{4, 5, 6},
+					TagSet: api.TagSet{
+						"app":      "server",
+						"dc":       "north",
+						"quantity": "median",
+					},
+				},
+				{
+					Values: []float64{7, 8, 9},
+					TagSet: api.TagSet{
+						"app":      "server",
+						"dc":       "south",
+						"quantity": "mean",
+					},
+				},
+				{
+					Values: []float64{2, 4, 8},
+					TagSet: api.TagSet{
+						"app":      "server",
+						"dc":       "south",
+						"quantity": "median",
+					},
+				},
+				{
+					Values: []float64{1, 1, 1},
+					TagSet: api.TagSet{
+						"app":      "proxy",
+						"dc":       "south",
+						"quantity": "mean",
+					},
+				},
+				{
+					Values: []float64{2, 2, 2},
+					TagSet: api.TagSet{
+						"app":      "proxy",
+						"dc":       "south",
+						"quantity": "median",
+					},
+				},
+			},
+		},
+		{
+			query: "graphite('latency.%host%.%method%') from -10m to now",
+			expected: []api.Timeseries{
+				{
+					Values: []float64{3, 3, 3},
+					TagSet: api.TagSet{
+						"host":   "host45",
+						"method": "http",
+					},
+				},
+				{
+					Values: []float64{4, 4, 4},
+					TagSet: api.TagSet{
+						"host":   "host68",
+						"method": "http",
+					},
+				},
+				{
+					Values: []float64{5, 5, 5},
+					TagSet: api.TagSet{
+						"host":   "host68",
+						"method": "rpc",
+					},
+				},
+				{
+					Values: []float64{6, 6, 6},
+					TagSet: api.TagSet{
+						"host":   "host22",
+						"method": "rpc",
+					},
+				},
+			},
+		},
+		{
+			query: "graphite('latency.%host%.%method%') where method = 'rpc' from -10m to now",
+			expected: []api.Timeseries{
+				{
+					Values: []float64{5, 5, 5},
+					TagSet: api.TagSet{
+						"host":   "host68",
+						"method": "rpc",
+					},
+				},
+				{
+					Values: []float64{6, 6, 6},
+					TagSet: api.TagSet{
+						"host":   "host22",
+						"method": "rpc",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		command, err := Parse(test.query)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing")
+			return
+		}
+		if command.Name() != "select" {
+			t.Errorf("Expected select command but got %s", command.Name())
+			continue
+		}
+		rawResult, err := command.Execute(ExecutionContext{Backend: fakeBackend, API: fakeAPI, FetchLimit: 1000, Timeout: 0})
+		if err != nil {
+			t.Errorf("Unexpected error while execution: %s", err.Error())
+			continue
+		}
+		seriesListList, ok := rawResult.([]api.SeriesList)
+		if !ok || len(seriesListList) != 1 {
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			continue
+		}
+		list := seriesListList[0]
+		if err != nil {
+			t.Fatal(err)
+		}
+		a := assert.New(t)
+		expectedSeries := test.expected
+		lookup := map[string][]float64{}
+		for _, expect := range expectedSeries {
+			lookup[expect.TagSet.Serialize()] = expect.Values
+		}
+		a.EqString(list.Name, "$graphite")
+		for _, series := range list.Series {
+			a.EqFloatArray(series.Values, lookup[series.TagSet.Serialize()], 1e-100)
+		}
+	}
+}
+
+// Verify that we filter before fetching
+func TestGraphiteLimits(t *testing.T) {
+	fakeAPI := fakeGraphiteAPI{}
+	fakeBackend := backend.NewSequentialMultiBackend(fakeGraphiteBackend{})
+	tests := []struct {
+		query    string
+		expected []api.Timeseries
+	}{
+		{
+			query: "graphite('%app%.%dc%.cpu.%quantity%') where app = 'server' and dc = 'north' from -10m to now",
+			expected: []api.Timeseries{
+				{
+					Values: []float64{1, 2, 3},
+					TagSet: api.TagSet{
+						"app":      "server",
+						"dc":       "north",
+						"quantity": "mean",
+					},
+				},
+				{
+					Values: []float64{4, 5, 6},
+					TagSet: api.TagSet{
+						"app":      "server",
+						"dc":       "north",
+						"quantity": "median",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		command, err := Parse(test.query)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing")
+			return
+		}
+		if command.Name() != "select" {
+			t.Errorf("Expected select command but got %s", command.Name())
+			continue
+		}
+		rawResult, err := command.Execute(ExecutionContext{Backend: fakeBackend, API: fakeAPI, FetchLimit: 2, Timeout: 0})
+		if err != nil {
+			t.Errorf("Unexpected error while execution: %s", err.Error())
+			continue
+		}
+		seriesListList, ok := rawResult.([]api.SeriesList)
+		if !ok || len(seriesListList) != 1 {
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			continue
+		}
+		list := seriesListList[0]
+		if err != nil {
+			t.Fatal(err)
+		}
+		a := assert.New(t)
+		expectedSeries := test.expected
+		lookup := map[string][]float64{}
+		for _, expect := range expectedSeries {
+			lookup[expect.TagSet.Serialize()] = expect.Values
+		}
+		a.EqString(list.Name, "$graphite")
+		for _, series := range list.Series {
+			a.EqFloatArray(series.Values, lookup[series.TagSet.Serialize()], 1e-100)
+		}
+	}
+}
+
+func TestGraphiteFailure(t *testing.T) {
+	fakeAPI := fakeGraphiteAPI{}
+	fakeBackend := backend.NewSequentialMultiBackend(fakeGraphiteBackend{})
+	tests := []string{
+		"graphite('') from -10m to now",
+		"graphite('does.not.exist') from -10m to now",
+		"graphite('latency.%host%.%method%s') where host = 'hostDNE' from -10m to now",
+		"graphite('latency.%host%.%invalid') where host = 'hostDNE' from -10m to now",
+		"graphite('latency.%host%.invalid%') where host = 'hostDNE' from -10m to now",
+	}
+	for _, test := range tests {
+		command, err := Parse(test)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing: `%s`", test)
+		}
+		_, err = command.Execute(ExecutionContext{Backend: fakeBackend, API: fakeAPI, FetchLimit: 1000, Timeout: 0})
+		if err == nil {
+			t.Fatalf("Expected query `%s` to fail", test)
+		}
+	}
+	// These tests make sure that the Fetch limit is being exercized
+	smallTests := []string{
+		"graphite('%app%.%dc%.cpu.%quantity%') from -10m to now",
+		"graphite('latency.%host%.%method%') from -10m to now",
+	}
+	for _, test := range smallTests {
+		command, err := Parse(test)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing: `%s`", test)
+		}
+		_, err = command.Execute(ExecutionContext{Backend: fakeBackend, API: fakeAPI, FetchLimit: 2, Timeout: 0})
+		if err == nil {
+			t.Fatalf("Expected query `%s` to fail", test)
+		}
+	}
+}

--- a/query/command_graphite_test.go
+++ b/query/command_graphite_test.go
@@ -24,37 +24,14 @@ import (
 )
 
 type fakeGraphiteAPI struct {
-}
-
-func (a fakeGraphiteAPI) AddMetric(metric api.TaggedMetric) error {
-	return nil
-}
-
-func (a fakeGraphiteAPI) RemoveMetric(metric api.TaggedMetric) error {
-	return nil
+	api.API
 }
 
 func (a fakeGraphiteAPI) ToGraphiteName(metric api.TaggedMetric) (api.GraphiteMetric, error) {
 	if graphiteMetric, ok := metric.TagSet["$graphite"]; ok {
 		return api.GraphiteMetric(graphiteMetric), nil
 	}
-	panic("ToGraphiteName invoked on fakeGraphiteAPI without a $graphite tag")
-}
-
-func (a fakeGraphiteAPI) ToTaggedName(metric api.GraphiteMetric) (api.TaggedMetric, error) {
-	panic("ToTaggedName invoked on fakeGraphiteAPI")
-}
-
-func (a fakeGraphiteAPI) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error) {
-	return nil, nil
-}
-
-func (a fakeGraphiteAPI) GetAllMetrics() ([]api.MetricKey, error) {
-	return nil, nil
-}
-
-func (a fakeGraphiteAPI) GetMetricsForTag(tagKey, tagValue string) ([]api.MetricKey, error) {
-	return nil, nil
+	return a.API.ToGraphiteName(metric)
 }
 
 func (a fakeGraphiteAPI) AddGraphiteMetric(api.GraphiteMetric) error {

--- a/query/command_graphite_test.go
+++ b/query/command_graphite_test.go
@@ -234,6 +234,7 @@ func TestGraphite(t *testing.T) {
 		}
 		a := assert.New(t)
 		expectedSeries := test.expected
+		a.EqInt(len(list.Series), len(expectedSeries))
 		lookup := map[string][]float64{}
 		for _, expect := range expectedSeries {
 			lookup[expect.TagSet.Serialize()] = expect.Values
@@ -296,9 +297,6 @@ func TestGraphiteLimits(t *testing.T) {
 			continue
 		}
 		list := seriesListList[0]
-		if err != nil {
-			t.Fatal(err)
-		}
 		a := assert.New(t)
 		expectedSeries := test.expected
 		lookup := map[string][]float64{}

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -75,6 +75,13 @@ MetricLoop:
 	return list, nil
 }
 
+func (a fakeAPI) AddGraphiteMetric(api.GraphiteMetric) error {
+	return nil
+}
+func (a fakeAPI) GetAllGraphiteMetrics() ([]api.GraphiteMetric, error) {
+	return nil, nil
+}
+
 type fakeBackend struct {
 }
 

--- a/schema/schema.cql
+++ b/schema/schema.cql
@@ -29,5 +29,5 @@ create table metric_name_set (
 create table graphite_names (
   shard int,
   graphite_name varchar,
-  primary key (shard)
+  primary key ((shard) graphite_name)
 );

--- a/schema/schema.cql
+++ b/schema/schema.cql
@@ -27,6 +27,7 @@ create table metric_name_set (
 
 -- graphite_names
 create table graphite_names (
+  shard int,
   graphite_name varchar,
-  primary key (graphite_name)
+  primary key (shard)
 );

--- a/schema/schema.cql
+++ b/schema/schema.cql
@@ -24,3 +24,9 @@ create table metric_name_set (
   metric_names set<varchar>,
   primary key (shard)
 );
+
+-- graphite_names
+create table graphite_names (
+  graphite_name varchar,
+  primary key (graphite_name)
+);

--- a/schema/schema_test.cql
+++ b/schema/schema_test.cql
@@ -29,5 +29,5 @@ create table metric_name_set (
 create table graphite_names (
   shard int,
   graphite_name varchar,
-  primary key (shard)
+  primary key ((shard), graphite_name)
 );

--- a/schema/schema_test.cql
+++ b/schema/schema_test.cql
@@ -27,6 +27,7 @@ create table metric_name_set (
 
 -- graphite_names
 create table graphite_names (
+  shard int,
   graphite_name varchar,
-  primary key (graphite_name)
+  primary key (shard)
 );

--- a/schema/schema_test.cql
+++ b/schema/schema_test.cql
@@ -24,3 +24,9 @@ create table metric_name_set (
   metric_names set<varchar>,
   primary key (shard)
 );
+
+-- graphite_names
+create table graphite_names (
+  graphite_name varchar,
+  primary key (graphite_name)
+);


### PR DESCRIPTION
This PR adds a way to query graphite metrics directly from MQE, even without rules for them. This is accomplished by use of the highly magical `graphite` function.

For example, the query `graphite("mqe.%host%.%dc%.cpu")` will produce a serieslist of every graphite name matching this pattern (like Graphite's `mqe.*.*.cpu`)

In order to accomplish this, various changes were made to API-related behavior. These changes are reverse-compatible with the following exception: the special metric name `"$graphite"` is assumed by the default API type to refer to a graphite metric name, rather than an MQE metric name.

In order to index graphite metrics, the API object must be cast to an `api.GraphiteStore` interface, and then the `.AddGraphiteMetric(metric) error` method should be called for each Graphite metric encountered. They're stored in a table with a TTL of about 8 hours.

TODO: integration tests?