### PR TITLE
Fix Profiler - Delete ProfilingAPI types

### DIFF
--- a/api/metric_metadata_api.go
+++ b/api/metric_metadata_api.go
@@ -21,6 +21,10 @@ package api
 
 import "github.com/square/metrics/inspect"
 
+type MetricMetadataAPIContext struct {
+	Profiler *inspect.Profiler
+}
+
 type MetricMetadataConfig struct {
 	// Location of conversion rules. All *.yaml files in here will be loaded.
 	//TODO(cchandler): Move this into the util package along with
@@ -36,16 +40,16 @@ type MetricMetadataConfig struct {
 
 type MetricMetadataAPI interface {
 	// AddMetric adds the metric to the system.
-	AddMetric(metric TaggedMetric, profiler *inspect.Profiler) error
+	AddMetric(metric TaggedMetric, context MetricMetadataAPIContext) error
 	// Bulk metrics addition
-	AddMetrics(metric []TaggedMetric, profiler *inspect.Profiler) error
+	AddMetrics(metric []TaggedMetric, context MetricMetadataAPIContext) error
 	// RemoveMetric removes the metric from the system.
-	RemoveMetric(metric TaggedMetric, profiler *inspect.Profiler) error
+	RemoveMetric(metric TaggedMetric, context MetricMetadataAPIContext) error
 	// For a given MetricKey, retrieve all the tagsets associated with it.
-	GetAllTags(metricKey MetricKey, profiler *inspect.Profiler) ([]TagSet, error)
+	GetAllTags(metricKey MetricKey, context MetricMetadataAPIContext) ([]TagSet, error)
 	// GetAllMetrics returns all metrics managed by the system.
-	GetAllMetrics(profiler *inspect.Profiler) ([]MetricKey, error)
+	GetAllMetrics(context MetricMetadataAPIContext) ([]MetricKey, error)
 	// For a given tag key-value pair, obtain the list of all the MetricKeys
 	// associated with them.
-	GetMetricsForTag(tagKey, tagValue string, profiler *inspect.Profiler) ([]MetricKey, error)
+	GetMetricsForTag(tagKey, tagValue string, context MetricMetadataAPIContext) ([]MetricKey, error)
 }

--- a/api/metric_metadata_api.go
+++ b/api/metric_metadata_api.go
@@ -19,6 +19,8 @@
 
 package api
 
+import "github.com/square/metrics/inspect"
+
 type MetricMetadataConfig struct {
 	// Location of conversion rules. All *.yaml files in here will be loaded.
 	//TODO(cchandler): Move this into the util package along with
@@ -34,16 +36,16 @@ type MetricMetadataConfig struct {
 
 type MetricMetadataAPI interface {
 	// AddMetric adds the metric to the system.
-	AddMetric(metric TaggedMetric) error
+	AddMetric(metric TaggedMetric, profiler *inspect.Profiler) error
 	// Bulk metrics addition
-	AddMetrics(metric []TaggedMetric) error
+	AddMetrics(metric []TaggedMetric, profiler *inspect.Profiler) error
 	// RemoveMetric removes the metric from the system.
-	RemoveMetric(metric TaggedMetric) error
+	RemoveMetric(metric TaggedMetric, profiler *inspect.Profiler) error
 	// For a given MetricKey, retrieve all the tagsets associated with it.
-	GetAllTags(metricKey MetricKey) ([]TagSet, error)
+	GetAllTags(metricKey MetricKey, profiler *inspect.Profiler) ([]TagSet, error)
 	// GetAllMetrics returns all metrics managed by the system.
-	GetAllMetrics() ([]MetricKey, error)
+	GetAllMetrics(profiler *inspect.Profiler) ([]MetricKey, error)
 	// For a given tag key-value pair, obtain the list of all the MetricKeys
 	// associated with them.
-	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
+	GetMetricsForTag(tagKey, tagValue string, profiler *inspect.Profiler) ([]MetricKey, error)
 }

--- a/api/metric_metadata_api.go
+++ b/api/metric_metadata_api.go
@@ -19,8 +19,6 @@
 
 package api
 
-import "github.com/square/metrics/inspect"
-
 type MetricMetadataConfig struct {
 	// Location of conversion rules. All *.yaml files in here will be loaded.
 	//TODO(cchandler): Move this into the util package along with
@@ -48,36 +46,4 @@ type MetricMetadataAPI interface {
 	// For a given tag key-value pair, obtain the list of all the MetricKeys
 	// associated with them.
 	GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error)
-}
-
-type ProfilingMetricMetadataAPI struct {
-	Profiler       *inspect.Profiler
-	MetricMetadata MetricMetadataAPI
-}
-
-var _ MetricMetadataAPI = (*ProfilingMetricMetadataAPI)(nil)
-
-func (api ProfilingMetricMetadataAPI) AddMetric(metric TaggedMetric) error {
-	defer api.Profiler.Record("api.AddMetric")()
-	return api.MetricMetadata.AddMetric(metric)
-}
-func (api ProfilingMetricMetadataAPI) AddMetrics(metrics []TaggedMetric) error {
-	defer api.Profiler.Record("api.AddMetrics")()
-	return api.MetricMetadata.AddMetrics(metrics)
-}
-func (api ProfilingMetricMetadataAPI) RemoveMetric(metric TaggedMetric) error {
-	defer api.Profiler.Record("api.RemoveMetric")()
-	return api.MetricMetadata.RemoveMetric(metric)
-}
-func (api ProfilingMetricMetadataAPI) GetAllTags(metricKey MetricKey) ([]TagSet, error) {
-	defer api.Profiler.Record("api.GetAllTags")()
-	return api.MetricMetadata.GetAllTags(metricKey)
-}
-func (api ProfilingMetricMetadataAPI) GetAllMetrics() ([]MetricKey, error) {
-	defer api.Profiler.Record("api.GetAllMetrics")()
-	return api.MetricMetadata.GetAllMetrics()
-}
-func (api ProfilingMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string) ([]MetricKey, error) {
-	defer api.Profiler.Record("api.GetMetricsForTag")()
-	return api.MetricMetadata.GetMetricsForTag(tagKey, tagValue)
 }

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -25,29 +25,13 @@ type TimeseriesStorageAPI interface {
 	FetchMultipleTimeseries(request FetchMultipleTimeseriesRequest) (SeriesList, error)
 }
 
-type ProfilingTimeseriesStorageAPI struct {
-	Profiler             *inspect.Profiler
-	TimeseriesStorageAPI TimeseriesStorageAPI
-}
-
-var _ TimeseriesStorageAPI = (*ProfilingTimeseriesStorageAPI)(nil)
-
-func (a ProfilingTimeseriesStorageAPI) FetchSingleTimeseries(request FetchTimeseriesRequest) (Timeseries, error) {
-	defer a.Profiler.Record("timeseriesStorage.FetchSingleTimeseries")()
-	return a.TimeseriesStorageAPI.FetchSingleTimeseries(request)
-}
-
-func (a ProfilingTimeseriesStorageAPI) FetchMultipleTimeseries(request FetchMultipleTimeseriesRequest) (SeriesList, error) {
-	defer a.Profiler.Record("timeseriesStorage.FetchMultipleTimeseries")()
-	return a.TimeseriesStorageAPI.FetchMultipleTimeseries(request)
-}
-
 type FetchTimeseriesRequest struct {
 	Metric         TaggedMetric // metric to fetch.
 	SampleMethod   SampleMethod // up/downsampling behavior.
 	Timerange      Timerange    // time range to fetch data from.
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
+	Profiler       *inspect.Profiler
 }
 
 type FetchMultipleTimeseriesRequest struct {
@@ -56,6 +40,7 @@ type FetchMultipleTimeseriesRequest struct {
 	Timerange      Timerange
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
+	Profiler       *inspect.Profiler
 }
 
 type TimeseriesStorageErrorCode int
@@ -108,6 +93,7 @@ func (r FetchMultipleTimeseriesRequest) ToSingle() []FetchTimeseriesRequest {
 			Cancellable:    r.Cancellable,
 			SampleMethod:   r.SampleMethod,
 			Timerange:      r.Timerange,
+			Profiler:       r.Profiler,
 		}
 		fetchSingleRequests = append(fetchSingleRequests, request)
 	}

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -48,7 +48,6 @@ type FetchTimeseriesRequest struct {
 	Timerange      Timerange    // time range to fetch data from.
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
-	Profiler       *inspect.Profiler
 }
 
 type FetchMultipleTimeseriesRequest struct {
@@ -57,7 +56,6 @@ type FetchMultipleTimeseriesRequest struct {
 	Timerange      Timerange
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
-	Profiler       *inspect.Profiler
 }
 
 type TimeseriesStorageErrorCode int
@@ -110,7 +108,6 @@ func (r FetchMultipleTimeseriesRequest) ToSingle() []FetchTimeseriesRequest {
 			Cancellable:    r.Cancellable,
 			SampleMethod:   r.SampleMethod,
 			Timerange:      r.Timerange,
-			Profiler:       r.Profiler,
 		}
 		fetchSingleRequests = append(fetchSingleRequests, request)
 	}

--- a/function/expression.go
+++ b/function/expression.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
 )
 
 // EvaluationContext is the central piece of logic, providing
@@ -23,6 +24,7 @@ type EvaluationContext struct {
 	FetchLimit           FetchCounter             // A limit on the number of fetches which may be performed
 	Cancellable          api.Cancellable
 	Registry             Registry
+	Profiler             *inspect.Profiler // A profiler pointer
 }
 
 type Registry interface {

--- a/function/expression.go
+++ b/function/expression.go
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 
 	"github.com/square/metrics/api"
-	"github.com/square/metrics/inspect"
 )
 
 // EvaluationContext is the central piece of logic, providing
@@ -23,7 +22,6 @@ type EvaluationContext struct {
 	Predicate            api.Predicate            // Predicate to apply to TagSets prior to fetching
 	FetchLimit           FetchCounter             // A limit on the number of fetches which may be performed
 	Cancellable          api.Cancellable
-	Profiler             *inspect.Profiler
 	Registry             Registry
 }
 

--- a/main/metadata/metadata.go
+++ b/main/metadata/metadata.go
@@ -45,7 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("Success\n")
-	stuff, err := metadataAPI.GetAllTags("jvm.thread-states")
+	stuff, err := metadataAPI.GetAllTags("jvm.thread-states", nil)
 	if err != nil {
 		fmt.Printf("ERROR %s\n", err)
 		os.Exit(1)

--- a/main/metadata/metadata.go
+++ b/main/metadata/metadata.go
@@ -45,7 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("Success\n")
-	stuff, err := metadataAPI.GetAllTags("jvm.thread-states", nil)
+	stuff, err := metadataAPI.GetAllTags("jvm.thread-states", api.MetricMetadataAPIContext{})
 	if err != nil {
 		fmt.Printf("ERROR %s\n", err)
 		os.Exit(1)

--- a/main/ruletester/ruletester.go
+++ b/main/ruletester/ruletester.go
@@ -139,7 +139,7 @@ func run(ruleset util.RuleSet, scanner *bufio.Scanner, apiInstance api.MetricMet
 					perMetric := stat.perMetric[converted.MetricKey]
 					perMetric.matched++
 					if *insertToDatabase {
-						apiInstance.AddMetric(converted)
+						apiInstance.AddMetric(converted, nil)
 					}
 					if *reverse {
 						reversed, err := ruleset.ToGraphiteName(converted)

--- a/metric_metadata/cassandra/cassandra.go
+++ b/metric_metadata/cassandra/cassandra.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/square/metrics/api"
-	"github.com/square/metrics/inspect"
 )
 
 type CassandraMetricMetadataAPI struct {
@@ -48,8 +47,8 @@ func NewCassandraMetricMetadataAPI(config CassandraMetricMetadataConfig) (api.Me
 	}, nil
 }
 
-func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
-	defer profiler.Record("Cassandra AddMetric")()
+func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("Cassandra AddMetric")()
 	if err := a.db.AddMetricName(metric.MetricKey, metric.TagSet); err != nil {
 		return err
 	}
@@ -61,29 +60,29 @@ func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric, profiler
 	return nil
 }
 
-func (a *CassandraMetricMetadataAPI) AddMetrics(metrics []api.TaggedMetric, profiler *inspect.Profiler) error {
-	defer profiler.Record("Cassandra AddMetrics")()
+func (a *CassandraMetricMetadataAPI) AddMetrics(metrics []api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("Cassandra AddMetrics")()
 	a.db.AddMetricNames(metrics)
 	return nil
 }
 
-func (a *CassandraMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, profiler *inspect.Profiler) ([]api.TagSet, error) {
-	defer profiler.Record("Cassandra GetAllTags")()
+func (a *CassandraMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, context api.MetricMetadataAPIContext) ([]api.TagSet, error) {
+	defer context.Profiler.Record("Cassandra GetAllTags")()
 	return a.db.GetTagSet(metricKey)
 }
 
-func (a *CassandraMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, profiler *inspect.Profiler) ([]api.MetricKey, error) {
-	defer profiler.Record("Cassandra GetMetricsForTag")()
+func (a *CassandraMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, context api.MetricMetadataAPIContext) ([]api.MetricKey, error) {
+	defer context.Profiler.Record("Cassandra GetMetricsForTag")()
 	return a.db.GetMetricKeys(tagKey, tagValue)
 }
 
-func (a *CassandraMetricMetadataAPI) GetAllMetrics(profiler *inspect.Profiler) ([]api.MetricKey, error) {
-	defer profiler.Record("Cassandra GetAllMetrics")()
+func (a *CassandraMetricMetadataAPI) GetAllMetrics(context api.MetricMetadataAPIContext) ([]api.MetricKey, error) {
+	defer context.Profiler.Record("Cassandra GetAllMetrics")()
 	return a.db.GetAllMetrics()
 }
 
-func (a *CassandraMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
-	defer profiler.Record("Cassandra RemoveMetric")()
+func (a *CassandraMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("Cassandra RemoveMetric")()
 	if err := a.db.RemoveMetricName(metric.MetricKey, metric.TagSet); err != nil {
 		return err
 	}

--- a/metric_metadata/cassandra/cassandra.go
+++ b/metric_metadata/cassandra/cassandra.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
 )
 
 type CassandraMetricMetadataAPI struct {
@@ -47,7 +48,8 @@ func NewCassandraMetricMetadataAPI(config CassandraMetricMetadataConfig) (api.Me
 	}, nil
 }
 
-func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric) error {
+func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
+	defer profiler.Record("Cassandra AddMetric")()
 	if err := a.db.AddMetricName(metric.MetricKey, metric.TagSet); err != nil {
 		return err
 	}
@@ -59,24 +61,29 @@ func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric) error {
 	return nil
 }
 
-func (a *CassandraMetricMetadataAPI) AddMetrics(metrics []api.TaggedMetric) error {
+func (a *CassandraMetricMetadataAPI) AddMetrics(metrics []api.TaggedMetric, profiler *inspect.Profiler) error {
+	defer profiler.Record("Cassandra AddMetrics")()
 	a.db.AddMetricNames(metrics)
 	return nil
 }
 
-func (a *CassandraMetricMetadataAPI) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error) {
+func (a *CassandraMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, profiler *inspect.Profiler) ([]api.TagSet, error) {
+	defer profiler.Record("Cassandra GetAllTags")()
 	return a.db.GetTagSet(metricKey)
 }
 
-func (a *CassandraMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string) ([]api.MetricKey, error) {
+func (a *CassandraMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, profiler *inspect.Profiler) ([]api.MetricKey, error) {
+	defer profiler.Record("Cassandra GetMetricsForTag")()
 	return a.db.GetMetricKeys(tagKey, tagValue)
 }
 
-func (a *CassandraMetricMetadataAPI) GetAllMetrics() ([]api.MetricKey, error) {
+func (a *CassandraMetricMetadataAPI) GetAllMetrics(profiler *inspect.Profiler) ([]api.MetricKey, error) {
+	defer profiler.Record("Cassandra GetAllMetrics")()
 	return a.db.GetAllMetrics()
 }
 
-func (a *CassandraMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric) error {
+func (a *CassandraMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
+	defer profiler.Record("Cassandra RemoveMetric")()
 	if err := a.db.RemoveMetricName(metric.MetricKey, metric.TagSet); err != nil {
 		return err
 	}

--- a/query/command.go
+++ b/query/command.go
@@ -235,6 +235,6 @@ func (cmd ProfilingCommand) Name() string {
 
 func (cmd ProfilingCommand) Execute(context ExecutionContext) (interface{}, error) {
 	defer cmd.Profiler.Record(fmt.Sprintf("%s.Execute", cmd.Name()))()
-	context.Profiler = inspect.New()
+	context.Profiler = cmd.Profiler
 	return cmd.Command.Execute(context)
 }

--- a/query/command.go
+++ b/query/command.go
@@ -32,7 +32,6 @@ type ExecutionContext struct {
 	MetricMetadataAPI    api.MetricMetadataAPI    // the api
 	FetchLimit           int                      // the maximum number of fetches
 	Timeout              time.Duration            // optional
-	Profiler             *inspect.Profiler        // optional
 	Registry             function.Registry        // optional
 	SlotLimit            int                      // optional (0 => default 1000)
 }
@@ -170,7 +169,6 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		SampleMethod:         cmd.context.SampleMethod,
 		Timerange:            timerange,
 		Cancellable:          cancellable,
-		Profiler:             context.Profiler,
 		Registry:             r,
 	}
 	if hasTimeout {
@@ -238,6 +236,9 @@ func (cmd ProfilingCommand) Execute(context ExecutionContext) (interface{}, erro
 		Profiler:       cmd.Profiler,
 		MetricMetadata: context.MetricMetadataAPI,
 	}
-	context.Profiler = cmd.Profiler
+	context.TimeseriesStorageAPI = api.ProfilingTimeseriesStorageAPI{
+		Profiler:             cmd.Profiler,
+		TimeseriesStorageAPI: context.TimeseriesStorageAPI,
+	}
 	return cmd.Command.Execute(context)
 }

--- a/query/command.go
+++ b/query/command.go
@@ -73,7 +73,7 @@ type SelectCommand struct {
 
 // Execute returns the list of tags satisfying the provided predicate.
 func (cmd *DescribeCommand) Execute(context ExecutionContext) (interface{}, error) {
-	tagsets, _ := context.MetricMetadataAPI.GetAllTags(cmd.metricName)
+	tagsets, _ := context.MetricMetadataAPI.GetAllTags(cmd.metricName, context.Profiler)
 	// Splitting each tag key into its own set of values is helpful for discovering actual metrics.
 	keyValueSets := map[string]map[string]bool{} // a map of tag_key => Set{tag_value}.
 	for _, tagset := range tagsets {
@@ -106,7 +106,7 @@ func (cmd *DescribeCommand) Name() string {
 
 // Execute of a DescribeAllCommand returns the list of all metrics.
 func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (interface{}, error) {
-	result, err := context.MetricMetadataAPI.GetAllMetrics()
+	result, err := context.MetricMetadataAPI.GetAllMetrics(context.Profiler)
 	if err == nil {
 		filtered := make([]api.MetricKey, 0, len(result))
 		for _, row := range result {
@@ -126,7 +126,7 @@ func (cmd *DescribeAllCommand) Name() string {
 
 // Execute asks for all metrics with the given name.
 func (cmd *DescribeMetricsCommand) Execute(context ExecutionContext) (interface{}, error) {
-	return context.MetricMetadataAPI.GetMetricsForTag(cmd.tagKey, cmd.tagValue)
+	return context.MetricMetadataAPI.GetMetricsForTag(cmd.tagKey, cmd.tagValue, context.Profiler)
 }
 
 func (cmd *DescribeMetricsCommand) Name() string {

--- a/query/command.go
+++ b/query/command.go
@@ -73,7 +73,9 @@ type SelectCommand struct {
 
 // Execute returns the list of tags satisfying the provided predicate.
 func (cmd *DescribeCommand) Execute(context ExecutionContext) (interface{}, error) {
-	tagsets, _ := context.MetricMetadataAPI.GetAllTags(cmd.metricName, context.Profiler)
+	tagsets, _ := context.MetricMetadataAPI.GetAllTags(cmd.metricName, api.MetricMetadataAPIContext{
+		Profiler: context.Profiler,
+	})
 	// Splitting each tag key into its own set of values is helpful for discovering actual metrics.
 	keyValueSets := map[string]map[string]bool{} // a map of tag_key => Set{tag_value}.
 	for _, tagset := range tagsets {
@@ -106,7 +108,9 @@ func (cmd *DescribeCommand) Name() string {
 
 // Execute of a DescribeAllCommand returns the list of all metrics.
 func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (interface{}, error) {
-	result, err := context.MetricMetadataAPI.GetAllMetrics(context.Profiler)
+	result, err := context.MetricMetadataAPI.GetAllMetrics(api.MetricMetadataAPIContext{
+		Profiler: context.Profiler,
+	})
 	if err == nil {
 		filtered := make([]api.MetricKey, 0, len(result))
 		for _, row := range result {
@@ -126,7 +130,9 @@ func (cmd *DescribeAllCommand) Name() string {
 
 // Execute asks for all metrics with the given name.
 func (cmd *DescribeMetricsCommand) Execute(context ExecutionContext) (interface{}, error) {
-	return context.MetricMetadataAPI.GetMetricsForTag(cmd.tagKey, cmd.tagValue, context.Profiler)
+	return context.MetricMetadataAPI.GetMetricsForTag(cmd.tagKey, cmd.tagValue, api.MetricMetadataAPIContext{
+		Profiler: context.Profiler,
+	})
 }
 
 func (cmd *DescribeMetricsCommand) Name() string {

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -40,16 +40,16 @@ func TestCommand_Describe(t *testing.T) {
 		metricmetadata api.MetricMetadataAPI
 		expected       map[string][]string
 	}{
-		{"describe series_0", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
-		{"describe`series_0`", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
-		{"describe series_0 where dc='west'", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe`series_0`where(dc='west')", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe series_0 where dc='west' or env = 'production'", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
-		{"describe series_0 where`dc`='west'or`env`='production'", &fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
-		{"describe series_0 where dc='west' or env = 'production' and doesnotexist = ''", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe series_0 where env = 'production' and doesnotexist = '' or dc = 'west'", &fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
-		{"describe series_0 where (dc='west' or env = 'production') and doesnotexist = ''", &fakeAPI, map[string][]string{}},
-		{"describe series_0 where(dc='west' or env = 'production')and`doesnotexist` = ''", &fakeAPI, map[string][]string{}},
+		{"describe series_0", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
+		{"describe`series_0`", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c", "d"}}},
+		{"describe series_0 where dc='west'", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe`series_0`where(dc='west')", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where dc='west' or env = 'production'", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
+		{"describe series_0 where`dc`='west'or`env`='production'", fakeAPI, map[string][]string{"dc": {"east", "west"}, "env": {"production", "staging"}, "host": {"a", "b", "c"}}},
+		{"describe series_0 where dc='west' or env = 'production' and doesnotexist = ''", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where env = 'production' and doesnotexist = '' or dc = 'west'", fakeAPI, map[string][]string{"dc": {"west"}, "env": {"production", "staging"}, "host": {"a", "b"}}},
+		{"describe series_0 where (dc='west' or env = 'production') and doesnotexist = ''", fakeAPI, map[string][]string{}},
+		{"describe series_0 where(dc='west' or env = 'production')and`doesnotexist` = ''", fakeAPI, map[string][]string{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		command, err := Parse(test.query)
@@ -78,9 +78,9 @@ func TestCommand_DescribeAll(t *testing.T) {
 		metricmetadata api.MetricMetadataAPI
 		expected       []api.MetricKey
 	}{
-		{"describe all", &fakeAPI, []api.MetricKey{"series_0", "series_1", "series_2", "series_3"}},
-		{"describe all match '_0'", &fakeAPI, []api.MetricKey{"series_0"}},
-		{"describe all match '_5'", &fakeAPI, []api.MetricKey{}},
+		{"describe all", fakeAPI, []api.MetricKey{"series_0", "series_1", "series_2", "series_3"}},
+		{"describe all match '_0'", fakeAPI, []api.MetricKey{"series_0"}},
+		{"describe all match '_5'", fakeAPI, []api.MetricKey{}},
 	} {
 		a := assert.New(t).Contextf("query=%s", test.query)
 		command, err := Parse(test.query)
@@ -420,7 +420,7 @@ func TestCommand_Select(t *testing.T) {
 		a.EqString(command.Name(), "select")
 		rawResult, err := command.Execute(ExecutionContext{
 			TimeseriesStorageAPI: fakeBackend,
-			MetricMetadataAPI:    &fakeAPI,
+			MetricMetadataAPI:    fakeAPI,
 			FetchLimit:           1000,
 			Timeout:              10 * time.Millisecond,
 		})
@@ -456,7 +456,7 @@ func TestCommand_Select(t *testing.T) {
 	}
 	context := ExecutionContext{
 		TimeseriesStorageAPI: fakeBackend,
-		MetricMetadataAPI:    &fakeAPI,
+		MetricMetadataAPI:    fakeAPI,
 		FetchLimit:           3,
 		Timeout:              0,
 	}
@@ -548,7 +548,7 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: &fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
@@ -632,7 +632,7 @@ func TestQuery(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: &fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
@@ -728,7 +728,7 @@ func TestTag(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: &fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue

--- a/query/expression.go
+++ b/query/expression.go
@@ -75,6 +75,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 			context.Timerange,
 			context.MetricMetadataAPI,
 			context.Cancellable,
+			context.Profiler,
 		},
 	)
 

--- a/query/expression.go
+++ b/query/expression.go
@@ -75,7 +75,6 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 			context.Timerange,
 			context.MetricMetadataAPI,
 			context.Cancellable,
-			context.Profiler,
 		},
 	)
 

--- a/query/expression.go
+++ b/query/expression.go
@@ -49,7 +49,9 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 		predicate = &andPredicate{[]api.Predicate{expr.predicate, context.Predicate}}
 	}
 
-	metricTagSets, err := context.MetricMetadataAPI.GetAllTags(api.MetricKey(expr.metricName), context.Profiler)
+	metricTagSets, err := context.MetricMetadataAPI.GetAllTags(api.MetricKey(expr.metricName), api.MetricMetadataAPIContext{
+		Profiler: context.Profiler,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/query/expression.go
+++ b/query/expression.go
@@ -49,7 +49,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 		predicate = &andPredicate{[]api.Predicate{expr.predicate, context.Predicate}}
 	}
 
-	metricTagSets, err := context.MetricMetadataAPI.GetAllTags(api.MetricKey(expr.metricName))
+	metricTagSets, err := context.MetricMetadataAPI.GetAllTags(api.MetricKey(expr.metricName), context.Profiler)
 	if err != nil {
 		return nil, err
 	}

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 	"time"
 
-	// "github.com/square/metrics/api/backend"
+	"github.com/square/metrics/api"
 	"github.com/square/metrics/testing_support/mocks"
+	"github.com/square/metrics/util"
 )
 
 func TestProfilerIntegration(t *testing.T) {
-	t.Skip("This test is entirely broken. Postponing until proper cleanup can be done. Notes in-line")
 	myAPI := mocks.NewFakeMetricMetadataAPI()
 	fakeTimeStorage := mocks.FakeTimeseriesStorageAPI{}
 	// 	myAPI := fakeAPI{
@@ -47,10 +47,20 @@ func TestProfilerIntegration(t *testing.T) {
 	// 	},
 	// }
 
-	// emptyGraphiteName := util.GraphiteMetric("")
-	// myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=1,y=2")}, emptyGraphiteName)
+	emptyGraphiteName := util.GraphiteMetric("")
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=1,y=2")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=2,y=2")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=3,y=1")}, emptyGraphiteName)
 
-	multiBackend := fakeTimeStorage
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.ParseTagSet("q=foo")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.ParseTagSet("q=bar")}, emptyGraphiteName)
+
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=1")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=2")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=3")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=4")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=5")}, emptyGraphiteName)
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=6")}, emptyGraphiteName)
 
 	testCases := []struct {
 		query    string
@@ -60,64 +70,64 @@ func TestProfilerIntegration(t *testing.T) {
 			query: "describe all",
 			expected: map[string]int{
 				"describe all.Execute": 1,
-				"api.GetAllMetrics":    1,
+				"Mock GetAllMetrics":   1,
 			},
 		},
 		{
 			query: "select A from 0 to 0",
 			expected: map[string]int{
-				"select.Execute":      1,
-				"fetchMultipleSeries": 1,
-				"api.GetAllTags":      1,
-				"fetchSingleSeries":   3,
+				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 1,
+				"Mock GetAllTags":              1,
+				"Mock FetchSingleTimeseries":   3,
 			},
 		},
 		{
 			query: "select A+A from 0 to 0",
 			expected: map[string]int{
-				"select.Execute":      1,
-				"fetchMultipleSeries": 2,
-				"api.GetAllTags":      2,
-				"fetchSingleSeries":   6,
+				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 2,
+				"Mock GetAllTags":              2,
+				"Mock FetchSingleTimeseries":   6,
 			},
 		},
 		{
 			query: "select A+2 from 0 to 0",
 			expected: map[string]int{
-				"select.Execute":      1,
-				"fetchMultipleSeries": 1,
-				"api.GetAllTags":      1,
-				"fetchSingleSeries":   3,
+				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 1,
+				"Mock GetAllTags":              1,
+				"Mock FetchSingleTimeseries":   3,
 			},
 		},
 		{
 			query: "select A where y = '2' from 0 to 0",
 			expected: map[string]int{
-				"select.Execute":      1,
-				"fetchMultipleSeries": 1,
-				"api.GetAllTags":      1,
-				"fetchSingleSeries":   2,
+				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 1,
+				"Mock GetAllTags":              1,
+				"Mock FetchSingleTimeseries":   2,
 			},
 		},
 		{
 			query: "describe A",
 			expected: map[string]int{
 				"describe.Execute": 1,
-				"api.GetAllTags":   1,
+				"Mock GetAllTags":  1,
 			},
 		},
 		{
 			query: "describe metrics where y='2'",
 			expected: map[string]int{
 				"describe metrics.Execute": 1,
-				"api.GetMetricsForTag":     1,
+				"Mock GetMetricsForTag":    1,
 			},
 		},
 		{
 			query: "describe all",
 			expected: map[string]int{
 				"describe all.Execute": 1,
-				"api.GetAllMetrics":    1,
+				"Mock GetAllMetrics":   1,
 			},
 		},
 	}
@@ -131,8 +141,8 @@ func TestProfilerIntegration(t *testing.T) {
 		profilingCommand, profiler := NewProfilingCommand(cmd)
 
 		_, err = profilingCommand.Execute(ExecutionContext{
-			TimeseriesStorageAPI: multiBackend,
-			MetricMetadataAPI:    &myAPI,
+			TimeseriesStorageAPI: fakeTimeStorage,
+			MetricMetadataAPI:    myAPI,
 			FetchLimit:           10000,
 			Timeout:              time.Second * 4,
 		})
@@ -146,16 +156,15 @@ func TestProfilerIntegration(t *testing.T) {
 			counts[node.Name()]++
 		}
 
-		//TODO(cchandler): This added expectation demonstrates that this test has always
-		//been broken. We'll have to clean this up later when we can address the time series
-		//storage API.
-		if len(test.expected) != len(list) {
-			t.Errorf("The number of calls doesn't match the expected amount: %+v %+v", test.expected, list)
+		if len(test.expected) != len(counts) {
+			t.Errorf("The number of calls doesn't match the expected amount.")
+			t.Errorf("Expected %+v, but got %+v", test.expected, counts)
 		}
 
-		for name, count := range counts {
-			if test.expected[name] != count {
-				t.Errorf("Expected %+v but got %+v (from %+v)", test.expected, counts, list)
+		for name, count := range test.expected {
+			if counts[name] != count {
+				t.Errorf("Expected `%s` to have %d occurrences, but had %d\n", name, count, counts[name])
+				t.Errorf("Expected: %+v\nBut got: %+v\n", test.expected, counts)
 				break
 			}
 		}

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -74,7 +74,7 @@ func TestMovingAverage(t *testing.T) {
 	backend := fakeBackend
 	result, err := evaluateToSeriesList(expression,
 		function.EvaluationContext{
-			MetricMetadataAPI:    &fakeAPI,
+			MetricMetadataAPI:    fakeAPI,
 			TimeseriesStorageAPI: backend,
 			Timerange:            timerange,
 			SampleMethod:         api.SampleMean,

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -34,8 +34,8 @@ type FakeMetricMetadataAPI struct {
 
 var _ api.MetricMetadataAPI = (*FakeMetricMetadataAPI)(nil)
 
-func NewFakeMetricMetadataAPI() FakeMetricMetadataAPI {
-	return FakeMetricMetadataAPI{
+func NewFakeMetricMetadataAPI() *FakeMetricMetadataAPI {
+	return &FakeMetricMetadataAPI{
 		metricTagSets: make(map[api.MetricKey][]api.TagSet),
 		metricsForTags: make(map[struct {
 			key   string
@@ -145,7 +145,7 @@ func (fa *FakeGraphiteConverter) ToTaggedName(metric util.GraphiteMetric) (api.T
 type FakeTimeseriesStorageAPI struct{}
 
 func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request api.FetchTimeseriesRequest) (api.Timeseries, error) {
-	defer request.Profiler.Record("FakeTimeseriesStorageAPI FetchSingleTimeseries")()
+	defer request.Profiler.Record("Mock FetchSingleTimeseries")()
 	metricMap := map[api.MetricKey][]api.Timeseries{
 		"series_1": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}},
 		"series_2": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}, {[]float64{3, 0, 3, 6, 2}, api.ParseTagSet("dc=east")}},
@@ -172,7 +172,7 @@ func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request api.FetchTimeser
 }
 
 func (f FakeTimeseriesStorageAPI) FetchMultipleTimeseries(request api.FetchMultipleTimeseriesRequest) (api.SeriesList, error) {
-	defer request.Profiler.Record("FakeTimeseriesStorageAPI FetchMultipleTimeseries")()
+	defer request.Profiler.Record("Mock FetchMultipleTimeseries")()
 	timeseries := make([]api.Timeseries, 0)
 
 	singleRequests := request.ToSingle()

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/util"
 )
 
@@ -61,23 +62,28 @@ func (fa *FakeMetricMetadataAPI) AddPairWithoutGraphite(tm api.TaggedMetric, gm 
 	}
 }
 
-func (fa *FakeMetricMetadataAPI) AddMetric(metric api.TaggedMetric) error {
+func (fa *FakeMetricMetadataAPI) AddMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
+	defer profiler.Record("Mock AddMetric")()
 	return nil
 }
 
-func (fa *FakeMetricMetadataAPI) AddMetrics(metric []api.TaggedMetric) error {
+func (fa *FakeMetricMetadataAPI) AddMetrics(metric []api.TaggedMetric, profiler *inspect.Profiler) error {
+	defer profiler.Record("Mock AddMetrics")()
 	return nil
 }
 
-func (fa *FakeMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric) error {
+func (fa *FakeMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
+	defer profiler.Record("Mock RemoveMetric")()
 	return nil
 }
 
-func (fa *FakeMetricMetadataAPI) GetAllTags(metricKey api.MetricKey) ([]api.TagSet, error) {
+func (fa *FakeMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, profiler *inspect.Profiler) ([]api.TagSet, error) {
+	defer profiler.Record("Mock GetAllTags")()
 	return fa.metricTagSets[metricKey], nil
 }
 
-func (fa *FakeMetricMetadataAPI) GetAllMetrics() ([]api.MetricKey, error) {
+func (fa *FakeMetricMetadataAPI) GetAllMetrics(profiler *inspect.Profiler) ([]api.MetricKey, error) {
+	defer profiler.Record("Mock GetAllMetrics")()
 	array := []api.MetricKey{}
 	for key := range fa.metricTagSets {
 		array = append(array, key)
@@ -95,7 +101,8 @@ func (fa *FakeMetricMetadataAPI) AddMetricsForTag(key string, value string, metr
 	fa.metricsForTags[pair] = append(fa.metricsForTags[pair], api.MetricKey(metric))
 }
 
-func (fa *FakeMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string) ([]api.MetricKey, error) {
+func (fa *FakeMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, profiler *inspect.Profiler) ([]api.MetricKey, error) {
+	defer profiler.Record("Mock GetMetricsForTag")()
 	list := []api.MetricKey{}
 MetricLoop:
 	for metric, tagsets := range fa.metricTagSets {
@@ -138,6 +145,7 @@ func (fa *FakeGraphiteConverter) ToTaggedName(metric util.GraphiteMetric) (api.T
 type FakeTimeseriesStorageAPI struct{}
 
 func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request api.FetchTimeseriesRequest) (api.Timeseries, error) {
+	defer request.Profiler.Record("FakeTimeseriesStorageAPI FetchSingleTimeseries")()
 	metricMap := map[api.MetricKey][]api.Timeseries{
 		"series_1": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}},
 		"series_2": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}, {[]float64{3, 0, 3, 6, 2}, api.ParseTagSet("dc=east")}},
@@ -164,6 +172,7 @@ func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request api.FetchTimeser
 }
 
 func (f FakeTimeseriesStorageAPI) FetchMultipleTimeseries(request api.FetchMultipleTimeseriesRequest) (api.SeriesList, error) {
+	defer request.Profiler.Record("FakeTimeseriesStorageAPI FetchMultipleTimeseries")()
 	timeseries := make([]api.Timeseries, 0)
 
 	singleRequests := request.ToSingle()

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 
 	"github.com/square/metrics/api"
-	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/util"
 )
 
@@ -62,28 +61,28 @@ func (fa *FakeMetricMetadataAPI) AddPairWithoutGraphite(tm api.TaggedMetric, gm 
 	}
 }
 
-func (fa *FakeMetricMetadataAPI) AddMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
-	defer profiler.Record("Mock AddMetric")()
+func (fa *FakeMetricMetadataAPI) AddMetric(metric api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("Mock AddMetric")()
 	return nil
 }
 
-func (fa *FakeMetricMetadataAPI) AddMetrics(metric []api.TaggedMetric, profiler *inspect.Profiler) error {
-	defer profiler.Record("Mock AddMetrics")()
+func (fa *FakeMetricMetadataAPI) AddMetrics(metric []api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("Mock AddMetrics")()
 	return nil
 }
 
-func (fa *FakeMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric, profiler *inspect.Profiler) error {
-	defer profiler.Record("Mock RemoveMetric")()
+func (fa *FakeMetricMetadataAPI) RemoveMetric(metric api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("Mock RemoveMetric")()
 	return nil
 }
 
-func (fa *FakeMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, profiler *inspect.Profiler) ([]api.TagSet, error) {
-	defer profiler.Record("Mock GetAllTags")()
+func (fa *FakeMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, context api.MetricMetadataAPIContext) ([]api.TagSet, error) {
+	defer context.Profiler.Record("Mock GetAllTags")()
 	return fa.metricTagSets[metricKey], nil
 }
 
-func (fa *FakeMetricMetadataAPI) GetAllMetrics(profiler *inspect.Profiler) ([]api.MetricKey, error) {
-	defer profiler.Record("Mock GetAllMetrics")()
+func (fa *FakeMetricMetadataAPI) GetAllMetrics(context api.MetricMetadataAPIContext) ([]api.MetricKey, error) {
+	defer context.Profiler.Record("Mock GetAllMetrics")()
 	array := []api.MetricKey{}
 	for key := range fa.metricTagSets {
 		array = append(array, key)
@@ -101,8 +100,8 @@ func (fa *FakeMetricMetadataAPI) AddMetricsForTag(key string, value string, metr
 	fa.metricsForTags[pair] = append(fa.metricsForTags[pair], api.MetricKey(metric))
 }
 
-func (fa *FakeMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, profiler *inspect.Profiler) ([]api.MetricKey, error) {
-	defer profiler.Record("Mock GetMetricsForTag")()
+func (fa *FakeMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, context api.MetricMetadataAPIContext) ([]api.MetricKey, error) {
+	defer context.Profiler.Record("Mock GetMetricsForTag")()
 	list := []api.MetricKey{}
 MetricLoop:
 	for metric, tagsets := range fa.metricTagSets {

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -192,6 +192,7 @@ func (b *Blueflood) fetchManyLazy(cancellable api.Cancellable, works []func() (a
 }
 
 func (b *Blueflood) FetchMultipleTimeseries(request api.FetchMultipleTimeseriesRequest) (api.SeriesList, error) {
+	defer request.Profiler.Record("Blueflood FetchMultipleTimeseries")()
 	if request.Cancellable == nil {
 		panic("The cancellable component of a FetchMultipleTimeseriesRequest cannot be nil")
 	}
@@ -216,6 +217,7 @@ func (b *Blueflood) FetchMultipleTimeseries(request api.FetchMultipleTimeseriesR
 }
 
 func (b *Blueflood) FetchSingleTimeseries(request api.FetchTimeseriesRequest) (api.Timeseries, error) {
+	defer request.Profiler.Record("Blueflood FetchSingleTimeseries")()
 	sampler, ok := samplerMap[request.SampleMethod]
 	if !ok {
 		return api.Timeseries{}, fmt.Errorf("unsupported SampleMethod %s", request.SampleMethod.String())

--- a/timeseries_storage/blueflood/blueflood_test.go
+++ b/timeseries_storage/blueflood/blueflood_test.go
@@ -166,7 +166,7 @@ func Test_Blueflood(t *testing.T) {
 			Metric:         test.queryMetric,
 			SampleMethod:   test.sampleMethod,
 			Timerange:      test.timerange,
-			MetricMetadata: &fakeApi,
+			MetricMetadata: fakeApi,
 			Cancellable:    api.NewCancellable(),
 		})
 
@@ -389,7 +389,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		},
 		SampleMethod:   api.SampleMean,
 		Timerange:      queryTimerange,
-		MetricMetadata: &fakeApi,
+		MetricMetadata: fakeApi,
 		Cancellable:    api.NewCancellable(),
 	})
 	if err != nil {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -132,7 +132,7 @@ func (h tokenHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 	// 2. functions
 	// 3. identifiers
 	body["functions"] = h.context.Registry.All()
-	metrics, err := h.context.MetricMetadataAPI.GetAllMetrics()
+	metrics, err := h.context.MetricMetadataAPI.GetAllMetrics(nil) // no profiling used
 	if err != nil {
 		errorResponse(writer, http.StatusInternalServerError, err)
 		return

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/square/metrics/api"
 	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/log"
 	_ "github.com/square/metrics/main/static" // ensure that the static files are included.
@@ -132,7 +133,7 @@ func (h tokenHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 	// 2. functions
 	// 3. identifiers
 	body["functions"] = h.context.Registry.All()
-	metrics, err := h.context.MetricMetadataAPI.GetAllMetrics(nil) // no profiling used
+	metrics, err := h.context.MetricMetadataAPI.GetAllMetrics(api.MetricMetadataAPIContext{}) // no profiling used
 	if err != nil {
 		errorResponse(writer, http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
This PR fixes profiling in MQE. See #206 as well, which offers a different solution.

In this version, the `*inspect.Profiler` pointers are carried by the `ExecutionContext` and the `EvaluationContext`, and added to the `FetchTimeseriesRequest` and `FetchMultipleTimeseriesRequest` when they are created. The `*Profiler` for the `MetricMetadataAPI` is placed into a `MetricMetadataAPIContext` which is added as an argument to every call. Currently, it's simplest created by putting the `*Profiler` from the execution context or the evaluation context into it.

Each MetadataAPI and TimeseriesStorageAPI implementation is responsible for performing its own profiling- there's no longer any kind of `ProfilingFooAPI`. 

~~The main advantage of #207 over #206 is that you're able to get profiling data from `.FetchSingleTimeseries` in addition to the aggregate time total from `.FetchMultipleTimeseries` This disadvantage of this design is that each new API (including the mocks, etc.) are required to implement their own profiling.~~

#206 has been closed in favor of #207.
