### PR TITLE
Fix Profilers - Remove *Profiler from Contexts

### DIFF
--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -48,7 +48,6 @@ type FetchTimeseriesRequest struct {
 	Timerange      Timerange    // time range to fetch data from.
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
-	Profiler       *inspect.Profiler
 }
 
 type FetchMultipleTimeseriesRequest struct {
@@ -57,7 +56,6 @@ type FetchMultipleTimeseriesRequest struct {
 	Timerange      Timerange
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
-	Profiler       *inspect.Profiler
 }
 
 type TimeseriesStorageErrorCode int
@@ -110,7 +108,6 @@ func (r FetchMultipleTimeseriesRequest) ToSingle() []FetchTimeseriesRequest {
 			Cancellable:    r.Cancellable,
 			SampleMethod:   r.SampleMethod,
 			Timerange:      r.Timerange,
-			Profiler:       r.Profiler,
 		}
 		fetchSingleRequests = append(fetchSingleRequests, request)
 	}

--- a/function/expression.go
+++ b/function/expression.go
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 
 	"github.com/square/metrics/api"
-	"github.com/square/metrics/inspect"
 )
 
 // EvaluationContext is the central piece of logic, providing
@@ -23,7 +22,6 @@ type EvaluationContext struct {
 	Predicate            api.Predicate            // Predicate to apply to TagSets prior to fetching
 	FetchLimit           FetchCounter             // A limit on the number of fetches which may be performed
 	Cancellable          api.Cancellable
-	Profiler             *inspect.Profiler
 	Registry             Registry
 }
 

--- a/query/command.go
+++ b/query/command.go
@@ -32,7 +32,6 @@ type ExecutionContext struct {
 	MetricMetadataAPI    api.MetricMetadataAPI    // the api
 	FetchLimit           int                      // the maximum number of fetches
 	Timeout              time.Duration            // optional
-	Profiler             *inspect.Profiler        // optional
 	Registry             function.Registry        // optional
 	SlotLimit            int                      // optional (0 => default 1000)
 }
@@ -170,7 +169,6 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		SampleMethod:         cmd.context.SampleMethod,
 		Timerange:            timerange,
 		Cancellable:          cancellable,
