### PR TITLE
Expose the full query even if an alias was used

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -325,7 +325,8 @@ func (sm SampleMethod) String() string {
 type SeriesList struct {
 	Series    []Timeseries `json:"series"`
 	Timerange Timerange    `json:"timerange"`
-	Name      string       `json:"name"` // human-readable description of the given time series.
+	Name      string       `json:"name"`  // human-readable description of the given time series.
+	Query     string       `json:"query"` // query actually executed for the series
 }
 
 // IsValid determines whether the given time series is valid.

--- a/function/aggregate/aggregate.go
+++ b/function/aggregate/aggregate.go
@@ -214,6 +214,7 @@ func AggregateBy(list api.SeriesList, aggregator func([]float64) float64, tags [
 		Series:    make([]api.Timeseries, len(groups)),
 		Timerange: list.Timerange,
 		Name:      list.Name,
+		Query:     list.Query,
 	}
 
 	for i, group := range groups {

--- a/function/aggregate/aggregate_test.go
+++ b/function/aggregate/aggregate_test.go
@@ -71,6 +71,7 @@ func Test_groupBy(t *testing.T) {
 		},
 		Timerange: api.Timerange{},
 		Name:      "",
+		Query:     "",
 	}
 
 	var aggregateTestCases = []struct {
@@ -332,6 +333,7 @@ func Test_AggregateBy(t *testing.T) {
 		},
 		timerange,
 		"Test.List",
+		"",
 	}
 
 	var aggregatedTests = []struct {

--- a/function/join/join_test.go
+++ b/function/join/join_test.go
@@ -36,12 +36,12 @@ var (
 
 	voidSeries = api.Timeseries{[]float64{0, 0, 0}, map[string]string{}}
 
-	emptyList = api.SeriesList{[]api.Timeseries{}, api.Timerange{}, ""}
-	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}, api.Timerange{}, ""}
-	dcList    = api.SeriesList{[]api.Timeseries{seriesDC_A, seriesDC_B, seriesDC_C}, api.Timerange{}, ""}
-	envList   = api.SeriesList{[]api.Timeseries{seriesENV_PROD, seriesENV_STAGE}, api.Timerange{}, ""}
+	emptyList = api.SeriesList{[]api.Timeseries{}, api.Timerange{}, "", ""}
+	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}, api.Timerange{}, "", ""}
+	dcList    = api.SeriesList{[]api.Timeseries{seriesDC_A, seriesDC_B, seriesDC_C}, api.Timerange{}, "", ""}
+	envList   = api.SeriesList{[]api.Timeseries{seriesENV_PROD, seriesENV_STAGE}, api.Timerange{}, "", ""}
 
-	voidList = api.SeriesList{[]api.Timeseries{voidSeries}, api.Timerange{}, ""}
+	voidList = api.SeriesList{[]api.Timeseries{voidSeries}, api.Timerange{}, "", ""}
 )
 
 var testCases = []struct {

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -162,7 +162,8 @@ func NewFilter(name string, summary func([]float64) float64, ascending bool) fun
 				return nil, fmt.Errorf("expected positive count but got %d", count)
 			}
 			result := filter.FilterBy(list, count, summary, ascending)
-			result.Name = fmt.Sprintf("%s(%s, %d)", name, value.GetName(), count)
+			result.Query = fmt.Sprintf("%s(%s, %d)", name, value.GetName(), count)
+			result.Name = result.Query
 			return result, nil
 		},
 	}
@@ -206,7 +207,8 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 				return nil, err
 			}
 			result := filter.FilterRecentBy(list, count, summary, ascending, duration)
-			result.Name = fmt.Sprintf("%s(%s, %d)", name, value.GetName(), count)
+			result.Query = fmt.Sprintf("%s(%s, %d)", name, value.GetName(), count)
+			result.Name = result.Query
 			return result, nil
 		},
 	}
@@ -235,14 +237,15 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 				groupNames[i] += group
 			}
 			if len(groups.List) == 0 {
-				result.Name = fmt.Sprintf("%s(%s)", name, value.GetName())
+				result.Query = fmt.Sprintf("%s(%s)", name, value.GetName())
 			} else {
 				verbName := "group"
 				if groups.Collapses {
 					verbName = "collapse"
 				}
-				result.Name = fmt.Sprintf("%s(%s %s by %s)", name, value.GetName(), verbName, strings.Join(groupNames, ", "))
+				result.Query = fmt.Sprintf("%s(%s %s by %s)", name, value.GetName(), verbName, strings.Join(groupNames, ", "))
 			}
+			result.Name = result.Query
 			return result, nil
 		},
 	}
