### PR TITLE
Add warning on embed UI when series limit is reached

### DIFF
--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -26,6 +26,7 @@
   <div class="metrics-link">
     <a ng-href="{{metricsURL}}" target="_blank">See on metrics indexer</a>
   </div>
+  <div class="limit-warning" ng-show="totalResult > maxResult">Embedded view is only rendering {{ maxResult }} results of {{ totalResult }} total.</div>
 </div>
 </body>
 </html>

--- a/main/static/style_embed.css
+++ b/main/static/style_embed.css
@@ -46,3 +46,10 @@ body {
   top:0;
   padding: 8px;
 }
+
+.limit-warning {
+  position: absolute;
+  left: 5px;
+  top: 5px;
+  font-weight: bold;
+}


### PR DESCRIPTION
Only 200 series are ever shown, even if more are returned. This is true on both the main UI view and the embedded view.

However, when the limit is enforced, the main UI view got a message, while the embedded view did not.

This PR adds a notice to embedded views when there are more than 200 series (but only the 200 are shown).

Before:
<img width="612" alt="screen shot 2015-07-28 at 1 27 32 pm" src="https://cloud.githubusercontent.com/assets/6179181/8942853/97278d0c-352c-11e5-811f-26a443bcb6e2.png">
After:
<img width="608" alt="screen shot 2015-07-28 at 1 28 18 pm" src="https://cloud.githubusercontent.com/assets/6179181/8942858/9e96646e-352c-11e5-9f11-f39e2d141dba.png">
