### PR TITLE
Build txt file reports from what matches and what doesn't

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ main/ui/ui
 main/metadata/metadata
 main/**/conversion_rules
 main/**/*.yaml
+main/ruletester/report

--- a/main/ruletester/ruletester.go
+++ b/main/ruletester/ruletester.go
@@ -162,10 +162,10 @@ func DoAnalysis(metrics []string, graphiteConverter util.RuleBasedGraphiteConver
 	var wg sync.WaitGroup
 
 	i := 0
-	for i = 0; i < len(metrics); i = i + 25 {
+	for i = 0; i+25 < len(metrics); i = i + 25 {
 		workQueue <- metrics[i : i+25]
 	}
-	if i <= len(metrics) {
+	if i < len(metrics) {
 		workQueue <- metrics[i:]
 	}
 

--- a/main/ruletester/ruletester.go
+++ b/main/ruletester/ruletester.go
@@ -19,12 +19,16 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
+	"compress/zlib"
+	"encoding/gob"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
-	"runtime"
-	"sort"
+	// "runtime"
+	// "sort"
 	"sync"
 
 	"github.com/square/metrics/api"
@@ -34,10 +38,9 @@ import (
 )
 
 var (
-	metricsFile      = flag.String("metrics-file", "", "Location of YAML configuration file.")
-	unmatchedFile    = flag.String("unmatched-file", "", "location of metrics list to output unmatched transformations.")
-	insertToDatabase = flag.Bool("insert-to-db", false, "If true, insert rows to database.")
-	reverse          = flag.Bool("reverse", false, "If true, then attempt the reverse-rule lookup also.")
+	metricsFile   = flag.String("metrics-file", "", "Location of zlib compressed gob string file.")
+	unmatchedFile = flag.String("unmatched-file", "", "location of metrics list to output unmatched transformations.")
+	reverse       = flag.Bool("reverse", false, "If true, then attempt the reverse-rule lookup also.")
 )
 
 // Statistics represents the aggregated result of rules
@@ -57,9 +60,39 @@ type PerMetricStatistics struct {
 	reverseIncorrect int // number of incorrectly reversed entries.
 }
 
+func ReadMetricsFile(file string) ([]string, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]int)
+	r, err := zlib.NewReader(bytes.NewBuffer(data))
+	b := new(bytes.Buffer)
+	io.Copy(b, r)
+	d := gob.NewDecoder(b)
+
+	err = d.Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	strings := []string{}
+	for k, _ := range result {
+		strings = append(strings, k)
+	}
+	return strings, nil
+}
+
 func main() {
 	flag.Parse()
 	common.SetupLogger()
+
+	if *metricsFile == "" {
+		common.ExitWithMessage("No metric file.")
+		fmt.Printf("You must specify a metrics file.\n")
+		os.Exit(1)
+	}
 
 	config := common.LoadConfig()
 
@@ -72,132 +105,248 @@ func main() {
 	if err != nil {
 		common.ExitWithMessage(fmt.Sprintf("Error while reading rules: %s", err.Error()))
 	}
-	_ = util.RuleBasedGraphiteConverter{Ruleset: ruleset}
+	graphiteConverter := util.RuleBasedGraphiteConverter{Ruleset: ruleset}
 
-	metricFile, err := os.Open(*metricsFile)
+	// metricFile, err := os.Open(*metricsFile)
+	metrics, err := ReadMetricsFile(*metricsFile)
+	if err != nil {
+		fmt.Printf("Fatal error reading metrics file %s\n", err)
+		os.Exit(1)
+	}
+
+	DoAnalysis(metrics, graphiteConverter)
+
+	fmt.Printf("Total metric count %d\n", len(metrics))
+
+	// matched := 0
+	// unmatched := 0
+	// reverse_convert_failed := 0
+
+	// fmt.Printf("Matched: %d\n", matched)
+	// fmt.Printf("Unmatched: %d\n", unmatched)
+	// fmt.Printf("Reverse convert failed: %d\n", reverse_convert_failed)
+
 	if err != nil {
 		common.ExitWithMessage("No metric file.")
 	}
-	scanner := bufio.NewScanner(metricFile)
+	// scanner := bufio.NewScanner(metricFile)
 	cassandraConfig := cassandra.CassandraMetricMetadataConfig{
 		Hosts:    config.MetricMetadataConfig.Hosts,
 		Keyspace: config.MetricMetadataConfig.Keyspace,
 	}
-	apiInstance := common.NewMetricMetadataAPI(cassandraConfig)
+	_ = common.NewMetricMetadataAPI(cassandraConfig)
 
-	var output *os.File
-	if *unmatchedFile != "" {
-		output, err = os.Create(*unmatchedFile)
-		if err != nil {
-			common.ExitWithMessage(fmt.Sprintf("Error creating the output file: %s", err.Error()))
-		}
-	}
-	stat := run(ruleset, scanner, apiInstance, output)
-	report(stat)
+	// var output *os.File
+	// if *unmatchedFile != "" {
+	// 	output, err = os.Create(*unmatchedFile)
+	// 	if err != nil {
+	// 		common.ExitWithMessage(fmt.Sprintf("Error creating the output file: %s", err.Error()))
+	// 	}
+	// }
+	// stat := run(ruleset, scanner, apiInstance, output)
+	// report(stat)
 }
 
-func run(ruleset util.RuleSet, scanner *bufio.Scanner, apiInstance api.MetricMetadataAPI, unmatched *os.File) Statistics {
+type ChunkResult struct {
+	matched                int
+	unmatched              int
+	reverse_convert_failed int
+}
+
+func DoAnalysis(metrics []string, graphiteConverter util.RuleBasedGraphiteConverter) {
+	workQueue := make(chan []string, len(metrics)/25+1)
+	resultQueue := make(chan ChunkResult, len(metrics))
 	var wg sync.WaitGroup
-	stat := Statistics{
-		perMetric: make(map[api.MetricKey]PerMetricStatistics),
+
+	i := 0
+	for i = 0; i < len(metrics); i = i + 25 {
+		workQueue <- metrics[i : i+25]
 	}
-	type result struct {
-		input   string
-		result  api.TaggedMetric
-		success bool
+	if i <= len(metrics) {
+		workQueue <- metrics[i:]
 	}
-	inputBuffer := make(chan string, 10)
-	outputBuffer := make(chan result, 10)
-	done := make(chan struct{})
-	for id := 0; id < runtime.NumCPU(); id++ {
+
+	close(workQueue)
+
+	fmt.Printf("Starting work...\n")
+	for j := 0; j < 10; j++ {
+		wg.Add(1)
 		go func() {
+			counter := 0
+			defer wg.Done()
 			for {
 				select {
-				case <-done:
-					return
-				case input := <-inputBuffer:
-					metric, matched := ruleset.MatchRule(input)
-					outputBuffer <- result{
-						input,
-						metric,
-						matched,
+				case metrics, more := <-workQueue:
+					counter++
+					if counter%100 == 0 && counter != 0 {
+						fmt.Printf(".")
 					}
-				}
-			}
-		}()
-	}
-	go func() {
-		// aggregate function.
-		for {
-			select {
-			case <-done:
-				return
-			case output := <-outputBuffer:
-				converted, matched := output.result, output.success
-				if matched {
-					stat.matched++
-					perMetric := stat.perMetric[converted.MetricKey]
-					perMetric.matched++
-					if *insertToDatabase {
-						apiInstance.AddMetric(converted)
-					}
-					if *reverse {
-						reversed, err := ruleset.ToGraphiteName(converted)
+					chunk_result := ChunkResult{}
+					for _, metric := range metrics {
+						graphiteMetric := util.GraphiteMetric(metric)
+						taggedMetric, err := graphiteConverter.ToTaggedName(graphiteMetric)
 						if err != nil {
-							perMetric.reverseError++
-						} else if string(reversed) != output.input {
-							perMetric.reverseIncorrect++
+							_, err := graphiteConverter.ToGraphiteName(taggedMetric)
+							if err != nil {
+								chunk_result.reverse_convert_failed++
+							} else {
+
+							}
+							chunk_result.matched++
 						} else {
-							perMetric.reverseSuccess++
+							chunk_result.unmatched++
 						}
 					}
-					stat.perMetric[converted.MetricKey] = perMetric
-				} else {
-					stat.unmatched++
-					if unmatched != nil {
-						unmatched.WriteString(output.input)
-						unmatched.WriteString("\n")
+					resultQueue <- chunk_result
+
+					if !more {
+						return
 					}
+				default:
+					fmt.Printf("Nothing more!\n")
 				}
-				wg.Done()
+			}
+
+		}()
+	}
+	wg.Wait()
+	close(resultQueue)
+
+	fmt.Printf("\n")
+	fmt.Printf("Processing results!")
+	totalResults := ChunkResult{}
+	//Merge chunks
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case result, more := <-resultQueue:
+				totalResults.matched += result.matched
+				totalResults.unmatched += result.unmatched
+				totalResults.reverse_convert_failed += result.reverse_convert_failed
+
+				if !more {
+					return
+				}
 			}
 		}
 	}()
 
-	for scanner.Scan() {
-		wg.Add(1)
-		input := scanner.Text()
-		inputBuffer <- input
-	}
 	wg.Wait()
-	close(done) // broadcast to shutdown all goroutines.
-	return stat
+	fmt.Printf("\n")
+	fmt.Printf("Matched: %d\n", totalResults.matched)
+	fmt.Printf("Unmatched: %d\n", totalResults.unmatched)
+	fmt.Printf("Reverse convert failed: %d\n", totalResults.reverse_convert_failed)
+
 }
 
-func report(stat Statistics) {
-	total := stat.matched + stat.unmatched
-	fmt.Printf("Processed %d entries\n", total)
-	fmt.Printf("Matched:   %d\n", stat.matched)
-	fmt.Printf("Unmatched: %d\n", stat.unmatched)
-	fmt.Printf("Per-rule statistics\n")
-	rowformat := "%-60s %7d %7d %7d %7d\n"
-	headformat := "%-60s %7s %7s %7s %7s\n"
-	fmt.Printf(headformat, "name", "match", "rev-suc", "rev-err", "rev-fail")
-	sortedKeys := make([]string, len(stat.perMetric))
-	index := 0
-	for key := range stat.perMetric {
-		sortedKeys[index] = string(key)
-		index++
-	}
-	sort.Strings(sortedKeys)
-	for _, key := range sortedKeys {
-		perMetric := stat.perMetric[api.MetricKey(key)]
-		fmt.Printf(rowformat,
-			string(key),
-			perMetric.matched,
-			perMetric.reverseSuccess,
-			perMetric.reverseError,
-			perMetric.reverseIncorrect,
-		)
-	}
+func ProcessWork(workQueue chan []string) {
+
 }
+
+// func run(ruleset util.RuleSet, scanner *bufio.Scanner, apiInstance api.MetricMetadataAPI, unmatched *os.File) Statistics {
+// 	var wg sync.WaitGroup
+// 	stat := Statistics{
+// 		perMetric: make(map[api.MetricKey]PerMetricStatistics),
+// 	}
+// 	type result struct {
+// 		input   string
+// 		result  api.TaggedMetric
+// 		success bool
+// 	}
+// 	inputBuffer := make(chan string, 10)
+// 	outputBuffer := make(chan result, 10)
+// 	done := make(chan struct{})
+// 	for id := 0; id < runtime.NumCPU(); id++ {
+// 		go func() {
+// 			for {
+// 				select {
+// 				case <-done:
+// 					return
+// 				case input := <-inputBuffer:
+// 					metric, matched := ruleset.MatchRule(input)
+// 					outputBuffer <- result{
+// 						input,
+// 						metric,
+// 						matched,
+// 					}
+// 				}
+// 			}
+// 		}()
+// 	}
+// 	go func() {
+// 		// aggregate function.
+// 		for {
+// 			select {
+// 			case <-done:
+// 				return
+// 			case output := <-outputBuffer:
+// 				converted, matched := output.result, output.success
+// 				if matched {
+// 					stat.matched++
+// 					perMetric := stat.perMetric[converted.MetricKey]
+// 					perMetric.matched++
+// 					if *insertToDatabase {
+// 						apiInstance.AddMetric(converted)
+// 					}
+// 					if *reverse {
+// 						reversed, err := ruleset.ToGraphiteName(converted)
+// 						if err != nil {
+// 							perMetric.reverseError++
+// 						} else if string(reversed) != output.input {
+// 							perMetric.reverseIncorrect++
+// 						} else {
+// 							perMetric.reverseSuccess++
+// 						}
+// 					}
+// 					stat.perMetric[converted.MetricKey] = perMetric
+// 				} else {
+// 					stat.unmatched++
+// 					if unmatched != nil {
+// 						unmatched.WriteString(output.input)
+// 						unmatched.WriteString("\n")
+// 					}
+// 				}
+// 				wg.Done()
+// 			}
+// 		}
+// 	}()
+
+// 	for scanner.Scan() {
+// 		wg.Add(1)
+// 		input := scanner.Text()
+// 		inputBuffer <- input
+// 	}
+// 	wg.Wait()
+// 	close(done) // broadcast to shutdown all goroutines.
+// 	return stat
+// }
+
+// func report(stat Statistics) {
+// 	total := stat.matched + stat.unmatched
+// 	fmt.Printf("Processed %d entries\n", total)
+// 	fmt.Printf("Matched:   %d\n", stat.matched)
+// 	fmt.Printf("Unmatched: %d\n", stat.unmatched)
+// 	fmt.Printf("Per-rule statistics\n")
+// 	rowformat := "%-60s %7d %7d %7d %7d\n"
+// 	headformat := "%-60s %7s %7s %7s %7s\n"
+// 	fmt.Printf(headformat, "name", "match", "rev-suc", "rev-err", "rev-fail")
+// 	sortedKeys := make([]string, len(stat.perMetric))
+// 	index := 0
+// 	for key := range stat.perMetric {
+// 		sortedKeys[index] = string(key)
+// 		index++
+// 	}
+// 	sort.Strings(sortedKeys)
+// 	for _, key := range sortedKeys {
+// 		perMetric := stat.perMetric[api.MetricKey(key)]
+// 		fmt.Printf(rowformat,
+// 			string(key),
+// 			perMetric.matched,
+// 			perMetric.reverseSuccess,
+// 			perMetric.reverseError,
+// 			perMetric.reverseIncorrect,
+// 		)
+// 	}
+// }

--- a/util/graphite_converter.go
+++ b/util/graphite_converter.go
@@ -36,8 +36,14 @@ type GraphiteConverterConfig struct {
 	ConversionRulesPath string `yaml:"conversion_rules_path"`
 }
 
+var _ GraphiteConverter = (*RuleBasedGraphiteConverter)(nil)
+
 type RuleBasedGraphiteConverter struct {
 	Ruleset RuleSet
+}
+
+func (g *RuleBasedGraphiteConverter) EnableStats() {
+	g.Ruleset.EnableStats()
 }
 
 func (g *RuleBasedGraphiteConverter) ToGraphiteName(metric api.TaggedMetric) (GraphiteMetric, error) {
@@ -54,7 +60,7 @@ func (g *RuleBasedGraphiteConverter) ToTaggedName(metric GraphiteMetric) (api.Ta
 
 func LoadRules(conversionRulesPath string) (RuleSet, error) {
 	ruleSet := RuleSet{
-		rules: []Rule{},
+		Rules: []Rule{},
 	}
 
 	filenames, err := filepath.Glob(filepath.Join(conversionRulesPath, "*.yaml"))
@@ -82,7 +88,7 @@ func LoadRules(conversionRulesPath string) (RuleSet, error) {
 			return RuleSet{}, err
 		}
 
-		ruleSet.rules = append(ruleSet.rules, rs.rules...)
+		ruleSet.Rules = append(ruleSet.Rules, rs.Rules...)
 	}
 
 	return ruleSet, nil
@@ -96,5 +102,3 @@ type GraphiteConverter interface {
 	// using the configured rules. May error out.
 	ToTaggedName(metric GraphiteMetric) (api.TaggedMetric, error)
 }
-
-var _ GraphiteConverter = (*RuleBasedGraphiteConverter)(nil)

--- a/util/rules_test.go
+++ b/util/rules_test.go
@@ -154,9 +154,9 @@ rules:
   `
 	ruleSet, err := LoadYAML([]byte(rawYAML))
 	a.CheckError(err)
-	a.EqInt(len(ruleSet.rules), 1)
-	a.EqString(string(ruleSet.rules[0].raw.MetricKeyPattern), "abc")
-	a.Eq(ruleSet.rules[0].graphitePatternTags, []string{"tag"})
+	a.EqInt(len(ruleSet.Rules), 1)
+	a.EqString(string(ruleSet.Rules[0].raw.MetricKeyPattern), "abc")
+	a.Eq(ruleSet.Rules[0].graphitePatternTags, []string{"tag"})
 }
 
 func TestLoadYAML_Invalid(t *testing.T) {
@@ -170,7 +170,7 @@ rules
   `
 	ruleSet, err := LoadYAML([]byte(rawYAML))
 	checkRuleErrorCode(a, err, InvalidYaml)
-	a.EqInt(len(ruleSet.rules), 0)
+	a.EqInt(len(ruleSet.Rules), 0)
 }
 
 func TestToGraphiteName(t *testing.T) {


### PR DESCRIPTION
I've modified the old ruletester file to be able to read the new zlib compressed gob encoded cache file we generate from the metrics-indexer upstream. Yes, the ruletester file is a bit of a mess right now, but I think that's fine. We need to refine this and get more data out of it most likely, so I'm leaving it there for now for the next person :-).

I've also exported a lot of the data from the util.GraphiteConverter stuff so we can get per-rule statistics from within the converter itself. There's probably more we want to track.