@@ -279,10 +282,11 @@ func NewTransform(name string, parameterCount int, transformer func([]float64, [
 				parameterNames[i] = param.GetName()
 			}
 			if len(parameters) != 0 {
-				result.Name = fmt.Sprintf("%s(%s, %s)", name, listValue.GetName(), strings.Join(parameterNames, ", "))
+				result.Query = fmt.Sprintf("%s(%s, %s)", name, listValue.GetName(), strings.Join(parameterNames, ", "))
 			} else {
-				result.Name = fmt.Sprintf("%s(%s)", name, listValue.GetName())
+				result.Query = fmt.Sprintf("%s(%s)", name, listValue.GetName())
 			}
+			result.Name = result.Query
 			return result, nil
 		},
 	}
@@ -325,10 +329,12 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 				result[i] = api.Timeseries{array, row.TagSet}
 			}
 
+			query := fmt.Sprintf("(%s %s %s)", leftValue.GetName(), op, rightValue.GetName())
 			return api.SeriesList{
 				Series:    result,
 				Timerange: context.Timerange,
-				Name:      fmt.Sprintf("(%s %s %s)", leftValue.GetName(), op, rightValue.GetName()),
+				Name:      query,
+				Query:     query,
 			}, nil
 		},
 	}

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -41,6 +41,7 @@ func DropTag(list api.SeriesList, tag string) api.SeriesList {
 		series,
 		list.Timerange,
 		list.Name,
+		list.Query,
 	}
 }
 
@@ -65,6 +66,7 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 		series,
 		list.Timerange,
 		list.Name,
+		list.Query,
 	}
 }
 

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -17,6 +17,7 @@ package transform
 import (
 	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
@@ -45,7 +46,8 @@ var Timeshift = function.MetricFunction{
 
 		if seriesValue, ok := result.(api.SeriesList); ok {
 			seriesValue.Timerange = context.Timerange
-			seriesValue.Name = fmt.Sprintf("transform.timeshift(%s,%s)", result.GetName(), value.GetName())
+			seriesValue.Query = fmt.Sprintf("transform.timeshift(%s,%s)", result.GetName(), value.GetName())
+			seriesValue.Name = seriesValue.Query
 			return seriesValue, nil
 		}
 		return result, nil
@@ -123,7 +125,8 @@ var MovingAverage = function.MetricFunction{
 			}
 			list.Series[index].Values = results
 		}
-		list.Name = fmt.Sprintf("transform.moving_average(%s, %s)", listValue.GetName(), sizeValue.GetName())
+		list.Query = fmt.Sprintf("transform.moving_average(%s, %s)", listValue.GetName(), sizeValue.GetName())
+		list.Name = list.Query
 		return list, nil
 	},
 }
@@ -150,6 +153,7 @@ var Alias = function.MetricFunction{
 			return nil, err
 		}
 		list.Name = name
+		list.Query = fmt.Sprintf("transform.alias(%s, %s)", value.GetName(), strconv.Quote(name))
 		return list, nil
 	},
 }

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -46,6 +46,7 @@ func ApplyTransform(list api.SeriesList, transform transform, parameters []funct
 		Series:    make([]api.Timeseries, len(list.Series)),
 		Timerange: list.Timerange,
 		Name:      list.Name,
+		Query:     list.Query,
 	}
 	var err error
 	for i, series := range list.Series {

--- a/query/expression.go
+++ b/query/expression.go
@@ -84,6 +84,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 	}
 
 	serieslist.Name = expr.metricName
+	serieslist.Query = expr.metricName
 
 	return serieslist, nil
 }

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -121,6 +121,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 				},
 				api.Timerange{},
 				"",
+				"",
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -130,6 +131,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 					},
 				},
 				api.Timerange{},
+				"",
 				"",
 			},
 			func(left, right float64) float64 { return left + right },
@@ -147,6 +149,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 				},
 				api.Timerange{},
 				"",
+				"",
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -155,6 +158,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 					},
 				},
 				api.Timerange{},
+				"",
 				"",
 			},
 			func(left, right float64) float64 { return left - right },
@@ -190,6 +194,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 				},
 				api.Timerange{},
 				"",
+				"",
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -207,6 +212,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 					},
 				},
 				api.Timerange{},
+				"",
 				"",
 			},
 			func(left, right float64) float64 { return left + right },
@@ -242,6 +248,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 				},
 				api.Timerange{},
 				"",
+				"",
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -259,6 +266,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 					},
 				},
 				api.Timerange{},
+				"",
 				"",
 			},
 			func(left, right float64) float64 { return left * right },
@@ -294,6 +302,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 				},
 				api.Timerange{},
 				"",
+				"",
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -311,6 +320,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 					},
 				},
 				api.Timerange{},
+				"",
 				"",
 			},
 			func(left, right float64) float64 { return left - right },


### PR DESCRIPTION
This introduces a new field on `SeriesList` named `Query` that has the full query for the given TimeSeries. This will be the same as `Name` unless `transform.alias` is used.