### PR TITLE
Add bulk add Metrics API and remove db-specific caching.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,7 +24,8 @@ import "github.com/square/metrics/inspect"
 type API interface {
 	// AddMetric adds the metric to the system.
 	AddMetric(metric TaggedMetric) error
-  AddMetrics(metric []TaggedMetric) error
+	// Bulk metrics addition
+	AddMetrics(metric []TaggedMetric) error
 
 	// RemoveMetric removes the metric from the system.
 	RemoveMetric(metric TaggedMetric) error
@@ -71,8 +72,8 @@ func (api ProfilingAPI) AddMetric(metric TaggedMetric) error {
 	return api.API.AddMetric(metric)
 }
 func (api ProfilingAPI) AddMetrics(metrics []TaggedMetric) error {
-  defer api.Profiler.Record("api.AddMetrics")()
-  return api.API.AddMetrics(metrics)
+	defer api.Profiler.Record("api.AddMetrics")()
+	return api.API.AddMetrics(metrics)
 }
 func (api ProfilingAPI) RemoveMetric(metric TaggedMetric) error {
 	defer api.Profiler.Record("api.RemoveMetric")()

--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,7 @@ import "github.com/square/metrics/inspect"
 type API interface {
 	// AddMetric adds the metric to the system.
 	AddMetric(metric TaggedMetric) error
+  AddMetrics(metric []TaggedMetric) error
 
 	// RemoveMetric removes the metric from the system.
 	RemoveMetric(metric TaggedMetric) error
@@ -68,6 +69,10 @@ type ProfilingAPI struct {
 func (api ProfilingAPI) AddMetric(metric TaggedMetric) error {
 	defer api.Profiler.Record("api.AddMetric")()
 	return api.API.AddMetric(metric)
+}
+func (api ProfilingAPI) AddMetrics(metrics []TaggedMetric) error {
+  defer api.Profiler.Record("api.AddMetrics")()
+  return api.API.AddMetrics(metrics)
 }
 func (api ProfilingAPI) RemoveMetric(metric TaggedMetric) error {
 	defer api.Profiler.Record("api.RemoveMetric")()

--- a/internal/api.go
+++ b/internal/api.go
@@ -87,6 +87,12 @@ func (a *defaultAPI) AddMetric(metric api.TaggedMetric) error {
 	return nil
 }
 
+func (a *defaultAPI) AddMetrics(metrics []api.TaggedMetric) error {
+	log.Infof("Using the bulk metrics\n")
+	a.db.AddMetricNames(metrics)
+	return nil
+}
+
 func (a *defaultAPI) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error) {
 	return a.db.GetTagSet(metricKey)
 }

--- a/internal/cassandra_test.go
+++ b/internal/cassandra_test.go
@@ -17,7 +17,6 @@ package internal
 import (
 	"fmt"
 	"sort"
-	"sync"
 	"testing"
 
 	"github.com/gocql/gocql"
@@ -41,11 +40,7 @@ func newDatabase(t *testing.T) *defaultDatabase {
 		}
 	}
 	return &defaultDatabase{
-		session:         session,
-		allMetricsCache: make(map[api.MetricKey]bool),
-		allMetricsMutex: &sync.Mutex{},
-		tagIndexCache:   make(map[tagIndexCacheKey]bool),
-		tagIndexMutex:   &sync.Mutex{},
+		session: session,
 	}
 }
 

--- a/mocks/api.go
+++ b/mocks/api.go
@@ -56,6 +56,10 @@ func (fa *FakeApi) AddMetric(metric api.TaggedMetric) error {
 	return nil
 }
 
+func (fa *FakeApi) AddMetrics(metric []api.TaggedMetric) error {
+	return nil
+}
+
 func (fa *FakeApi) RemoveMetric(metric api.TaggedMetric) error {
 	return nil
 }

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -31,6 +31,11 @@ func (a fakeAPI) AddMetric(metric api.TaggedMetric) error {
 	return nil
 }
 
+func (a fakeAPI) AddMetrics(metrics []api.TaggedMetric) error {
+	// NOTHING
+	return nil
+}
+
 func (a fakeAPI) RemoveMetric(metric api.TaggedMetric) error {
 	// NOTHING
 	return nil


### PR DESCRIPTION
This adds a simpler bulk add metrics API for cassandra that does streaming. Doesn't look like the go cassandra driver supports the same level of streaming large inserts that the Java/C# driver does (https://medium.com/@foundev/cassandra-batch-loading-without-the-batch-keyword-40f00e35e23e). I could be wrong. Either way this is about as fast as I can get it without relying on more clever methods.

I'm also removing the caching from the cassandra code in favor of moving it higher up into the stack.