### PR TITLE
Dynamic resolution adjustment

### DIFF
--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -341,7 +341,7 @@ func (b blueflood) DecideTimerange(start int64, end int64, resolution int64) (ap
 		return answer, nil
 	}
 	for _, resolution := range Resolutions {
-		if timerange, err := api.NewSnappedTimerange(start, end, int64(resolution.duration/time.Millisecond)); err == nill && timerange.Slots() <= slotLimit {
+		if timerange, err := api.NewSnappedTimerange(start, end, int64(resolution.duration/time.Millisecond)); err == nil && timerange.Slots() <= slotLimit {
 			return timerange, nil
 		}
 	}

--- a/api/backend/multibackend.go
+++ b/api/backend/multibackend.go
@@ -42,6 +42,10 @@ func (m *sequentialMultiBackend) FetchMultipleSeries(request api.FetchMultipleRe
 	}, nil
 }
 
+func (m *sequentialMultiBackend) DecideTimerange(start int64, end int64, userResolutionMillis int64) (api.Timerange, error) {
+	return m.Backend.DecideTimerange(start, end, userResolutionMillis)
+}
+
 type parallelMultiBackend struct {
 	limit   int
 	tickets chan struct{}
@@ -134,4 +138,8 @@ func (m *parallelMultiBackend) FetchMultipleSeries(request api.FetchMultipleRequ
 		Series:    resultSeries,
 		Timerange: request.Timerange,
 	}, nil
+}
+
+func (m *parallelMultiBackend) DecideTimerange(start int64, end int64, userResolutionMillis int64) (api.Timerange, error) {
+	return m.Backend.DecideTimerange(start, end, userResolutionMillis)
 }

--- a/api/backend/multibackend_test.go
+++ b/api/backend/multibackend_test.go
@@ -18,6 +18,10 @@ func (b fakeBackend) FetchSingleSeries(request api.FetchSeriesRequest) (api.Time
 	return api.Timeseries{}, nil
 }
 
+func (b fakeBackend) DecideTimerange(start int64, end int64, resolution int64) (api.Timerange, error) {
+	return api.NewSnappedTimerange(start, end, resolution)
+}
+
 type Suite struct {
 	backend      fakeBackend
 	waitGroup    sync.WaitGroup

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -66,7 +66,6 @@ func main() {
 		API:        apiInstance,
 		Backend:    backend,
 		FetchLimit: 1000,
-		SlotLimit:  5000,
 		Registry:   registry.Default(),
 	})
 }

--- a/query/command.go
+++ b/query/command.go
@@ -135,20 +135,34 @@ func (cmd *DescribeMetricsCommand) Name() string {
 
 // Execute performs the query represented by the given query string, and returs the result.
 func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error) {
-	timerange, err := api.NewSnappedTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
-	if err != nil {
-		return nil, err
-	}
 	slotLimit := context.SlotLimit
 	defaultLimit := 1000
 	if slotLimit == 0 {
 		slotLimit = defaultLimit // the default limit
 	}
-	if timerange.Slots() > slotLimit {
-		return nil, function.NewLimitError(
-			"Requested number of data points exceeds the configured limit",
-			timerange.Slots(), slotLimit)
+	resolutions := []int64{
+		cmd.context.Resolution,
+		// Try each of these resolutions in order
+		// Use the first that's fine-grained enough, if the user-specified value fails
+		30 * 1000,
+		5 * 60 * 1000,
+		20 * 60 * 1000,
+		60 * 60 * 1000,
+		240 * 60 * 1000,
+		1440 * 60 * 1000,
 	}
+	var timerange api.Timerange
+	var err error
+	for _, resolution := range resolutions {
+		timerange, err = api.NewSnappedTimerange(cmd.context.Start, cmd.context.End, resolution)
+		if err != nil {
+			return nil, err
+		}
+		if timerange.Slots() <= slotLimit {
+			break
+		}
+	}
+	fmt.Printf("Picked a timerange: %+v\n", timerange)
 	hasTimeout := context.Timeout != 0
 	var cancellable api.Cancellable
 	if hasTimeout {

--- a/query/command.go
+++ b/query/command.go
@@ -138,7 +138,6 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("Picked a timerange: %+v\n", timerange)
 	hasTimeout := context.Timeout != 0
 	var cancellable api.Cancellable
 	if hasTimeout {

--- a/query/command.go
+++ b/query/command.go
@@ -146,9 +146,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		// Use the first that's fine-grained enough, if the user-specified value fails
 		30 * 1000,
 		5 * 60 * 1000,
-		20 * 60 * 1000,
 		60 * 60 * 1000,
-		240 * 60 * 1000,
 		1440 * 60 * 1000,
 	}
 	var timerange api.Timerange
@@ -158,7 +156,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		if err != nil {
 			return nil, err
 		}
-		if timerange.Slots() <= slotLimit {
+		if timerange.Slots() <= 3000 {
 			break
 		}
 	}

--- a/query/command.go
+++ b/query/command.go
@@ -34,7 +34,6 @@ type ExecutionContext struct {
 	Timeout    time.Duration     // optional
 	Profiler   *inspect.Profiler // optional
 	Registry   function.Registry // optional
-	SlotLimit  int               // optional (0 => default 1000)
 }
 
 // Command is the final result of the parsing.

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -435,7 +435,6 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}},
-		{"select series_1 from -1000d to now resolution 30s", true, api.SeriesList{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		expected := test.expected

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -31,6 +31,10 @@ var emptyGraphiteName = api.GraphiteMetric("")
 
 type fakeApiBackend struct{}
 
+func (b fakeApiBackend) DecideTimerange(start int64, end int64, resolution int64) (api.Timerange, error) {
+	return api.NewSnappedTimerange(start, end, resolution)
+}
+
 func (f fakeApiBackend) FetchSingleSeries(request api.FetchSeriesRequest) (api.Timeseries, error) {
 	metricMap := map[api.MetricKey][]api.Timeseries{
 		"series_1": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}},

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -82,6 +82,10 @@ func (f fakeBackend) FetchSingleSeries(request api.FetchSeriesRequest) (api.Time
 	return api.Timeseries{}, nil
 }
 
+func (f fakeBackend) DecideTimerange(start int64, end int64, resolution int64) (api.Timerange, error) {
+	return api.NewSnappedTimerange(start, end, resolution)
+}
+
 func TestProfilerIntegration(t *testing.T) {
 	myAPI := fakeAPI{
 		tagSets: map[string][]api.TagSet{"A": []api.TagSet{

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -30,6 +30,10 @@ import (
 
 type movingAverageBackend struct{}
 
+func (b movingAverageBackend) DecideTimerange(start int64, end int64, resolution int64) (api.Timerange, error) {
+	return api.NewSnappedTimerange(start, end, resolution)
+}
+
 func (b movingAverageBackend) FetchSingleSeries(r api.FetchSeriesRequest) (api.Timeseries, error) {
 	t := r.Timerange
 	values := []float64{9, 2, 1, 6, 4, 5}


### PR DESCRIPTION
If the given query in time requires more than 3000 points, the resolution will be dynamically lowered (they're tried in the order `user-choice`, `30s`, `5m`, `1hr`, `1d`).

3000 points at 30s: 1 day
3000 points at 5m: 10d
3000 points at 1hr: 120 days

TODO: fully integration with blueflood; a `blueflood` interface method `DecideTimerange` is used to calculate the timerange with its resolution. However, it uses hard-coded magic numbers to describe the available options instead of the defined blueflood resolutions.

TODO: configure the slot limit (currently hard-coded as 3000)