-		Profiler:             context.Profiler,
 		Registry:             r,
 	}
 	if hasTimeout {
@@ -238,6 +236,9 @@ func (cmd ProfilingCommand) Execute(context ExecutionContext) (interface{}, erro
 		Profiler:       cmd.Profiler,
 		MetricMetadata: context.MetricMetadataAPI,
 	}
-	context.Profiler = cmd.Profiler
+	context.TimeseriesStorageAPI = api.ProfilingTimeseriesStorageAPI{
+		Profiler:             cmd.Profiler,
+		TimeseriesStorageAPI: context.TimeseriesStorageAPI,
+	}
 	return cmd.Command.Execute(context)
 }

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -40,16 +40,16 @@ func TestCommand_Describe(t *testing.T) {
 		metricmetadata api.MetricMetadataAPI
 		expected       map[string][]string
 	}{
-		{"describe series_0", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
-		{"describe`series_0`", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
-		{"describe series_0 where dc='west'", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe`series_0`where(dc='west')", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe series_0 where dc='west' or env = 'production'", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
-		{"describe series_0 where`dc`='west'or`env`='production'", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
-		{"describe series_0 where dc='west' or env = 'production' and doesnotexist = ''", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe series_0 where env = 'production' and doesnotexist = '' or dc = 'west'", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe series_0 where (dc='west' or env = 'production') and doesnotexist = ''", &fakeAPI, map[string][]string{}},
-		{"describe series_0 where(dc='west' or env = 'production')and`doesnotexist` = ''", &fakeAPI, map[string][]string{}},
+		{"describe series_0", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
+		{"describe`series_0`", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
+		{"describe series_0 where dc='west'", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe`series_0`where(dc='west')", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where dc='west' or env = 'production'", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
+		{"describe series_0 where`dc`='west'or`env`='production'", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
+		{"describe series_0 where dc='west' or env = 'production' and doesnotexist = ''", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where env = 'production' and doesnotexist = '' or dc = 'west'", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where (dc='west' or env = 'production') and doesnotexist = ''", fakeAPI, map[string][]string{}},
+		{"describe series_0 where(dc='west' or env = 'production')and`doesnotexist` = ''", fakeAPI, map[string][]string{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		command, err := Parse(test.query)
@@ -78,9 +78,9 @@ func TestCommand_DescribeAll(t *testing.T) {
 		metricmetadata api.MetricMetadataAPI
 		expected       []api.MetricKey
 	}{
-		{"describe all", &fakeAPI, []api.MetricKey{"series_0", "series_1", "series_2", "series_3"}},
-		{"describe all match '_0'", &fakeAPI, []api.MetricKey{"series_0"}},
-		{"describe all match '_5'", &fakeAPI, []api.MetricKey{}},
+		{"describe all", fakeAPI, []api.MetricKey{"series_0", "series_1", "series_2", "series_3"}},
+		{"describe all match '_0'", fakeAPI, []api.MetricKey{"series_0"}},
+		{"describe all match '_5'", fakeAPI, []api.MetricKey{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		command, err := Parse(test.query)
@@ -420,7 +420,7 @@ func TestCommand_Select(t *testing.T) {
 		a.EqString(command.Name(), "select")
 		rawResult, err := command.Execute(ExecutionContext{
 			TimeseriesStorageAPI: fakeBackend,
-			MetricMetadataAPI:    &fakeAPI,
+			MetricMetadataAPI:    fakeAPI,
 			FetchLimit:           1000,
 			Timeout:              10 * time.Millisecond,
 		})
@@ -456,7 +456,7 @@ func TestCommand_Select(t *testing.T) {
 	}
 	context := ExecutionContext{
 		TimeseriesStorageAPI: fakeBackend,
-		MetricMetadataAPI:    &fakeAPI,
+		MetricMetadataAPI:    fakeAPI,
 		FetchLimit:           3,
 		Timeout:              0,
 	}
@@ -548,7 +548,7 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: &fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
@@ -632,7 +632,7 @@ func TestQuery(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: &fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
@@ -728,7 +728,7 @@ func TestTag(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: &fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue

--- a/query/expression.go
+++ b/query/expression.go
@@ -75,7 +75,6 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 			context.Timerange,
 			context.MetricMetadataAPI,
 			context.Cancellable,
-			context.Profiler,
 		},
 	)
 

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -74,7 +74,7 @@ func TestMovingAverage(t *testing.T) {
 	backend := fakeBackend
 	result, err := evaluateToSeriesList(expression,
 		function.EvaluationContext{
-			MetricMetadataAPI:    &fakeAPI,
+			MetricMetadataAPI:    fakeAPI,
 			TimeseriesStorageAPI: backend,
 			Timerange:            timerange,
 			SampleMethod:         api.SampleMean,

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -33,8 +33,8 @@ type FakeMetricMetadataAPI struct {
 
 var _ api.MetricMetadataAPI = (*FakeMetricMetadataAPI)(nil)
 
-func NewFakeMetricMetadataAPI() FakeMetricMetadataAPI {
-	return FakeMetricMetadataAPI{
+func NewFakeMetricMetadataAPI() *FakeMetricMetadataAPI {
+	return &FakeMetricMetadataAPI{
 		metricTagSets: make(map[api.MetricKey][]api.TagSet),
 		metricsForTags: make(map[struct {
 			key   string

--- a/timeseries_storage/blueflood/blueflood_test.go
+++ b/timeseries_storage/blueflood/blueflood_test.go
@@ -147,9 +147,9 @@ func Test_Blueflood(t *testing.T) {
 	} {
 		a := assert.New(t).Contextf("%s", test.name)
 
-		fakeApi := mocks.NewFakeMetricMetadataAPI()
+		fakeAPI := mocks.NewFakeMetricMetadataAPI()
 		for k, v := range test.metricMap {
-			fakeApi.AddPair(v, k, &graphite)
+			fakeAPI.AddPair(v, k, &graphite)
 		}
 
 		fakeHttpClient := mocks.NewFakeHttpClient()
@@ -166,7 +166,7 @@ func Test_Blueflood(t *testing.T) {
 			Metric:         test.queryMetric,
 			SampleMethod:   test.sampleMethod,
 			Timerange:      test.timerange,
-			MetricMetadata: &fakeApi,
+			MetricMetadata: fakeAPI,
 			Cancellable:    api.NewCancellable(),
 		})
 
@@ -253,8 +253,8 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		},
 	}
 
-	fakeApi := mocks.NewFakeMetricMetadataAPI()
-	fakeApi.AddPair(
+	fakeAPI := mocks.NewFakeMetricMetadataAPI()
+	fakeAPI.AddPair(
 		api.TaggedMetric{
 			MetricKey: api.MetricKey("some.key"),
 			TagSet:    api.ParseTagSet("tag=value"),
@@ -389,7 +389,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		},
 		SampleMethod:   api.SampleMean,
 		Timerange:      queryTimerange,
-		MetricMetadata: &fakeApi,
+		MetricMetadata: fakeAPI,
 		Cancellable:    api.NewCancellable(),
 	})
 	if err != nil {


### PR DESCRIPTION
This PR fixes profiling in MQE. See #207 as well, which offers a different solution. 

This change moves the `*Profiler` pointers out of the `ExecutionContext`s, `EvaluationContext`s, and the `FetchSingle/MultipleRequest`s. 

Instead, the `*inspect.Profiler` pointer is placed exclusively in the `ProfilingMetadataAPI`, the `ProfilingTimeseriesStorageAPI`, and the `ProfilingCommand`.

However, because of this, it is not possible to profile individual `FetchSingleSeries` calls, since the `ProfilingTimeseriesStorageAPI` isn't able to capture these calls (single the `blueflood` object explicitly invokes the methods on itself).

In general, this might not be a problem (for example, a backend which uses batched requests wouldn't have any meaningful single-series requests to profile).

PR #207 goes in a different direction, instead getting rid of the `ProfilingAPI` types and exclusively passing the `*inspect.Profiler` pointer around in the contexts. 