### PR TITLE
Add an externalized optimizer.

### DIFF
--- a/function/expression.go
+++ b/function/expression.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/inspect"
+	"github.com/square/metrics/optimize"
 )
 
 // EvaluationContext is the central piece of logic, providing
@@ -16,15 +17,16 @@ import (
 // * Contains current timerange being queried for - this can be
 // changed by say, application of time shift function.
 type EvaluationContext struct {
-	TimeseriesStorageAPI api.TimeseriesStorageAPI // Backend to fetch data from
-	MetricMetadataAPI    api.MetricMetadataAPI    // Api to obtain metadata from
-	Timerange            api.Timerange            // Timerange to fetch data from
-	SampleMethod         api.SampleMethod         // SampleMethod to use when up/downsampling to match the requested resolution
-	Predicate            api.Predicate            // Predicate to apply to TagSets prior to fetching
-	FetchLimit           FetchCounter             // A limit on the number of fetches which may be performed
-	Cancellable          api.Cancellable
-	Registry             Registry
-	Profiler             *inspect.Profiler // A profiler pointer
+	TimeseriesStorageAPI      api.TimeseriesStorageAPI // Backend to fetch data from
+	MetricMetadataAPI         api.MetricMetadataAPI    // Api to obtain metadata from
+	Timerange                 api.Timerange            // Timerange to fetch data from
+	SampleMethod              api.SampleMethod         // SampleMethod to use when up/downsampling to match the requested resolution
+	Predicate                 api.Predicate            // Predicate to apply to TagSets prior to fetching
+	FetchLimit                FetchCounter             // A limit on the number of fetches which may be performed
+	Cancellable               api.Cancellable
+	Registry                  Registry
+	Profiler                  *inspect.Profiler // A profiler pointer
+	OptimizationConfiguration *optimize.OptimizationConfiguration
 }
 
 type Registry interface {

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -25,6 +25,7 @@ import (
 	"github.com/square/metrics/function/registry"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/metric_metadata/cassandra"
+	"github.com/square/metrics/optimize"
 	"github.com/square/metrics/query"
 	"github.com/square/metrics/timeseries_storage/blueflood"
 	"github.com/square/metrics/ui"
@@ -68,11 +69,15 @@ func main() {
 
 	blueflood := blueflood.NewBlueflood(config.Blueflood)
 
+	optimizer := optimize.NewOptimizationConfiguration()
+	optimizer.EnableMetricMetadataCaching = true
+
 	startServer(config.UIConfig, query.ExecutionContext{
-		MetricMetadataAPI:    apiInstance,
-		TimeseriesStorageAPI: blueflood,
-		FetchLimit:           1000,
-		SlotLimit:            5000,
-		Registry:             registry.Default(),
+		MetricMetadataAPI:         apiInstance,
+		TimeseriesStorageAPI:      blueflood,
+		FetchLimit:                1000,
+		SlotLimit:                 5000,
+		Registry:                  registry.Default(),
+		OptimizationConfiguration: optimizer,
 	})
 }

--- a/optimize/optimize.go
+++ b/optimize/optimize.go
@@ -1,0 +1,83 @@
+package optimize
+
+import (
+	_ "fmt"
+	"sync"
+	"time"
+
+	"github.com/square/metrics/api"
+)
+
+// The optimization package is designed to be an externalized
+// set of behaviors that can be shared across query/function to
+// enable selective behaviors that will improve performance.
+// The goal is to keep them as implementation-agnostic as possible.
+
+// Optimization configuration has the tunable nobs for
+// improving performance.
+type OptimizationConfiguration struct {
+	EnableMetricMetadataCaching bool
+	metricMetadataAPI           api.MetricMetadataAPI
+	metricKeyToTagCache         map[api.MetricKey]TagSetCacheEntry
+	mutex                       *sync.Mutex
+	TimeSourceForNow            TimeSource
+	CacheTTL                    time.Duration
+}
+
+type TimeSource func() time.Time
+
+type TagSetCacheEntry struct {
+	tags      []api.TagSet
+	expiresAt time.Time
+}
+
+func NewOptimizationConfiguration() *OptimizationConfiguration {
+	optimize := OptimizationConfiguration{
+		metricKeyToTagCache: make(map[api.MetricKey]TagSetCacheEntry, 3000),
+		mutex:               &sync.Mutex{},
+		CacheTTL:            time.Hour * 2,
+		TimeSourceForNow:    time.Now,
+	}
+	return &optimize
+}
+
+// If we have a cached result for this particular metric then use it,
+// otherwise call the supplied update function and cache the result
+// transparently.
+func (optimize *OptimizationConfiguration) AllTagsCacheHitOrExecute(metric api.MetricKey, update func() ([]api.TagSet, error)) ([]api.TagSet, error) {
+	// If caching is disabled, always run the provided update function
+	if !optimize.EnableMetricMetadataCaching {
+		return update()
+	}
+
+	tags, cacheHit := optimize.cacheGet(metric)
+	if !cacheHit {
+		var err error
+		if tags, err = update(); err != nil {
+			return nil, err
+		}
+
+		optimize.cacheUpdate(metric, tags)
+		return tags, nil
+	}
+	return tags, nil
+}
+
+func (optimize *OptimizationConfiguration) cacheUpdate(metric api.MetricKey, tags []api.TagSet) {
+	optimize.mutex.Lock()
+	defer optimize.mutex.Unlock()
+	optimize.metricKeyToTagCache[metric] = TagSetCacheEntry{
+		tags:      tags,
+		expiresAt: time.Now().Add(optimize.CacheTTL),
+	}
+}
+
+func (optimize *OptimizationConfiguration) cacheGet(metric api.MetricKey) ([]api.TagSet, bool) {
+	if val, ok := optimize.metricKeyToTagCache[metric]; ok {
+		if optimize.TimeSourceForNow().After(val.expiresAt) {
+			return nil, false
+		}
+		return val.tags, true
+	}
+	return nil, false
+}

--- a/optimize/optimize_test.go
+++ b/optimize/optimize_test.go
@@ -1,0 +1,53 @@
+package optimize
+
+import (
+	"testing"
+	"time"
+
+	"github.com/square/metrics/api"
+)
+
+func TestCaching(t *testing.T) {
+	optimizer := NewOptimizationConfiguration()
+	optimizer.EnableMetricMetadataCaching = true
+
+	updateFunc := func() ([]api.TagSet, error) {
+		// map[string]string
+		result := []api.TagSet{api.NewTagSet()}
+		return result, nil
+	}
+	someMetric := api.MetricKey("blah")
+	optimizer.AllTagsCacheHitOrExecute(someMetric, updateFunc)
+
+	updateFunc = func() ([]api.TagSet, error) {
+		t.Errorf("Should not be called")
+		return nil, nil
+	}
+
+	optimizer.AllTagsCacheHitOrExecute(someMetric, updateFunc)
+}
+
+func TestCacheExpiration(t *testing.T) {
+	optimizer := NewOptimizationConfiguration()
+	optimizer.EnableMetricMetadataCaching = true
+
+	latch := false
+	updateFunc := func() ([]api.TagSet, error) {
+		// map[string]string
+		latch = true
+		result := []api.TagSet{api.NewTagSet()}
+		return result, nil
+	}
+	someMetric := api.MetricKey("blah")
+	optimizer.AllTagsCacheHitOrExecute(someMetric, updateFunc)
+	if !latch {
+		t.Errorf("We expected the update function to be called, but it wasn't")
+	}
+	optimizer.TimeSourceForNow = func() time.Time { return time.Now().Add(5 * time.Hour) }
+	latch = false // Reset the latch
+
+	optimizer.AllTagsCacheHitOrExecute(someMetric, updateFunc)
+	if !latch {
+		t.Errorf("We expected the update function to be called, but it wasn't")
+	}
+}

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
+	"github.com/square/metrics/optimize"
 	"github.com/square/metrics/testing_support/assert"
 	"github.com/square/metrics/testing_support/mocks"
 	"github.com/square/metrics/util"
@@ -60,7 +61,13 @@ func TestCommand_Describe(t *testing.T) {
 
 		a.EqString(command.Name(), "describe")
 		fakeTimeseriesStorage := mocks.FakeTimeseriesStorageAPI{}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeTimeseriesStorage, MetricMetadataAPI: test.metricmetadata, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{
+			TimeseriesStorageAPI:      fakeTimeseriesStorage,
+			MetricMetadataAPI:         test.metricmetadata,
+			FetchLimit:                1000,
+			Timeout:                   0,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
+		})
 		a.CheckError(err)
 		a.Eq(rawResult, test.expected)
 	}
@@ -91,7 +98,13 @@ func TestCommand_DescribeAll(t *testing.T) {
 
 		a.EqString(command.Name(), "describe all")
 		fakeMulti := mocks.FakeTimeseriesStorageAPI{}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeMulti, MetricMetadataAPI: test.metricmetadata, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{
+			TimeseriesStorageAPI:      fakeMulti,
+			MetricMetadataAPI:         test.metricmetadata,
+			FetchLimit:                1000,
+			Timeout:                   0,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
+		})
 		a.CheckError(err)
 		a.Eq(rawResult, test.expected)
 	}
@@ -419,10 +432,11 @@ func TestCommand_Select(t *testing.T) {
 		}
 		a.EqString(command.Name(), "select")
 		rawResult, err := command.Execute(ExecutionContext{
-			TimeseriesStorageAPI: fakeBackend,
-			MetricMetadataAPI:    fakeAPI,
-			FetchLimit:           1000,
-			Timeout:              100 * time.Millisecond,
+			TimeseriesStorageAPI:      fakeBackend,
+			MetricMetadataAPI:         fakeAPI,
+			FetchLimit:                1000,
+			Timeout:                   100 * time.Millisecond,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		if err != nil {
 			if !test.expectError {
@@ -455,10 +469,11 @@ func TestCommand_Select(t *testing.T) {
 		return
 	}
 	context := ExecutionContext{
-		TimeseriesStorageAPI: fakeBackend,
-		MetricMetadataAPI:    fakeAPI,
-		FetchLimit:           3,
-		Timeout:              0,
+		TimeseriesStorageAPI:      fakeBackend,
+		MetricMetadataAPI:         fakeAPI,
+		FetchLimit:                3,
+		Timeout:                   0,
+		OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 	}
 	_, err = command.Execute(context)
 	if err != nil {
@@ -548,7 +563,13 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{
+			TimeseriesStorageAPI:      fakeBackend,
+			MetricMetadataAPI:         fakeAPI,
+			FetchLimit:                1000,
+			Timeout:                   0,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
+		})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
@@ -632,7 +653,13 @@ func TestQuery(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{
+			TimeseriesStorageAPI:      fakeBackend,
+			MetricMetadataAPI:         fakeAPI,
+			FetchLimit:                1000,
+			Timeout:                   0,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
+		})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
@@ -728,7 +755,13 @@ func TestTag(t *testing.T) {
 			t.Errorf("Expected select command but got %s", command.Name())
 			continue
 		}
-		rawResult, err := command.Execute(ExecutionContext{TimeseriesStorageAPI: fakeBackend, MetricMetadataAPI: fakeAPI, FetchLimit: 1000, Timeout: 0})
+		rawResult, err := command.Execute(ExecutionContext{
+			TimeseriesStorageAPI:      fakeBackend,
+			MetricMetadataAPI:         fakeAPI,
+			FetchLimit:                1000,
+			Timeout:                   0,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
+		})
 		if err != nil {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/optimize"
 	"github.com/square/metrics/testing_support/mocks"
 	"github.com/square/metrics/util"
 )
@@ -141,10 +142,11 @@ func TestProfilerIntegration(t *testing.T) {
 		profilingCommand, profiler := NewProfilingCommand(cmd)
 
 		_, err = profilingCommand.Execute(ExecutionContext{
-			TimeseriesStorageAPI: fakeTimeStorage,
-			MetricMetadataAPI:    myAPI,
-			FetchLimit:           10000,
-			Timeout:              time.Second * 4,
+			TimeseriesStorageAPI:      fakeTimeStorage,
+			MetricMetadataAPI:         myAPI,
+			FetchLimit:                10000,
+			Timeout:                   time.Second * 4,
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 
 		if err != nil {

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 	"github.com/square/metrics/function/registry"
+	"github.com/square/metrics/optimize"
 	"github.com/square/metrics/testing_support/mocks"
 )
 
@@ -74,13 +75,14 @@ func TestMovingAverage(t *testing.T) {
 	backend := fakeBackend
 	result, err := evaluateToSeriesList(expression,
 		function.EvaluationContext{
-			MetricMetadataAPI:    fakeAPI,
-			TimeseriesStorageAPI: backend,
-			Timerange:            timerange,
-			SampleMethod:         api.SampleMean,
-			FetchLimit:           function.NewFetchCounter(1000),
-			Registry:             registry.Default(),
-			Cancellable:          api.NewCancellable(),
+			MetricMetadataAPI:         fakeAPI,
+			TimeseriesStorageAPI:      backend,
+			Timerange:                 timerange,
+			SampleMethod:              api.SampleMean,
+			FetchLimit:                function.NewFetchCounter(1000),
+			Registry:                  registry.Default(),
+			Cancellable:               api.NewCancellable(),
+			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
The optimize functions are external to both query/function because
go forbids import loops and the capabilities have to be available
in both. Further, I'd like this to be as implementation agnostic
as possible since it's technically for query optimization, so I
opted to put it in its own package for now rather than push it into
the underlying metricmetadata API