### PR TITLE
Change layout for describe

### DIFF
--- a/main/static/index.html
+++ b/main/static/index.html
@@ -91,11 +91,12 @@
         <table ng-show="isTabular() && queryResult.name != 'describe'" class="table table-striped">
           <tr ng-repeat="row in queryResult.body"><td>{{row}}</td></tr>
         </table>
-        <div ng-show="isTabular() && queryResult.name == 'describe'">
+        <div ng-show="isTabular() && queryResult.name == 'describe'" class='describe-container'>
           <table ng-repeat="(key, list) in queryResult.body" class="table table-striped table-column">
             <tr><th>{{key}}</th></tr>
             <tr ng-repeat="value in list track by $index"><td>{{value}}</td></tr>
           </table>
+          <div style="clear:both;"></div>
         </div>
         <div>{{ (queryResult || "").trim() }}</div>
       </div>

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -31,10 +31,28 @@ textarea.queryinput {
   font-family: Consolas, monospace;
 }
 
+.describe-container {
+  white-space: nowrap;
+  overflow-x: scroll;
+  max-height: 500px;
+}
+
+::-webkit-scrollbar {
+    -webkit-appearance: none;
+    background: #EEE;
+    width: 7px;
+    height: 7px;
+}
+::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0,0,0,.5);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
 .table-column {
+  vertical-align: top;
   display: inline-block;
   margin-right: 10px;
-  float: left;
   width: auto;
   min-width: 100px;
   border-left: 1px solid #DDD;

--- a/main/static/style.css
+++ b/main/static/style.css
@@ -33,7 +33,7 @@ textarea.queryinput {
 
 .describe-container {
   white-space: nowrap;
-  overflow-x: scroll;
+  overflow-x: auto;
   max-height: 500px;
 }
 


### PR DESCRIPTION
When there were lots of tags, the columns would layout in a way that was very difficult to read and understand.

This change places the columns from a `describe ...` query into a box of fixed maximum size, showing scrollbars when its contents can't all be shown at once.