### PR TITLE
Show error when 0 series are returned

### DIFF
--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -17,7 +17,8 @@
     <div class="alert alert-info"   ng-show="screenState() == 'rendering'">Rendering chart...</div>
     <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
   </div>
-  <google-chart ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select'"
+  <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">Query resulted in 0 series</div>
+  <google-chart ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()"
 		class="metric-chart"
 		data="selectResult"
 		option="selectOptions"

--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -18,7 +18,8 @@
     <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
   </div>
   <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">{{ queryEmptyMessage }}</div>
-  <google-chart ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()"
+  <google-chart
+    ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()"
 		class="metric-chart"
 		data="selectResult"
 		option="selectOptions"

--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -17,7 +17,7 @@
     <div class="alert alert-info"   ng-show="screenState() == 'rendering'">Rendering chart...</div>
     <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
   </div>
-  <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">Query resulted in 0 series</div>
+  <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">{{ queryEmptyMessage }}</div>
   <google-chart ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()"
 		class="metric-chart"
 		data="selectResult"

--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -15,7 +15,9 @@
   <div ng-show="screenState() != 'rendered'">
     <div class="alert alert-info"   ng-show="screenState() == 'loading'">Waiting for response...</div>
     <div class="alert alert-info"   ng-show="screenState() == 'rendering'">Rendering chart...</div>
-    <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
+    <div class="alert alert-danger" ng-show="screenState() == 'error'">
+      <div class="alert alert-danger-message">{{(queryResult.message || "").trim()}}</div>
+    </div>
   </div>
   <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">{{ queryEmptyMessage }}</div>
   <google-chart

--- a/main/static/index.html
+++ b/main/static/index.html
@@ -52,9 +52,9 @@
       <div class="alert alert-info"   ng-show="screenState() == 'rendering'">Rendering chart...</div>
       <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
     </div>
-    <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">Query resulted in 0 series</div>
+    <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">{{ queryEmptyMessage }}</div>
 
-    <div ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select'">
+    <div ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()">
       <div class="col-xs-10">
         Query took <b>{{ elapsedMs / 1000 | number }}</b> seconds. <b>{{ totalResult }}</b> Series returned.
         <b ng-show="totalResult > maxResult">UI is only rendering {{ maxResult }} results.</b>

--- a/main/static/index.html
+++ b/main/static/index.html
@@ -52,6 +52,7 @@
       <div class="alert alert-info"   ng-show="screenState() == 'rendering'">Rendering chart...</div>
       <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
     </div>
+    <div class="alert alert-danger" ng-show="screenState() == 'rendered' && queryResultIsEmpty()">Query resulted in 0 series</div>
 
     <div ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select'">
       <div class="col-xs-10">
@@ -63,7 +64,7 @@
       </div>
     </div>
     <div
-      ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select'"
+      ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()"
       class="col-xs-12">
       <google-chart
         class="metric-chart"

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -318,7 +318,6 @@ module.controller("commonCtrl", function(
     if ($scope.selectResult) {
       for (var i = 0; i < queryResult.body.length; i++) {
         // Each of these is a list of series
-        console.log("?", queryResult.body[i].series.length);
         $scope.totalResult += queryResult.body[i].series.length;
       }
     }

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -277,6 +277,18 @@ module.controller("commonCtrl", function(
       1: {title: ""}
     }
   };
+  $scope.queryResultIsEmpty = function() {
+    var result = $scope.queryResult;
+    if (!result || result.name != "select") {
+      return false;
+    }
+    for (var i = 0; i < result.body.length; i++) {
+      if (result.body[i].series.length != 0) {
+        return false;
+      }
+    }
+    return true;
+  };
   $scope.$watch("inputModel.renderType", function(newValue) {
     if (newValue === "area") {
       $scope.selectOptions.isStacked = true;

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -283,11 +283,16 @@ module.controller("commonCtrl", function(
       return false;
     }
     for (var i = 0; i < result.body.length; i++) {
-      if (result.body[i].series.length != 0) {
-        return false;
+      if (result.body[i].series.length == 0) {
+        if (result.body.length == 1) {
+          $scope.queryEmptyMessage = "the query resulted in 0 series";
+        } else {
+          $scope.queryEmptyMessage = "expression " + (i+1) + " (of " + result.body.length + ") resulted in 0 series";
+        }
+        return true;
       }
     }
-    return true;
+    return false;
   };
   $scope.$watch("inputModel.renderType", function(newValue) {
     if (newValue === "area") {
@@ -313,6 +318,7 @@ module.controller("commonCtrl", function(
     if ($scope.selectResult) {
       for (var i = 0; i < queryResult.body.length; i++) {
         // Each of these is a list of series
+        console.log("?", queryResult.body[i].series.length);
         $scope.totalResult += queryResult.body[i].series.length;
       }
     }

--- a/main/static/style_embed.css
+++ b/main/static/style_embed.css
@@ -20,18 +20,27 @@ body {
 	overflow-y: hidden;
 }
 
-.alert-danger {
+.alert-danger-message {
   position: absolute;
-  width: 100%;
-  margin-top: -25px;
+
   top: 50%;
-  height: 50px;
-  line-height: 50px;
+  transform: translateY(-50%);
+
+  width: 100%;
   padding-top: 0;
   padding-bottom: 0;
+
   white-space: pre;
   font-family: Consolas, monospace;
   text-align: center;
+}
+
+.alert-danger {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .metric-chart {

--- a/main/static/style_embed.css
+++ b/main/static/style_embed.css
@@ -21,8 +21,17 @@ body {
 }
 
 .alert-danger {
+  position: absolute;
+  width: 100%;
+  margin-top: -25px;
+  top: 50%;
+  height: 50px;
+  line-height: 50px;
+  padding-top: 0;
+  padding-bottom: 0;
   white-space: pre;
   font-family: Consolas, monospace;
+  text-align: center;
 }
 
 .metric-chart {


### PR DESCRIPTION
Previously there was no good indicator that no series were returned. Now there is.

An error will show for both the UI view and the embed view.

If you do a query with multiple expressions (ie `select X, Y from -10m to now`) then if either `X` or `Y` result in 0 expressions, the error will be shown. 

@jeeyoungk @achow 