### PR TITLE
Ruletester Cleanup / Usability Improvements

### DIFF
--- a/main/common/common.go
+++ b/main/common/common.go
@@ -52,7 +52,9 @@ type Config struct {
 
 func LoadConfig() Config {
 	var config Config
-
+	if *ConfigFile == "" {
+		ExitWithMessage("No config file was specified. Specify it with '-config-file'")
+	}
 	f, err := os.Open(*ConfigFile)
 	if err != nil {
 		ExitWithMessage(fmt.Sprintf("unable to open config file `%s`", *ConfigFile))
@@ -80,7 +82,7 @@ func ExitWithRequired(flagName string) {
 
 // ExitWithMessage terminates the program with the provided message.
 func ExitWithMessage(message string) {
-	fmt.Fprint(os.Stderr, message)
+	fmt.Fprintf(os.Stderr, "%s\n", message)
 	os.Exit(1)
 }
 

--- a/main/ruletester/ruletester.go
+++ b/main/ruletester/ruletester.go
@@ -76,7 +76,7 @@ func ReadMetricsFile(file string) ([]string, error) {
 		return nil, err
 	}
 
-	strings := make([]string, 0, len(result))
+	strings := []string{}
 	for k := range result {
 		strings = append(strings, k)
 	}
@@ -84,7 +84,9 @@ func ReadMetricsFile(file string) ([]string, error) {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	if os.Getenv("GOMAXPROCS") == "" {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
 	flag.Parse()
 	common.SetupLogger()
 


### PR DESCRIPTION
While trying out the new ruletester, I ran into a few problems that were pretty straightforward to solve:

* When a flag is missing, say what flag it is: namely `-metrics-file` and `-rule-path`
* Don't ask for a complete configuration file (doesn't need `-config-file`)- only the conversion rule path was being used, so the rest of the config was extraneous
* Increase `runtime.GOMAXPROCS` to `runtime.NumCPU()` so that it runs fully in parallel - this increased speed slightly on my machine

I also just cleaned up the commented code and some unused functions, and added error checking in a handful of places.

The batching of metrics obscured what was going on in the code a little bit- so I got rid of it. Running the program a few times on my machine took ~65s (real/clock time) either way.

To help find buggy conversion rules, metrics which fail to be reversed are printed after the ruletester runs. Additionally, rules are now checked for successful conversion back into the original graphite, and these are also printed if they differ from the expected original.