### PR TITLE
Don't format responses with extra spacing

### DIFF
--- a/main/query/query.go
+++ b/main/query/query.go
@@ -63,7 +63,7 @@ func main() {
 			fmt.Println("execution error:", err.Error())
 			continue
 		}
-		encoded, err := json.MarshalIndent(result, "", "  ")
+		encoded, err := json.Marshal(result)
 		if err != nil {
 			fmt.Println("encoding error:", err.Error())
 			return

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -68,7 +68,7 @@ func errorResponse(writer http.ResponseWriter, code int, err error) {
 func bodyResponse(writer http.ResponseWriter, response response) {
 	commonResponse(writer)
 	response.Success = true
-	encoded, err := json.MarshalIndent(response, "", "  ")
+	encoded, err := json.Marshal(response)
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
 		writer.Write(failedMessage)


### PR DESCRIPTION
We tend to produce very large responses, nicely formatting the JSON wastes a ton of time. `python -mjson.tool` is your friend.