### PR TITLE
Configure display timezones

### DIFF
--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -17,6 +17,7 @@
     <div class="alert alert-info"   ng-show="screenState() == 'rendering'">Rendering chart...</div>
     <div class="alert alert-danger" ng-show="screenState() == 'error'">{{(queryResult.message || "").trim()}}</div>
   </div>
+  <div>{{ displayTimezone }}</div>
   <google-chart ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select'"
 		class="metric-chart"
 		data="selectResult"

--- a/main/static/index.html
+++ b/main/static/index.html
@@ -101,6 +101,7 @@
         <div>{{ (queryResult || "").trim() }}</div>
       </div>
     </div>
+    <div>Timezone {{ displayTimezone }}</div>
   </div>
 </div>
 </body>

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -509,6 +509,7 @@ var timezones = {
   MST: -7,
   PDT: -7,
   PST: -8,
+  JST: +9,
   UTC: 0,
   ET: {
     D: "EDT",
@@ -573,7 +574,6 @@ function getOffset(zone) {
 }
 
 function dateFromIndex(index, timerange, timezone) {
-  console.log(timezone);
   if (!parseFloat(timezone)) {
     timezone = getOffset(timezone);
   }

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -525,6 +525,213 @@ var timezones = {
   },
   LOCAL: -(new Date().getTimezoneOffset() / 60)
 };
+var extraTimezones = {
+  "ACDT": "+10.5", // Australian Central Daylight Saving Time
+  "ACST": "+09.5", // Australian Central Standard Time
+  "ACT": "−05", // Acre Time
+  "ACT": "+08", // ASEAN Common Time
+  "ADT": "−03", // Atlantic Daylight Time
+  "AEDT": "+11", // Australian Eastern Daylight Saving Time
+  "AEST": "+10", // Australian Eastern Standard Time
+  "AFT": "+04.5", // Afghanistan Time
+  "AKDT": "−08", // Alaska Daylight Time
+  "AKST": "−09", // Alaska Standard Time
+  "AMST": "−03", // Amazon Summer Time (Brazil)[1]
+  "AMST": "+05", // Armenia Summer Time
+  "AMT": "−04", // Amazon Time (Brazil)[2]
+  "AMT": "+04", // Armenia Time
+  "ART": "−03", // Argentina Time
+  "AST": "+03", // Arabia Standard Time
+  "AST": "−04", // Atlantic Standard Time
+  "AWDT": "+09", // Australian Western Daylight Time
+  "AWST": "+08", // Australian Western Standard Time
+  "AZOST": "−01", // Azores Standard Time
+  "AZT": "+04", // Azerbaijan Time
+  "BDT": "+08", // Brunei Time
+  "BDT": "+06", // Bangladesh Daylight Time (Bangladesh Daylight saving time keeps UTC+06 offset) [3]
+  "BIOT": "+06", // British Indian Ocean Time
+  "BIT": "−12", // Baker Island Time
+  "BOT": "−04", // Bolivia Time
+  "BRST": "−02", // Brasilia Summer Time
+  "BRT": "−03", // Brasilia Time
+  "BST": "+06", // Bangladesh Standard Time
+  "BST": "+11", // Bougainville Standard Time[4]
+  "BST": "+01", // British Summer Time (British Standard Time from Feb 1968 to Oct 1971)
+  "BTT": "+06", // Bhutan Time
+  "CAT": "+02", // Central Africa Time
+  "CCT": "+06.5", // Cocos Islands Time
+  "CDT": "−05", // Central Daylight Time (North America)
+  "CDT": "−04", // Cuba Daylight Time[5]
+  "CEDT": "+02", // Central European Daylight Time
+  "CEST": "+02", // Central European Summer Time (Cf. HAEC)
+  "CET": "+01", // Central European Time
+  "CHADT": "+13.75", // Chatham Daylight Time
+  "CHAST": "+12.75", // Chatham Standard Time
+  "CHOT": "+08", // Choibalsan
+  "ChST": "+10", // Chamorro Standard Time
+  "CHUT": "+10", // Chuuk Time
+  "CIST": "−08", // Clipperton Island Standard Time
+  "CIT": "+08", // Central Indonesia Time
+  "CKT": "−10", // Cook Island Time
+  "CLST": "−03", // Chile Summer Time
+  "CLT": "−04", // Chile Standard Time
+  "COST": "−04", // Colombia Summer Time
+  "COT": "−05", // Colombia Time
+  "CST": "−06", // Central Standard Time (North America)
+  "CST": "+08", // China Standard Time
+  "CST": "+09.5", // Central Standard Time (Australia)
+  "CST": "+10.5", // Central Summer Time (Australia)
+  "CST": "−05", // Cuba Standard Time
+  "CT": "+08", // China time
+  "CVT": "−01", // Cape Verde Time
+  "CWST": "+08.75", // Central Western Standard Time (Australia) unofficial
+  "CXT": "+07", // Christmas Island Time
+  "DAVT": "+07", // Davis Time
+  "DDUT": "+10", // Dumont d'Urville Time
+  "DFT": "+01", // AIX specific equivalent of Central European Time[6]
+  "EASST": "−05", // Easter Island Standard Summer Time
+  "EAST": "−06", // Easter Island Standard Time
+  "EAT": "+03", // East Africa Time
+  "ECT": "−04", // Eastern Caribbean Time (does not recognise DST)
+  "ECT": "−05", // Ecuador Time
+  "EDT": "−04", // Eastern Daylight Time (North America)
+  "EEDT": "+03", // Eastern European Daylight Time
+  "EEST": "+03", // Eastern European Summer Time
+  "EET": "+02", // Eastern European Time
+  "EGST": "+00", // Eastern Greenland Summer Time
+  "EGT": "−01", // Eastern Greenland Time
+  "EIT": "+09", // Eastern Indonesian Time
+  "EST": "−05", // Eastern Standard Time (North America)
+  // "EST": "+10", // Eastern Standard Time (Australia) - aliases with American Eastern Standard Time
+  "FET": "+03", // Further-eastern European Time
+  "FJT": "+12", // Fiji Time
+  "FKST": "−03", // Falkland Islands Standard Time
+  "FKST": "−03", // Falkland Islands Summer Time
+  "FKT": "−04", // Falkland Islands Time
+  "FNT": "−02", // Fernando de Noronha Time
+  "GALT": "−06", // Galapagos Time
+  "GAMT": "−09", // Gambier Islands
+  "GET": "+04", // Georgia Standard Time
+  "GFT": "−03", // French Guiana Time
+  "GILT": "+12", // Gilbert Island Time
+  "GIT": "−09", // Gambier Island Time
+  "GMT": "", // Greenwich Mean Time
+  "GST": "−02", // South Georgia and the South Sandwich Islands
+  "GST": "+04", // Gulf Standard Time
+  "GYT": "−04", // Guyana Time
+  "HADT": "−09", // Hawaii-Aleutian Daylight Time
+  "HAEC": "+02", // Heure Avancée d'Europe Centrale francised name for CEST
+  "HAST": "−10", // Hawaii-Aleutian Standard Time
+  "HKT": "+08", // Hong Kong Time
+  "HMT": "+05", // Heard and McDonald Islands Time
+  "HOVT": "+07", // Khovd Time
+  "HST": "−10", // Hawaii Standard Time
+  "ICT": "+07", // Indochina Time
+  "IDT": "+03", // Israel Daylight Time
+  "IOT": "+03", // Indian Ocean Time
+  "IRDT": "+04.5", // Iran Daylight Time
+  "IRKT": "+08", // Irkutsk Time
+  "IRST": "+03.5", // Iran Standard Time
+  "IST": "+05.5", // Indian Standard Time
+  "IST": "+01", // Irish Standard Time[7]
+  "IST": "+02", // Israel Standard Time
+  "JST": "+09", // Japan Standard Time
+  "KGT": "+06", // Kyrgyzstan time
+  "KOST": "+11", // Kosrae Time
+  "KRAT": "+07", // Krasnoyarsk Time
+  "KST": "+09", // Korea Standard Time
+  "LHST": "+10.5", // Lord Howe Standard Time
+  "LHST": "+11", // Lord Howe Summer Time
+  "LINT": "+14", // Line Islands Time
+  "MAGT": "+12", // Magadan Time
+  "MART": "−09.5", // Marquesas Islands Time
+  "MAWT": "+05", // Mawson Station Time
+  "MDT": "−06", // Mountain Daylight Time (North America)
+  "MET": "+01", // Middle European Time Same zone as CET
+  "MEST": "+02", // Middle European Saving Time Same zone as CEST
+  "MHT": "+12", // Marshall Islands
+  "MIST": "+11", // Macquarie Island Station Time
+  "MIT": "−09.5", // Marquesas Islands Time
+  "MMT": "+06.5", // Myanmar Time
+  "MSK": "+03", // Moscow Time
+  // "MST": "+08", // Malaysia Standard Time - aliases with American Mountain Standard Time
+  "MST": "−07", // Mountain Standard Time (North America)
+  // "MST": "+06.5", // Myanmar Standard Time - aliases with American Mountain Standard Time
+  "MUT": "+04", // Mauritius Time
+  "MVT": "+05", // Maldives Time
+  "MYT": "+08", // Malaysia Time
+  "NCT": "+11", // New Caledonia Time
+  "NDT": "−02.5", // Newfoundland Daylight Time
+  "NFT": "+11.5", // Norfolk Time
+  "NPT": "+05.75", // Nepal Time
+  "NST": "−03.5", // Newfoundland Standard Time
+  "NT": "−03.5", // Newfoundland Time
+  "NUT": "−11", // Niue Time
+  "NZDT": "+13", // New Zealand Daylight Time
+  "NZST": "+12", // New Zealand Standard Time
+  "OMST": "+06", // Omsk Time
+  "ORAT": "+05", // Oral Time
+  "PDT": "−07", // Pacific Daylight Time (North America)
+  "PET": "−05", // Peru Time
+  "PETT": "+12", // Kamchatka Time
+  "PGT": "+10", // Papua New Guinea Time
+  "PHOT": "+13", // Phoenix Island Time
+  "PKT": "+05", // Pakistan Standard Time
+  "PMDT": "−02", // Saint Pierre and Miquelon Daylight time
+  "PMST": "−03", // Saint Pierre and Miquelon Standard Time
+  "PONT": "+11", // Pohnpei Standard Time
+  "PST": "−08", // Pacific Standard Time (North America)
+  // "PST": "+08", // Philippine Standard Time - aliases with Pacific Standard Type
+  "PYST": "−03", // Paraguay Summer Time (South America)[8]
+  "PYT": "−04", // Paraguay Time (South America)[9]
+  "RET": "+04", // Réunion Time
+  "ROTT": "−03", // Rothera Research Station Time
+  "SAKT": "+11", // Sakhalin Island time
+  "SAMT": "+04", // Samara Time
+  "SAST": "+02", // South African Standard Time
+  "SBT": "+11", // Solomon Islands Time
+  "SCT": "+04", // Seychelles Time
+  "SGT": "+08", // Singapore Time
+  "SLST": "+05.5", // Sri Lanka Standard Time
+  "SRET": "+11", // Srednekolymsk Time
+  "SRT": "−03", // Suriname Time
+  "SST": "−11", // Samoa Standard Time
+  "SST": "+08", // Singapore Standard Time
+  "SYOT": "+03", // Showa Station Time
+  "TAHT": "−10", // Tahiti Time
+  "THA": "+07", // Thailand Standard Time
+  "TFT": "+05", // Indian/Kerguelen
+  "TJT": "+05", // Tajikistan Time
+  "TKT": "+13", // Tokelau Time
+  "TLT": "+09", // Timor Leste Time
+  "TMT": "+05", // Turkmenistan Time
+  "TOT": "+13", // Tonga Time
+  "TVT": "+12", // Tuvalu Time
+  "UCT": "", // Coordinated Universal Time
+  "ULAT": "+08", // Ulaanbaatar Time
+  "USZ1": "+02", // Kaliningrad Time
+  "UTC": "0", // Coordinated Universal Time
+  "UYST": "−02", // Uruguay Summer Time
+  "UYT": "−03", // Uruguay Standard Time
+  "UZT": "+05", // Uzbekistan Time
+  "VET": "−04.5", // Venezuelan Standard Time
+  "VLAT": "+10", // Vladivostok Time
+  "VOLT": "+04", // Volgograd Time
+  "VOST": "+06", // Vostok Station Time
+  "VUT": "+11", // Vanuatu Time
+  "WAKT": "+12", // Wake Island Time
+  "WAST": "+02", // West Africa Summer Time
+  "WAT": "+01", // West Africa Time
+  "WEDT": "+01", // Western European Daylight Time
+  "WEST": "+01", // Western European Summer Time
+  "WET": "", // Western European Time
+  "WIT": "+07", // Western Indonesian Time
+  "WST": "+08", // Western Standard Time
+  "YAKT": "+09", // Yakutsk Time
+  "YEKT": "+05", // Yekaterinburg Time
+  "Z": "" // Zulu Time (Coordinated Universal Time)
+}
+
 
 function isLocalDaylightSavings() {
   return new Date().getTimezoneOffset() == new Date( new Date().getFullYear(), 6, 1 ).getTimezoneOffset();
@@ -566,7 +773,7 @@ function getOffset(zone) {
   if (zone == "LOCAL") {
     return timezones["LOCAL"];
   }
-  var result = timezones[getZoneName(zone)];
+  var result = timezones[getZoneName(zone)] || extraTimezones[zone];
   if (result === undefined) {
     return 0;
   }


### PR DESCRIPTION
Adds a search parameter `timezone` to control the display timezone. These timezones, among many others, are supported:

* PST
* PDT
* MST
* MDT
* EST 
* EDT
* JST
* UTC

The following "magic" timezones are also supported:
* PT
* MT
* ET

When the display is specified to be one of these, either `_DT` or `_ST` corresponding to the timezone will be selected based on the user's current time of year and locale.

If you want to use a particular UTC offset, just set `location=-7` or `location=14` (to set -7 and +14 offsets respectively). These can also be fractional- `location=7.5` sets a timezone offset of `UTC+07:30`.

In addition, the special timezone `LOCAL` corresponds to local time (it's the default).

Zones are case-insensitive. 

Full support of timezone acronyms is not possible- due to the large number of worldwide timezones there are several with conflicting names. In order to support North American timezones, zones with conflicting names may be omitted.

TODO: make the timezone labels prettier
