### PR TITLE
Fix race condition in metric tag caching

### DIFF
--- a/optimize/optimize.go
+++ b/optimize/optimize.go
@@ -77,6 +77,8 @@ func (optimize *OptimizationConfiguration) cacheUpdate(metric api.MetricKey, tag
 }
 
 func (optimize *OptimizationConfiguration) cacheGet(metric api.MetricKey) ([]api.TagSet, bool) {
+	optimize.mutex.Lock()
+	defer optimize.mutex.Unlock()
 	if val, ok := optimize.metricKeyToTagCache[metric]; ok {
 		if optimize.TimeSourceForNow().After(val.expiresAt) {
 			return nil, false


### PR DESCRIPTION
This PR locks the cache mutex before reading from the `metricsKeyToTagCache` map.

Maps in Go are not threadsafe. It is only safe for there to be *one writer* **or** *many readers* **but not both**.

If a goroutine writes to the map while another goroutine is reading it, garbage may be read from it.