### PR TITLE
Fill in lower-resolution data with full resolution data

### DIFF
--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -126,7 +126,8 @@ type sampler struct {
 }
 
 // The amount of time before other resolutions become available
-const availableOnlyFull = time.Hour * 4
+// It's not "const" so that it can be mocked out for tests
+var availableOnlyFull = time.Hour * 4
 
 func (b *blueflood) FetchSingleSeries(request api.FetchSeriesRequest) (api.Timeseries, error) {
 	sampler, ok := samplerMap[request.SampleMethod]
@@ -154,7 +155,7 @@ func (b *blueflood) FetchSingleSeries(request api.FetchSeriesRequest) (api.Times
 
 	// The "now" as an epoch in milliseconds
 	now := time.Now().Unix() * 1000
-	earliestTime := now - int64(AvailableOnlyFull/time.Millisecond)
+	earliestTime := now - int64(availableOnlyFull/time.Millisecond)
 	latestTime := now
 
 	fullResolutionStart := fullResolutionRequest.Timerange.Start()
@@ -237,7 +238,7 @@ func (b *blueflood) fetch(request api.FetchSeriesRequest, queryUrl *url.URL) (qu
 	go func() {
 		resp, err := b.client.Get(queryUrl.String())
 		if err != nil {
-			failure <- api.BackendError{request.Metric, api.FetchIOError, "error while fetching - http connection"}
+			failure <- api.BackendError{request.Metric, api.FetchIOError, fmt.Sprintf("error while fetching - http connection [%s] error: %s", queryUrl.String(), err.Error())}
 			return
 		}
 		defer resp.Body.Close()

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -160,19 +160,19 @@ func (b *blueflood) FetchSingleSeries(request api.FetchSeriesRequest) (api.Times
 			// Clip the timerange
 			newTimerange, err := api.NewSnappedTimerange(request.Timerange.End()-b.config.FullResolutionOverlap*1000, request.Timerange.End(), request.Timerange.ResolutionMillis())
 			if err != nil {
-				log.Debugf("FULL resolution data errored while building timerange: %s", err.Error())
+				log.Infof("FULL resolution data errored while building timerange: %s", err.Error())
 				return nil
 			}
 			fullResolutionRequest.Timerange = newTimerange
 		}
 		fullResolutionQueryURL, err := b.constructURL(fullResolutionRequest, sampler, ResolutionFull)
 		if err != nil {
-			log.Debugf("FULL resolution data errored while building url: %s", err.Error())
+			log.Infof("FULL resolution data errored while building url: %s", err.Error())
 			return nil
 		}
 		fullResolutionParsedResult, err := b.fetch(request, fullResolutionQueryURL)
 		if err != nil {
-			log.Debugf("FULL resolution data errored while parsing result: %s", err.Error())
+			log.Infof("FULL resolution data errored while parsing result: %s", err.Error())
 			return nil
 		}
 		// The higher-resolution data will likely overlap with the requested data.

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -290,48 +290,50 @@ var samplerMap map[api.SampleMethod]sampler = map[api.SampleMethod]sampler{
 		fieldSelector: func(point metricPoint) float64 { return point.Average },
 		bucketSampler: func(bucket []float64) float64 {
 			value := 0.0
-			count := 0.0
+			count := 0
 			for _, v := range bucket {
 				if !math.IsNaN(v) {
 					value += v
 					count++
 				}
 			}
-			return value / count
+			return value / float64(count)
 		},
 	},
 	api.SampleMin: {
 		fieldName:     "min",
 		fieldSelector: func(point metricPoint) float64 { return point.Min },
 		bucketSampler: func(bucket []float64) float64 {
-			value := bucket[0]
+			smallest := math.NaN()
 			for _, v := range bucket {
 				if math.IsNaN(v) {
 					continue
 				}
-				if math.IsNaN(value) {
-					value = v
+				if math.IsNaN(smallest) {
+					smallest = v
+				} else {
+					smallest = math.Min(smallest, v)
 				}
-				value = math.Min(value, v)
 			}
-			return value
+			return smallest
 		},
 	},
 	api.SampleMax: {
 		fieldName:     "max",
 		fieldSelector: func(point metricPoint) float64 { return point.Max },
 		bucketSampler: func(bucket []float64) float64 {
-			value := bucket[0]
+			largest := math.NaN()
 			for _, v := range bucket {
 				if math.IsNaN(v) {
 					continue
 				}
-				if math.IsNaN(value) {
-					value = v
+				if math.IsNaN(largest) {
+					largest = v
+				} else {
+					largest = math.Max(largest, v)
 				}
-				value = math.Max(value, v)
 			}
-			return value
+			return largest
 		},
 	},
 }

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -126,7 +126,7 @@ type sampler struct {
 }
 
 // The amount of time before other resolutions become available
-var AvailableOnlyFull = time.Hour * 4
+const availableOnlyFull = time.Hour * 4
 
 func (b *blueflood) FetchSingleSeries(request api.FetchSeriesRequest) (api.Timeseries, error) {
 	sampler, ok := samplerMap[request.SampleMethod]
@@ -175,15 +175,15 @@ func (b *blueflood) FetchSingleSeries(request api.FetchSeriesRequest) (api.Times
 	var fullResolutionParsedResult queryResponse
 	fullResolutionRequest.Timerange, err = api.NewSnappedTimerange(fullResolutionStart, fullResolutionEnd, 30000)
 	if err != nil {
-		fmt.Printf("<<error snapping timerange for 30s>>\n")
+		log.Errorf("Error building full-resolution timerange: %s", err.Error())
 	} else {
 		fullResolutionQueryUrl, err := b.constructURL(fullResolutionRequest, sampler, ResolutionFull)
 		if err != nil {
-			fmt.Printf("<<Error building 30s URL>>\n")
+			log.Errorf("Error building full-resolution URL: %s", err.Error())
 		} else {
 			fullResolutionParsedResult, err = b.fetch(fullResolutionRequest, fullResolutionQueryUrl)
 			if err != nil {
-				fmt.Printf("<<Error parsing 30s result>>\n")
+				log.Errorf("Error parsing full-resolution query response: %s", err.Error())
 			}
 		}
 	}

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -238,7 +238,7 @@ func (b *blueflood) fetch(request api.FetchSeriesRequest, queryUrl *url.URL) (qu
 	go func() {
 		resp, err := b.client.Get(queryUrl.String())
 		if err != nil {
-			failure <- api.BackendError{request.Metric, api.FetchIOError, fmt.Sprintf("error while fetching - http connection [%s] error: %s", queryUrl.String(), err.Error())}
+			failure <- api.BackendError{request.Metric, api.FetchIOError, "error while fetching - http connection"}
 			return
 		}
 		defer resp.Body.Close()

--- a/api/backend/blueflood/blueflood.go
+++ b/api/backend/blueflood/blueflood.go
@@ -29,6 +29,10 @@ import (
 	"github.com/square/metrics/log"
 )
 
+var getNow = func() time.Time {
+	return time.Now()
+}
+
 type httpClient interface {
 	// our own client to mock out the standard golang HTTP Client.
 	Get(url string) (resp *http.Response, err error)
@@ -154,7 +158,7 @@ func (b *blueflood) FetchSingleSeries(request api.FetchSeriesRequest) (api.Times
 	fullResolutionRequest := request
 
 	// The "now" as an epoch in milliseconds
-	now := time.Now().Unix() * 1000
+	now := getNow().Unix() * 1000
 	earliestTime := now - int64(availableOnlyFull/time.Millisecond)
 	latestTime := now
 

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -272,7 +272,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		baseTime-300*1000*10, // 50 minutes ago
 		baseTime-300*1000*3,  // 15 minutes ago
 	)
-	fmt.Printf("expect regular [%s]\n", regularQueryURL)
+
 	regularResponse := fmt.Sprintf(`{
 	  "unit": "unknown",
 	  "values": [
@@ -315,7 +315,6 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		baseTime-300*1000*10, // 50 minutes ago
 		baseTime-300*1000*3,  // 15 minutes ago
 	)
-	fmt.Printf("expect full [%s]\n", fullResolutionQueryURL)
 	fullResolutionResponse := fmt.Sprintf(`{
 	  "unit": "unknown",
 	  "values": [

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -36,6 +36,7 @@ func Test_Blueflood(t *testing.T) {
 		"square",
 		make(map[string]int64),
 		time.Millisecond,
+		0,
 	}
 	// Not really MIN1440, but that's what default TTLs will get with the Timerange we use
 	defaultQueryUrl := "https://blueflood.url/v2.0/square/views/some.key.graphite?from=12000&resolution=MIN1440&select=numPoints%2Caverage&to=14000"
@@ -261,6 +262,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		"square",
 		make(map[string]int64),
 		time.Millisecond,
+		14400,
 	}
 
 	baseTime := 1438734300000

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -272,10 +272,10 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	}
 
 	// (X / 300) * 300 snaps it to a multiple of 300 (5 minutes).
-	now := (time.Now().Unix() / 300) * 300 * 1000
+	now := (getNow().Unix() / 300) * 300 * 1000
 	// rounded only to 30 seconds instead of 5m (300 seconds)
 	// and ROUND instead of TRUNCATE
-	now30 := ((time.Now().Unix() + 15) / 30) * 30 * 1000
+	now30 := ((getNow().Unix() + 15) / 30) * 30 * 1000
 
 	regularQueryURL := fmt.Sprintf(
 		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=MIN5&select=numPoints%%2Caverage&to=%d",

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -263,6 +263,14 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		make(map[string]int64),
 		time.Millisecond,
 	}
+
+	rightNow := time.Now()
+	// Stop time from moving forward by replacing `getNow` with this:
+	// (which prevents hard-to-find timing bugs that would cause the test to be flaky)
+	getNow = func() time.Time {
+		return rightNow
+	}
+
 	// (X / 300) * 300 snaps it to a multiple of 300 (5 minutes).
 	now := (time.Now().Unix() / 300) * 300 * 1000
 	// rounded only to 30 seconds instead of 5m (300 seconds)

--- a/api/backend/blueflood/blueflood_test.go
+++ b/api/backend/blueflood/blueflood_test.go
@@ -16,7 +16,6 @@ package blueflood
 
 import (
 	"fmt"
-	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -264,29 +263,14 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		time.Millisecond,
 	}
 
-	rightNow := time.Now()
-	// Stop time from moving forward by replacing `getNow` with this:
-	// (which prevents hard-to-find timing bugs that would cause the test to be flaky)
-	getNow = func() time.Time {
-		return rightNow
-	}
-
-	// (X / 300) * 300 snaps it to a multiple of 300 (5 minutes).
-	now := (getNow().Unix() / 300) * 300 * 1000
-	// rounded only to 30 seconds instead of 5m (300 seconds)
-	// and ROUND instead of TRUNCATE
-	now30 := ((getNow().Unix() + 15) / 30) * 30 * 1000
+	baseTime := 1438734300000
 
 	regularQueryURL := fmt.Sprintf(
 		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=MIN5&select=numPoints%%2Caverage&to=%d",
-		now-300*1000*10, // 50 minutes ago
-		now-300*1000*6,  // 30 minutes ago
+		baseTime-300*1000*10, // 50 minutes ago
+		baseTime-300*1000*3,  // 15 minutes ago
 	)
-	regularQueryRecentURL := fmt.Sprintf(
-		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=MIN5&select=numPoints%%2Caverage&to=%d",
-		now-300*1000*10, // 50 minutes ago
-		now-300*1000*3,  // 15 minutes ago
-	)
+	fmt.Printf("expect regular [%s]\n", regularQueryURL)
 	regularResponse := fmt.Sprintf(`{
 	  "unit": "unknown",
 	  "values": [
@@ -318,17 +302,18 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	    "marker": null
 	  }
 	}`,
-		now-300*1000*10, // 50 minutes ago
-		now-300*1000*9,  // 45 minutes ago
-		now-300*1000*8,  // 40 minutes ago
-		now-300*1000*7,  // 35 minutes ago
+		baseTime-300*1000*10, // 50 minutes ago
+		baseTime-300*1000*9,  // 45 minutes ago
+		baseTime-300*1000*8,  // 40 minutes ago
+		baseTime-300*1000*7,  // 35 minutes ago
 	)
 
 	fullResolutionQueryURL := fmt.Sprintf(
 		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=FULL&select=numPoints%%2Caverage&to=%d",
-		now-300*1000*10,        // 50 minutes ago
-		now-300*1000*4+30*1000, // 19.5 minutes ago
+		baseTime-300*1000*10, // 50 minutes ago
+		baseTime-300*1000*3,  // 15 minutes ago
 	)
+	fmt.Printf("expect full [%s]\n", fullResolutionQueryURL)
 	fullResolutionResponse := fmt.Sprintf(`{
 	  "unit": "unknown",
 	  "values": [
@@ -360,52 +345,14 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	    "marker": null
 	  }
 	}`,
-		now-300*1000*6,      // 30m ago
-		now-300*1000*5+17,   // 25m ago with random shuffling
-		now-300*1000*4+2821, // 20m ago with random shuffling
-		now-300*1000*3,      // 15m ago
-	)
-
-	fullResolutionForwardQueryURL := fmt.Sprintf(
-		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=FULL&select=numPoints%%2Caverage&to=%d",
-		now30-300*1000*5,       // 25 minutes ago, but rounded to nearest 30s instead of 5m
-		now-300*1000*4+30*1000, // 19.5 minutes ago
-	)
-	fullResolutionForwardResponse := fmt.Sprintf(`{
-	  "unit": "unknown",
-	  "values": [
-	    {
-	      "numPoints": 29,
-	      "timestamp": %d,
-	      "average": 16
-	    },
-	    {
-	      "numPoints": 27,
-	      "timestamp": %d,
-	      "average": 19
-	    },
-	    {
-	      "numPoints": 28,
-	      "timestamp": %d,
-	      "average": 27
-	    }
-	  ],
-	  "metadata": {
-	    "limit": null,
-	    "next_href": null,
-	    "count": 4,
-	    "marker": null
-	  }
-	}`,
-		now-300*1000*5+17,   // 25m ago with random shuffling
-		now-300*1000*4+2821, // 20m ago with random shuffling
-		now-300*1000*3,      // 15m ago
+		baseTime-300*1000*6,      // 30m ago
+		baseTime-300*1000*5+17,   // 25m ago with random shuffling
+		baseTime-300*1000*4+2821, // 20m ago with random shuffling
+		baseTime-300*1000*3,      // 15m ago
 	)
 
 	fakeHttpClient := mocks.NewFakeHttpClient()
 	fakeHttpClient.SetResponse(regularQueryURL, mocks.Response{regularResponse, 0, http.StatusOK})
-	fakeHttpClient.SetResponse(regularQueryRecentURL, mocks.Response{regularResponse, 0, http.StatusOK})
-	fakeHttpClient.SetResponse(fullResolutionForwardQueryURL, mocks.Response{fullResolutionForwardResponse, 0, http.StatusOK})
 	fakeHttpClient.SetResponse(fullResolutionQueryURL, mocks.Response{fullResolutionResponse, 0, http.StatusOK})
 
 	fakeApi := mocks.NewFakeApi()
@@ -421,9 +368,9 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	b.client = fakeHttpClient
 
 	queryTimerange, err := api.NewSnappedTimerange(
-		now-300*1000*10, // 50 minutes ago
-		now-300*1000*7,  // 35 minutes ago
-		300*1000,        // 5 minute resolution
+		int64(baseTime)-300*1000*10, // 50 minutes ago
+		int64(baseTime)-300*1000*4,  // 20 minutes ago
+		300*1000,                    // 5 minute resolution
 	)
 	if err != nil {
 		t.Fatalf("timerange error: %s", err.Error())
@@ -442,7 +389,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected success, but got error: %s", err.Error())
 	}
-	expected := []float64{100, 142, 138, 182}
+	expected := []float64{100, 142, 138, 182, 13, 16, 19}
 	if len(seriesList.Values) != len(expected) {
 		t.Fatalf("Expected %+v but got %+v", expected, seriesList)
 	}
@@ -451,79 +398,4 @@ func TestFullResolutionDataFilling(t *testing.T) {
 			t.Fatalf("Expected %+v but got %+v", expected, seriesList)
 		}
 	}
-	// Next: fetch closer to "now" which will pick up the full resolution data
-
-	queryTimerange, err = api.NewSnappedTimerange(
-		now-300*1000*10, // 50 minutes ago
-		now-300*1000*4,  // 20 minutes ago
-		300*1000,        // 5 minute resolution
-	)
-	if err != nil {
-		t.Fatalf("timerange error: %s", err.Error())
-	}
-
-	seriesList, err = b.FetchSingleSeries(api.FetchSeriesRequest{
-		Metric: api.TaggedMetric{
-			MetricKey: api.MetricKey("some.key"),
-			TagSet:    api.ParseTagSet("tag=value"),
-		},
-		SampleMethod: api.SampleMean,
-		Timerange:    queryTimerange,
-		API:          fakeApi,
-		Cancellable:  api.NewCancellable(),
-	})
-	if err != nil {
-		t.Fatalf("Expected success, but got error: %s", err.Error())
-	}
-	expected = []float64{100, 142, 138, 182, 13, 16, 19}
-	if len(seriesList.Values) != len(expected) {
-		t.Fatalf("Expected %+v but got %+v", expected, seriesList)
-	}
-	for i, expect := range expected {
-		if seriesList.Values[i] != expect {
-			t.Fatalf("Expected %+v but got %+v", expected, seriesList)
-		}
-	}
-
-	// Lastly, change the "availableOnlyFull" value forward and repeat:
-	availableOnlyFull = 25 * time.Minute
-
-	queryTimerange, err = api.NewSnappedTimerange(
-		now-300*1000*10, // 50 minutes ago
-		now-300*1000*4,  // 20 minutes ago
-		300*1000,        // 5 minute resolution
-	)
-	if err != nil {
-		t.Fatalf("timerange error: %s", err.Error())
-	}
-
-	seriesList, err = b.FetchSingleSeries(api.FetchSeriesRequest{
-		Metric: api.TaggedMetric{
-			MetricKey: api.MetricKey("some.key"),
-			TagSet:    api.ParseTagSet("tag=value"),
-		},
-		SampleMethod: api.SampleMean,
-		Timerange:    queryTimerange,
-		API:          fakeApi,
-		Cancellable:  api.NewCancellable(),
-	})
-	if err != nil {
-		t.Fatalf("Expected success, but got error: %s", err.Error())
-	}
-	expected = []float64{100, 142, 138, 182, math.NaN(), 16, 19}
-	if len(seriesList.Values) != len(expected) {
-		t.Fatalf("Expected %+v but got %+v", expected, seriesList)
-	}
-	for i, expect := range expected {
-		if math.IsNaN(expect) {
-			if !math.IsNaN(seriesList.Values[i]) {
-				t.Fatalf("Expected %+v but got %+v", expected, seriesList)
-			}
-			continue
-		}
-		if seriesList.Values[i] != expect {
-			t.Fatalf("Expected %+v but got %+v", expected, seriesList)
-		}
-	}
-
 }

--- a/query/language.peg.go
+++ b/query/language.peg.go
@@ -614,7 +614,7 @@ func translatePositions(buffer string, positions []int) textPositionMap {
 	sort.Ints(positions)
 
 search:
-	for i, c := range buffer[0:] {
+	for i, c := range []rune(buffer) {
 		if c == '\n' {
 			line, symbol = line+1, 0
 		} else {


### PR DESCRIPTION
Full resolution data (roughly 30s resolution) is usually available immediately. However, it takes a while for rollups to be performed and therefore lower resolution data (5m, 1hr, 1day) may not be available for a while.

This PR adds a feature to fetch full-resolution data to fill this gap in data. The last 4hrs (configurable) of the requested timerange is also fetched from full resolution data. They're combined when bucketing.

Since the full-resolution data should be sampled down in the same way that rollups are performed, it will look like the regular data is fully available. 

This essentially doubles the number of fetches required, although the number of points returned is not likely doubled.