### PR TITLE
Pixel-based margins for chart area

### DIFF
--- a/main/static/script.js
+++ b/main/static/script.js
@@ -65,13 +65,24 @@ module.directive("googleChart", function($chartWaiting, $timeout, $windowSize) {
         }
         render();
       });
-
+      function unitless(value) {
+        if (typeof value !== "string") {
+          return value;
+        }
+        if (value.substring(value.length-2) == "px") {
+          return value.substring(0, value.length-2);
+        }
+        if (value.substring(value.length-1) == "%") {
+          return value.substring(0, value.length-1);
+        }
+        return value;
+      }
       function fixUnits(value , total) {
         if (typeof value !== "string") {
           return value;
         }
         if (value.substring(value.length-2) == "px") {
-          var valuePixels = value.substring(0, value.length-2);
+          var valuePixels = unitless(value);
           return valuePixels / total * 100 + "%";
         }
         return value;
@@ -100,10 +111,8 @@ module.directive("googleChart", function($chartWaiting, $timeout, $windowSize) {
             google.visualization.events.addListener(chart, "ready", function() {
               scope.$apply(function() { $chartWaiting.dec(); });
             });
-            var totalWidth = getComputedStyle(element[0]).width;
-            totalWidth = totalWidth.substring(0, totalWidth.length-2) * 1;
-            var totalHeight = getComputedStyle(element[0]).height;
-            totalHeight = totalHeight.substring(0, totalHeight.length-2) * 1;
+            var totalWidth = unitless(getComputedStyle(element[0]).width) * 1;
+            var totalHeight = unitless(getComputedStyle(element[0]).height) * 1;
             option = deepCopy(option);
             if (option && option.chartArea) {
               var area = option.chartArea;
@@ -114,10 +123,10 @@ module.directive("googleChart", function($chartWaiting, $timeout, $windowSize) {
               var width = fixUnits(area.width, totalWidth);
               var height = fixUnits(area.height, totalHeight);
               if (right !== undefined) {
-                width = (100 - left.substring(0, left.length-1) - right.substring(0, right.length-1)) + "%";
+                width = (100 - unitless(left) - unitless(right)) + "%";
               }
               if (bottom !== undefined) {
-                height = (100 - top.substring(0, top.length-1) - bottom.substring(0, bottom.length-1)) + "%";
+                height = (100 - unitless(top) - unitless(bottom)) + "%";
               }
               option.chartArea = {
                 left:   left,

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -140,7 +140,6 @@ module.directive("googleChart", function($chartWaiting, $timeout, $windowSize) {
                 width:  width,
                 height: height
               };
-              console.log(option.chartArea);
             }
             chart.draw(data, option);
           }

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -100,8 +100,10 @@ module.directive("googleChart", function($chartWaiting, $timeout, $windowSize) {
             google.visualization.events.addListener(chart, "ready", function() {
               scope.$apply(function() { $chartWaiting.dec(); });
             });
-            var totalWidth = window.innerWidth;
-            var totalHeight = window.innerHeight - 30;
+            var totalWidth = getComputedStyle(element[0]).width;
+            totalWidth = totalWidth.substring(0, totalWidth.length-2) * 1;
+            var totalHeight = getComputedStyle(element[0]).height;
+            totalHeight = totalHeight.substring(0, totalHeight.length-2) * 1;
             option = deepCopy(option);
             if (option && option.chartArea) {
               var area = option.chartArea;
@@ -319,7 +321,7 @@ module.controller("commonCtrl", function(
   $scope.selectOptions = {
     legend:    {position: "bottom"},
     title:     $location.search()["title"],
-    chartArea: {left: "10px", right:"25px", top: "5px", bottom: "30px"},
+    chartArea: {left: "10px", right:"25px", top: "15px", bottom: "60px"},
     series:    null,
     vAxes: {
       0: {title: ""},

--- a/main/static/style_embed.css
+++ b/main/static/style_embed.css
@@ -29,9 +29,8 @@ body {
   display:    block;
   position: absolute;
   background: #EEE;
-  margin-top: 30px;
   width:      100%;
-  top: 0;
+  top: 30px;
   bottom: 0;
 }
 

--- a/main/static/style_embed.css
+++ b/main/static/style_embed.css
@@ -27,9 +27,12 @@ body {
 
 .metric-chart {
   display:    block;
+  position: absolute;
   background: #EEE;
+  margin-top: 30px;
   width:      100%;
-  height:     100%;
+  top: 0;
+  bottom: 0;
 }
 
 .fullscreen {

--- a/main/static/style_embed.css
+++ b/main/static/style_embed.css
@@ -30,7 +30,7 @@ body {
   position: absolute;
   background: #EEE;
   width:      100%;
-  top: 30px;
+  top: 23px;
   bottom: 0;
 }
 


### PR DESCRIPTION
Previously, the percentage-based chart areas meant that there'd be excessive or insufficient margins around charts depending on their size.

This PR allows `chartArea` to be given as left: right: top: bottom: in pixels, rather than left: top: width: height: in percents.

It's configurable by adding the URL parameters `marginleft`, `marginright`, `margintop`, or `marginbottom` as either percentages or pixels (such as `marginleft=50%25` or `marginleft=15px`)