### PR TITLE
Improvement to Autocomplete Performance

### DIFF
--- a/main/static/autocom.js
+++ b/main/static/autocom.js
@@ -304,14 +304,14 @@ function Autocom(input) {
 				tooltipSuppress = true;
 				refresh();
 				return;
-			} else if (e.keyCode == 38) { // UP
+			} else if (e.keyCode == 38 && !e.shiftKey) { // UP
 				e.preventDefault();
 				tooltipState.index--;
 				if (tooltipState.index < 0) {
 					tooltipState.index = tooltipState.words.length-1;
 				}
 				return;
-			} else if (e.keyCode == 40) { // DOWN
+			} else if (e.keyCode == 40 & &!e.shiftKey) { // DOWN
 				e.preventDefault();
 				tooltipState.index++;
 				if (tooltipState.index >= tooltipState.words.length) {
@@ -320,7 +320,6 @@ function Autocom(input) {
 				return;
 			} else if (
 					e.keyCode == 27 || // ESC
-					e.keyCode == 16 // shift
 			) {
 				tooltipSuppress = true;
 				return;

--- a/main/static/autocom.js
+++ b/main/static/autocom.js
@@ -373,12 +373,12 @@ function Autocom(input) {
 			// If it's not currently active, then become active.
 			tooltipState = {
 				active: true,
-				index: 0,
+				index: tooltipState.index || 0,
 				words: result.words,
 				at: result.at,
 			};
 			if (tooltipState.index >= tooltipState.words.length) {
-				tooltipState.index = 0;
+				tooltipState.index = tooltipState.active ? tooltipState.index : 0;
 			}
 			generateTooltipContents(elements.tooltip, tooltipState.words, tooltipState.index, completeSelect);
 			

--- a/main/static/autocom.js
+++ b/main/static/autocom.js
@@ -114,9 +114,25 @@ function scoreTable(table, A, B, i, j, config) {
 	return table[i][j] = Math.max( advanceI, advanceJ );
 }
 
+
+function serializeConfig(config) {
+	var configs = [];
+	for (var i in config) {
+		configs.push(i + ": " + config[i]);
+	}
+	configs.sort();
+	return configs.join(", ");
+}
+
+var scoreAgainstCache = {};
+
 // scoreAgainst computes how well the "letters" match "word" (this is not commutative).
 // The config contains parameters for the algorithm.
 function scoreAgainst(letters, word, config) {
+	var cacheIndex = letters + "||" + word + "||" + serializeConfig(config);
+	if (scoreAgainstCache[cacheIndex]) {
+		return scoreAgainstCache[cacheIndex];
+	}
 	var table = [];
 	for (var i = 0; i < letters.length; i++) {
 		table[i] = [];
@@ -125,7 +141,7 @@ function scoreAgainst(letters, word, config) {
 		}
 	}
 	var s = scoreTable(table, letters, word, 0, 0, config);
-	return s;
+	return scoreAgainstCache[cacheIndex] = s;
 }
 
 // generateElements creates the elements needed by an Autocom, based on the given input.
@@ -194,10 +210,11 @@ function predictReady(input, prefixPattern, continuePattern) {
 
 // filterCandidates finds a list of candidates, pursuant to the config, among the options
 // from the given prefix `word`.
-function filterCandidates(word, options, config) {
+function filterCandidates(word, givenOptions, config) {
 	// Compute the scores for each word.
-	for (var i = 0; i < options.length; i++) {
-		options[i] = { word: options[i], score: scoreAgainst(word, options[i], config) };
+	var options = [];
+	for (var i = 0; i < givenOptions.length; i++) {
+		options[i] = { word: givenOptions[i], score: scoreAgainst(word, givenOptions[i], config) };
 	}
 	options.sort(function(a, b) {
 		return b.score - a.score;
@@ -232,8 +249,8 @@ function moveTooltip(elements, offsetX, offsetY) {
 	// Resize the shadower:
 	elements.shadow.style.width = getComputedStyle(elements.input).width;
 	// Fill prior and after with text:
-	elements.prior.innerHTML = elements.input.value.substring(0, elements.input.selectionStart);
-	elements.after.innerHTML = elements.input.value.substring(elements.input.selectionStart);
+	elements.prior.textContent = elements.input.value.substring(0, elements.input.selectionStart);
+	elements.after.textContent = elements.input.value.substring(elements.input.selectionStart);
 	// Use marker's location to reposition tooltip:
 	elements.tooltip.style.left = Math.floor(elements.input.offsetLeft + elements.marker.offsetLeft + offsetX) + "px";
 	elements.tooltip.style.top = Math.floor(elements.input.offsetTop + elements.marker.offsetTop - elements.input.scrollTop + offsetY) + "px";
@@ -343,16 +360,14 @@ function Autocom(input) {
 		insertWord(input, tooltipState.at, tooltipState.words[index]);
 		refresh();
 	}
-
 	function renderTooltip() {
 		moveTooltip(elements, self.tooltipX, self.tooltipY);
-
 		var result = predict(predictReady(input, self.prefixPattern, self.continuePattern), self.options.slice(0), self.config);
 		if (result && !tooltipSuppress && document.activeElement === input) {
 			// If it's not currently active, then become active.
 			tooltipState = {
 				active: true,
-				index: tooltipState.active ? tooltipState.index : 0,
+				index: 0,
 				words: result.words,
 				at: result.at,
 			};

--- a/main/static/autocom.js
+++ b/main/static/autocom.js
@@ -373,12 +373,12 @@ function Autocom(input) {
 			// If it's not currently active, then become active.
 			tooltipState = {
 				active: true,
-				index: tooltipState.index || 0,
+				index: tooltipState.active ? tooltipState.index : 0,
 				words: result.words,
 				at: result.at,
 			};
 			if (tooltipState.index >= tooltipState.words.length) {
-				tooltipState.index = tooltipState.active ? tooltipState.index : 0;
+				tooltipState.index = 0;
 			}
 			generateTooltipContents(elements.tooltip, tooltipState.words, tooltipState.index, completeSelect);
 			

--- a/main/static/autocom.js
+++ b/main/static/autocom.js
@@ -284,9 +284,13 @@ function generateTooltipContents(tooltip, words, index, selectedCallback) {
 }
 
 // Inserts `word` at the location specified by `at` inside of `input`.
-function insertWord(input, at, word) {
+function insertWord(input, at, word, supressCallback) {
 	input.value = input.value.substring(0, at.from) + word + input.value.substring(at.to);
-	input.selectionStart = input.selectionEnd = at.from + word.length;
+	setTimeout(function() {
+		input.focus();
+		input.selectionStart = input.selectionEnd = at.from + word.length;
+		supressCallback();
+	}, 1);
 }
 
 
@@ -312,12 +316,16 @@ function Autocom(input) {
 	var tooltipState = {active: false, index: 0};
 	var tooltipSuppress = false;
 
+	function supressCallback() {
+		tooltipSuppress = true;
+	}
+
 	function keyPress(e) {
 		if (tooltipState.active && !tooltipSuppress) {
 			if (e.keyCode == 9 || e.keyCode == 13) { // TAB or ENTER
 				// Tab
 				e.preventDefault();
-				insertWord(input, tooltipState.at, tooltipState.words[tooltipState.index]);
+				insertWord(input, tooltipState.at, tooltipState.words[tooltipState.index], supressCallback);
 				tooltipSuppress = true;
 				refresh();
 				return;
@@ -328,16 +336,14 @@ function Autocom(input) {
 					tooltipState.index = tooltipState.words.length-1;
 				}
 				return;
-			} else if (e.keyCode == 40 & &!e.shiftKey) { // DOWN
+			} else if (e.keyCode == 40 && !e.shiftKey) { // DOWN
 				e.preventDefault();
 				tooltipState.index++;
 				if (tooltipState.index >= tooltipState.words.length) {
 					tooltipState.index = 0;
 				}
 				return;
-			} else if (
-					e.keyCode == 27 || // ESC
-			) {
+			} else if (e.keyCode == 27) { // ESC
 				tooltipSuppress = true;
 				return;
 			}
@@ -357,7 +363,7 @@ function Autocom(input) {
 	input.addEventListener("keydown", keyPress, false);
 
 	function completeSelect(index) {
-		insertWord(input, tooltipState.at, tooltipState.words[index]);
+		insertWord(input, tooltipState.at, tooltipState.words[index], supressCallback);
 		refresh();
 	}
 	function renderTooltip() {


### PR DESCRIPTION
When there are a lot of alternatives, the autcomplete performance starts to suffer. Adding a cache should help this a little bit.

Some related changes were made to how shift behavior works (now shift+arrows will suppress the tooltip, but not shift+letter which made it impossible to autocomplete things with capital letters).