### PR TITLE
Calculate full timeranges for rates & derivatives, change Integral & Cumulative

### DIFF
--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -43,9 +43,7 @@ func init() {
 	MustRegister(NewAggregate("aggregate.total", aggregate.Total))
 	MustRegister(NewAggregate("aggregate.count", aggregate.Count))
 	// Transformations
-	MustRegister(NewTransform("transform.derivative", 0, transform.Derivative))
 	MustRegister(NewTransform("transform.integral", 0, transform.Integral))
-	MustRegister(NewTransform("transform.rate", 0, transform.Rate))
 	MustRegister(NewTransform("transform.cumulative", 0, transform.Cumulative))
 	MustRegister(NewTransform("transform.nan_fill", 1, transform.Default))
 	MustRegister(NewTransform("transform.abs", 0, transform.MapMaker(math.Abs)))
@@ -70,9 +68,11 @@ func init() {
 	MustRegister(NewFilterRecent("filter.recent_lowest_min", aggregate.Min, true))
 
 	// Weird ones
-	MustRegister(transform.Timeshift)
 	MustRegister(transform.Alias)
+	MustRegister(transform.Derivative)
 	MustRegister(transform.MovingAverage)
+	MustRegister(transform.Rate)
+	MustRegister(transform.Timeshift)
 	// Tags
 	MustRegister(tag.DropFunction)
 	MustRegister(tag.SetFunction)

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -174,9 +174,11 @@ func derivative(values []float64, parameters []function.Value, scale float64) ([
 	return result, nil
 }
 
-// Rate is special because it needs to get one extra data point to the left
-// This transform functions exactly like Derivative but bounds the result to be positive.
-// That is, it returns consecutive differences which are at least 0.
+// Rate is special because it needs to get one extra data point to the left.
+// This transform functions mostly like Derivative but bounds the result to be positive.
+// Specifically this function is designed for strictly increasing counters that
+// only decrease when reset to zero. That is, thie function returns consecutive
+// differences which are at least 0, or math.Max of the newly reported value and 0
 var Rate = newDerivativeBasedTransform("rate", rate)
 
 func rate(values []float64, parameters []function.Value, scale float64) ([]float64, error) {

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -191,6 +191,8 @@ func rate(values []float64, parameters []function.Value, scale float64) ([]float
 		result[i-1] = (values[i] - values[i-1]) / scale
 		if result[i-1] < 0 {
 			// values[i] is our best approximatation of the delta between i-1 and i
+			// Why? This should only be used on counters, so if v[i] - v[i-1] < 0 then
+			// the counter has reset, and we know *at least* v[i] increments have happened
 			result[i-1] = math.Max(values[i], 0) / scale
 		}
 	}

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -210,6 +210,9 @@ func newDerivativeBasedTransform(name string, transformer transform) function.Me
 			newContext := context
 			timerange := context.Timerange
 			newContext.Timerange, err = api.NewSnappedTimerange(timerange.Start()-timerange.ResolutionMillis(), timerange.End(), timerange.ResolutionMillis())
+			if err != nil {
+				return nil, err
+			}
 
 			// The new context has a timerange which is extended beyond the query's.
 			listValue, err := arguments[0].Evaluate(newContext)

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -157,3 +157,90 @@ var Alias = function.MetricFunction{
 		return list, nil
 	},
 }
+
+// Derivative is special because it needs to get one extra data point to the left
+// This transform estimates the "change per second" between the two samples (scaled consecutive difference)
+var Derivative = newDerivativeBasedTransform("derivative", derivative)
+
+func derivative(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+	result := make([]float64, len(values)-1)
+	for i := range values {
+		if i == 0 {
+			continue
+		}
+		// Scaled difference
+		result[i-1] = (values[i] - values[i-1]) / scale
+	}
+	return result, nil
+}
+
+// Rate is special because it needs to get one extra data point to the left
+// This transform functions exactly like Derivative but bounds the result to be positive.
+// That is, it returns consecutive differences which are at least 0.
+var Rate = newDerivativeBasedTransform("rate", rate)
+
+func rate(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+	result := make([]float64, len(values)-1)
+	for i := range values {
+		if i == 0 {
+			continue
+		}
+		// Scaled difference
+		result[i-1] = (values[i] - values[i-1]) / scale
+		if result[i-1] < 0 {
+			// values[i] is our best approximatation of the delta between i-1 and i
+			result[i-1] = math.Max(values[i], 0) / scale
+		}
+	}
+	return result, nil
+}
+
+// newDerivativeBasedTransform returns a function.MetricFunction that performs
+// a delta between two data points. The transform parameter is a function of type
+// transform is expected to return an array of values whose length is 1 less
+// than the given series
+func newDerivativeBasedTransform(name string, transformer transform) function.MetricFunction {
+	return function.MetricFunction{
+		Name:         "transform." + name,
+		MinArguments: 1,
+		MaxArguments: 1,
+		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+			var err error
+			// Calcuate the new timerange to include one extra point to the left
+			newContext := context
+			timerange := context.Timerange
+			newContext.Timerange, err = api.NewSnappedTimerange(timerange.Start()-timerange.ResolutionMillis(), timerange.End(), timerange.ResolutionMillis())
+
+			// The new context has a timerange which is extended beyond the query's.
+			listValue, err := arguments[0].Evaluate(newContext)
+			if err != nil {
+				return nil, err
+			}
+
+			// This value must be a SeriesList.
+			list, err := listValue.ToSeriesList(newContext.Timerange)
+			if err != nil {
+				return nil, err
+			}
+
+			// Reset the timerange
+			list.Timerange = context.Timerange
+
+			result, err := ApplyTransform(list, transformer, []function.Value{})
+			if err != nil {
+				return nil, err
+			}
+
+			// Validate our series are the correct length
+			for i := range result.Series {
+				if len(result.Series[i].Values) != len(list.Series[i].Values)-1 {
+					return nil, fmt.Errorf("Expected transform to return %d values, received %d", len(list.Series[i].Values)-1, len(result.Series[i].Values))
+				}
+			}
+
+			result.Query = fmt.Sprintf("transform.%s(%s)", name, listValue.GetName())
+			result.Name = result.Query
+			return result, nil
+		},
+	}
+}

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -241,7 +241,7 @@ func newDerivativeBasedTransform(name string, transformer transform) function.Me
 			// Validate our series are the correct length
 			for i := range result.Series {
 				if len(result.Series[i].Values) != len(list.Series[i].Values)-1 {
-					return nil, fmt.Errorf("Expected transform to return %d values, received %d", len(list.Series[i].Values)-1, len(result.Series[i].Values))
+					panic(fmt.Sprintf("Expected transform to return %d values, received %d", len(list.Series[i].Values)-1, len(result.Series[i].Values)))
 				}
 			}
 

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -58,48 +58,21 @@ func ApplyTransform(list api.SeriesList, transform transform, parameters []funct
 	return result, nil
 }
 
-// Derivative estimates the "change per second" between the two samples (scaled consecutive difference)
-func Derivative(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
-	result := make([]float64, len(values))
-	for i := range values {
-		if i == 0 {
-			// The first element has 0
-			result[i] = 0
-			continue
-		}
-		// Otherwise, it's the scaled difference
-		result[i] = (values[i] - values[i-1]) / scale
-	}
-	return result, nil
-}
-
 // Integral integrates a series whose values are "X per millisecond" to estimate "total X so far"
 // if the series represents "X in this sampling interval" instead, then you should use transformCumulative.
 func Integral(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	result := make([]float64, len(values))
 	integral := 0.0
 	for i := range values {
+		// Skip the 0th element since thats not technically part of our timerange
+		if i == 0 {
+			continue
+		}
+
 		if !math.IsNaN(values[i]) {
 			integral += values[i]
 		}
 		result[i] = integral * scale
-	}
-	return result, nil
-}
-
-// Rate functions exactly like transformDerivative but bounds the result to be positive.
-// That is, it returns consecutive differences which are at least 0.
-func Rate(values []float64, parameters []function.Value, scale float64) ([]float64, error) {
-	result := make([]float64, len(values))
-	for i := range values {
-		if i == 0 {
-			result[i] = 0
-			continue
-		}
-		result[i] = (values[i] - values[i-1]) / scale
-		if result[i] < 0 {
-			result[i] = 0
-		}
 	}
 	return result, nil
 }
@@ -109,6 +82,11 @@ func Cumulative(values []float64, parameters []function.Value, scale float64) ([
 	result := make([]float64, len(values))
 	sum := 0.0
 	for i := range values {
+		// Skip the 0th element since thats not technically part of our timerange
+		if i == 0 {
+			continue
+		}
+
 		if !math.IsNaN(values[i]) {
 			sum += values[i]
 		}


### PR DESCRIPTION
The transform.rate and transform.derivative functions now fetch an extra point
before the start of the timerange so that the start of the timerange represents
the delta from the point before, not simply 0.

The transform.integral and transform.cumulative functions now always start at
zero since the left-most datapoint isn't technically part of the series we're
summing or integrating over.

R: @cchandler || @cuzelac