### PR TITLE
Add metadata to command execution results

### DIFF
--- a/main/query/query.go
+++ b/main/query/query.go
@@ -76,7 +76,7 @@ func main() {
 			fmt.Println("execution error:", err.Error())
 			continue
 		}
-		encoded, err := json.MarshalIndent(result, "", "  ")
+		encoded, err := json.MarshalIndent(result.Data, "", "  ")
 		if err != nil {
 			fmt.Println("encoding error:", err.Error())
 			return

--- a/main/query/query.go
+++ b/main/query/query.go
@@ -76,7 +76,7 @@ func main() {
 			fmt.Println("execution error:", err.Error())
 			continue
 		}
-		encoded, err := json.MarshalIndent(result.Data, "", "  ")
+		encoded, err := json.MarshalIndent(result.Body, "", "  ")
 		if err != nil {
 			fmt.Println("encoding error:", err.Error())
 			return

--- a/query/command.go
+++ b/query/command.go
@@ -39,12 +39,17 @@ type ExecutionContext struct {
 	OptimizationConfiguration *optimize.OptimizationConfiguration // optional
 }
 
+type CommandResult struct {
+	Data     interface{}
+	Metadata map[string]interface{}
+}
+
 // Command is the final result of the parsing.
 // A command contains all the information to execute the
 // given query against the API.
 type Command interface {
 	// Execute the given command. Returns JSON-encodable result or an error.
-	Execute(ExecutionContext) (interface{}, error)
+	Execute(ExecutionContext) (CommandResult, error)
 	Name() string
 }
 
@@ -74,7 +79,7 @@ type SelectCommand struct {
 }
 
 // Execute returns the list of tags satisfying the provided predicate.
-func (cmd *DescribeCommand) Execute(context ExecutionContext) (interface{}, error) {
+func (cmd *DescribeCommand) Execute(context ExecutionContext) (CommandResult, error) {
 
 	// We generate a simple update function that closes around the profiler
 	// so if we do have a cache miss it's correctly reported on this request.
@@ -109,7 +114,7 @@ func (cmd *DescribeCommand) Execute(context ExecutionContext) (interface{}, erro
 		natural_sort.Sort(list)
 		keyValueLists[key] = list
 	}
-	return keyValueLists, nil
+	return CommandResult{Data: keyValueLists}, nil
 }
 
 func (cmd *DescribeCommand) Name() string {
@@ -117,7 +122,7 @@ func (cmd *DescribeCommand) Name() string {
 }
 
 // Execute of a DescribeAllCommand returns the list of all metrics.
-func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (interface{}, error) {
+func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (CommandResult, error) {
 	result, err := context.MetricMetadataAPI.GetAllMetrics(api.MetricMetadataAPIContext{
 		Profiler: context.Profiler,
 	})
@@ -129,9 +134,9 @@ func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (interface{}, e
 			}
 		}
 		sort.Sort(api.MetricKeys(filtered))
-		return filtered, nil
+		return CommandResult{Data: filtered}, nil
 	}
-	return nil, err
+	return CommandResult{}, err
 }
 
 func (cmd *DescribeAllCommand) Name() string {
@@ -139,10 +144,14 @@ func (cmd *DescribeAllCommand) Name() string {
 }
 
 // Execute asks for all metrics with the given name.
-func (cmd *DescribeMetricsCommand) Execute(context ExecutionContext) (interface{}, error) {
-	return context.MetricMetadataAPI.GetMetricsForTag(cmd.tagKey, cmd.tagValue, api.MetricMetadataAPIContext{
+func (cmd *DescribeMetricsCommand) Execute(context ExecutionContext) (CommandResult, error) {
+	result, err := context.MetricMetadataAPI.GetMetricsForTag(cmd.tagKey, cmd.tagValue, api.MetricMetadataAPIContext{
 		Profiler: context.Profiler,
 	})
+	if err != nil {
+		return CommandResult{}, err
+	}
+	return CommandResult{Data: result}, err
 }
 
 func (cmd *DescribeMetricsCommand) Name() string {
@@ -150,10 +159,10 @@ func (cmd *DescribeMetricsCommand) Name() string {
 }
 
 // Execute performs the query represented by the given query string, and returs the result.
-func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error) {
+func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, error) {
 	timerange, err := api.NewSnappedTimerange(cmd.context.Start, cmd.context.End, cmd.context.Resolution)
 	if err != nil {
-		return nil, err
+		return CommandResult{}, err
 	}
 	slotLimit := context.SlotLimit
 	defaultLimit := 1000
@@ -174,11 +183,11 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 
 	chosenTimerange, err := api.NewSnappedTimerange(timerange.Start(), timerange.End(), int64(chosenResolution/time.Millisecond))
 	if err != nil {
-		return nil, err
+		return CommandResult{}, err
 	}
 
 	if chosenTimerange.Slots() > slotLimit {
-		return nil, function.NewLimitError(
+		return CommandResult{}, function.NewLimitError(
 			"Requested number of data points exceeds the configured limit",
 			chosenTimerange.Slots(), slotLimit)
 	}
@@ -222,26 +231,26 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		}()
 		select {
 		case <-timeout:
-			return nil, function.NewLimitError("Timeout while executing the query.",
+			return CommandResult{}, function.NewLimitError("Timeout while executing the query.",
 				context.Timeout, context.Timeout)
 		case result := <-results:
-			return result, nil
+			return CommandResult{Data: result}, nil
 		case err := <-errors:
-			return nil, err
+			return CommandResult{}, err
 		}
 	} else {
 		values, err := function.EvaluateMany(evaluationContext, cmd.expressions)
 		if err != nil {
-			return nil, err
+			return CommandResult{}, err
 		}
 		lists := make([]api.SeriesList, len(values))
 		for i := range values {
 			lists[i], err = values[i].ToSeriesList(evaluationContext.Timerange)
 			if err != nil {
-				return nil, err
+				return CommandResult{}, err
 			}
 		}
-		return lists, nil
+		return CommandResult{Data: lists}, nil
 	}
 }
 
@@ -267,7 +276,7 @@ func (cmd ProfilingCommand) Name() string {
 	return cmd.Command.Name()
 }
 
-func (cmd ProfilingCommand) Execute(context ExecutionContext) (interface{}, error) {
+func (cmd ProfilingCommand) Execute(context ExecutionContext) (CommandResult, error) {
 	defer cmd.Profiler.Record(fmt.Sprintf("%s.Execute", cmd.Name()))()
 	context.Profiler = cmd.Profiler
 	return cmd.Command.Execute(context)

--- a/query/command.go
+++ b/query/command.go
@@ -40,8 +40,8 @@ type ExecutionContext struct {
 }
 
 type CommandResult struct {
-	Data     interface{}
-	Metadata map[string]interface{}
+	Body     interface{}            `json:"body,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Command is the final result of the parsing.
@@ -114,7 +114,7 @@ func (cmd *DescribeCommand) Execute(context ExecutionContext) (CommandResult, er
 		natural_sort.Sort(list)
 		keyValueLists[key] = list
 	}
-	return CommandResult{Data: keyValueLists}, nil
+	return CommandResult{Body: keyValueLists}, nil
 }
 
 func (cmd *DescribeCommand) Name() string {
@@ -135,7 +135,7 @@ func (cmd *DescribeAllCommand) Execute(context ExecutionContext) (CommandResult,
 		}
 		sort.Sort(api.MetricKeys(filtered))
 		return CommandResult{
-			Data: filtered,
+			Body: filtered,
 			Metadata: map[string]interface{}{
 				"count": len(filtered),
 			},
@@ -157,7 +157,7 @@ func (cmd *DescribeMetricsCommand) Execute(context ExecutionContext) (CommandRes
 		return CommandResult{}, err
 	}
 	return CommandResult{
-		Data: data,
+		Body: data,
 		Metadata: map[string]interface{}{
 			"count": len(data),
 		},
@@ -278,7 +278,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 			description[key] = filtered
 		}
 		return CommandResult{
-			Data: lists,
+			Body: lists,
 			Metadata: map[string]interface{}{
 				"description": description,
 			},

--- a/query/command.go
+++ b/query/command.go
@@ -40,8 +40,8 @@ type ExecutionContext struct {
 }
 
 type CommandResult struct {
-	Body     interface{}            `json:"body,omitempty"`
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Body     interface{}
+	Metadata map[string]interface{}
 }
 
 // Command is the final result of the parsing.
@@ -343,6 +343,9 @@ func (cmd ProfilingCommand) Execute(context ExecutionContext) (CommandResult, er
 				Start:  profile.Start().UnixNano() / int64(time.Millisecond),
 				Finish: profile.Finish().UnixNano() / int64(time.Millisecond),
 			})
+		}
+		if result.Metadata == nil {
+			result.Metadata = map[string]interface{}{}
 		}
 		result.Metadata["profile"] = jsonProfiles
 	}

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -68,7 +68,7 @@ func TestCommand_Describe(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		a.CheckError(err)
-		a.Eq(rawResult.Data, test.expected)
+		a.Eq(rawResult.Body, test.expected)
 	}
 }
 
@@ -105,7 +105,7 @@ func TestCommand_DescribeAll(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		a.CheckError(err)
-		a.Eq(rawResult.Data, test.expected)
+		a.Eq(rawResult.Body, test.expected)
 	}
 }
 
@@ -442,7 +442,7 @@ func TestCommand_Select(t *testing.T) {
 			}
 		} else {
 			a.CheckError(err)
-			actual := rawResult.Data.([]api.SeriesList)
+			actual := rawResult.Body.([]api.SeriesList)
 			a.EqInt(len(actual), len(expected))
 			if len(actual) == len(expected) {
 				for i := range actual {
@@ -573,9 +573,9 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.Data.([]api.SeriesList)
+		seriesListList, ok := rawResult.Body.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Body, rawResult.Body)
 			continue
 		}
 		actual := seriesListList[0].Name
@@ -668,9 +668,9 @@ func TestQuery(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.Data.([]api.SeriesList)
+		seriesListList, ok := rawResult.Body.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Body, rawResult.Body)
 			continue
 		}
 		actual := seriesListList[0].Query
@@ -775,9 +775,9 @@ func TestTag(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.Data.([]api.SeriesList)
+		seriesListList, ok := rawResult.Body.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Body, rawResult.Body)
 			continue
 		}
 		list := seriesListList[0]

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -69,7 +69,7 @@ func TestCommand_Describe(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		a.CheckError(err)
-		a.Eq(rawResult, test.expected)
+		a.Eq(rawResult.Data, test.expected)
 	}
 }
 
@@ -106,7 +106,7 @@ func TestCommand_DescribeAll(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		a.CheckError(err)
-		a.Eq(rawResult, test.expected)
+		a.Eq(rawResult.Data, test.expected)
 	}
 }
 
@@ -443,7 +443,7 @@ func TestCommand_Select(t *testing.T) {
 				a.Errorf("Unexpected error while executing: %s", err.Error())
 			}
 		} else {
-			casted := rawResult.([]function.Value)
+			casted := rawResult.Data.([]function.Value)
 			actual, _ := casted[0].ToSeriesList(api.Timerange{})
 			a.EqInt(len(actual.Series), len(expected.Series))
 			if len(actual.Series) == len(expected.Series) {
@@ -574,9 +574,9 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]api.SeriesList)
+		seriesListList, ok := rawResult.Data.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
 			continue
 		}
 		actual := seriesListList[0].Name
@@ -664,9 +664,9 @@ func TestQuery(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]api.SeriesList)
+		seriesListList, ok := rawResult.Data.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
 			continue
 		}
 		actual := seriesListList[0].Query
@@ -766,9 +766,9 @@ func TestTag(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]api.SeriesList)
+		seriesListList, ok := rawResult.Data.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
 			continue
 		}
 		list := seriesListList[0]

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -438,7 +438,7 @@ func TestCommand_Select(t *testing.T) {
 		})
 		if test.expectError {
 			if err == nil {
-				t.Errorf("Expected error on %s but got no error; got value: %+v", test.query, rawResult.Data)
+				t.Errorf("Expected error on %s but got no error; got value: %+v", test.query, rawResult.Body)
 			}
 		} else {
 			a.CheckError(err)

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -68,7 +68,7 @@ func TestCommand_Describe(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		a.CheckError(err)
-		a.Eq(rawResult, test.expected)
+		a.Eq(rawResult.Data, test.expected)
 	}
 }
 
@@ -105,7 +105,7 @@ func TestCommand_DescribeAll(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		a.CheckError(err)
-		a.Eq(rawResult, test.expected)
+		a.Eq(rawResult.Data, test.expected)
 	}
 }
 
@@ -438,11 +438,11 @@ func TestCommand_Select(t *testing.T) {
 		})
 		if test.expectError {
 			if err == nil {
-				t.Errorf("Expected error on %s but got no error; got value: %+v", test.query, rawResult)
+				t.Errorf("Expected error on %s but got no error; got value: %+v", test.query, rawResult.Data)
 			}
 		} else {
 			a.CheckError(err)
-			actual := rawResult.([]api.SeriesList)
+			actual := rawResult.Data.([]api.SeriesList)
 			a.EqInt(len(actual), len(expected))
 			if len(actual) == len(expected) {
 				for i := range actual {
@@ -573,9 +573,9 @@ func TestNaming(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]api.SeriesList)
+		seriesListList, ok := rawResult.Data.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
 			continue
 		}
 		actual := seriesListList[0].Name
@@ -668,9 +668,9 @@ func TestQuery(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]api.SeriesList)
+		seriesListList, ok := rawResult.Data.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
 			continue
 		}
 		actual := seriesListList[0].Query
@@ -775,9 +775,9 @@ func TestTag(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.([]api.SeriesList)
+		seriesListList, ok := rawResult.Data.([]api.SeriesList)
 		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult, rawResult)
+			t.Errorf("expected query `%s` to produce []value; got %+v :: %T", test.query, rawResult.Data, rawResult.Data)
 			continue
 		}
 		list := seriesListList[0]

--- a/ui/data.go
+++ b/ui/data.go
@@ -27,11 +27,12 @@ type Hook struct {
 }
 
 type response struct {
-	Success bool          `json:"success"`
-	Name    string        `json:"name,omitempty"`
-	Message string        `json:"message,omitempty"`
-	Body    interface{}   `json:"body,omitempty"`
-	Profile []profileJSON `json:"profile,omitempty"`
+	Success  bool          `json:"success"`
+	Name     string        `json:"name,omitempty"`
+	Message  string        `json:"message,omitempty"`
+	Body     interface{}   `json:"body,omitempty"`
+	Metadata interface{}   `json:"metadata,omitempty"`
+	Profile  []profileJSON `json:"profile,omitempty"`
 }
 
 type profileJSON struct {

--- a/ui/data.go
+++ b/ui/data.go
@@ -27,12 +27,11 @@ type Hook struct {
 }
 
 type response struct {
-	Success  bool          `json:"success"`
-	Name     string        `json:"name,omitempty"`
-	Message  string        `json:"message,omitempty"`
-	Body     interface{}   `json:"body,omitempty"`
-	Metadata interface{}   `json:"metadata,omitempty"`
-	Profile  []profileJSON `json:"profile,omitempty"`
+	Success       bool          `json:"success"`
+	Name          string        `json:"name,omitempty"`
+	Message       string        `json:"message,omitempty"`
+	CommandResult               // embedding command result means we get 'Body' and 'Metadata' for free
+	Profile       []profileJSON `json:"profile,omitempty"`
 }
 
 type profileJSON struct {

--- a/ui/data.go
+++ b/ui/data.go
@@ -27,11 +27,12 @@ type Hook struct {
 }
 
 type response struct {
-	Success       bool          `json:"success"`
-	Name          string        `json:"name,omitempty"`
-	Message       string        `json:"message,omitempty"`
-	CommandResult               // embedding command result means we get 'Body' and 'Metadata' for free
-	Profile       []profileJSON `json:"profile,omitempty"`
+	Success  bool                   `json:"success"`
+	Name     string                 `json:"name,omitempty"`
+	Message  string                 `json:"message,omitempty"`
+	Body     interface{}            `json:"body,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Profile  []profileJSON          `json:"profile,omitempty"`
 }
 
 type profileJSON struct {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -168,8 +168,9 @@ func (q queryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 	response := response{
-		CommandResult: result,
-		Name:          cmd.Name(),
+		Body:     result.Body,
+		Metadata: result.Metadata,
+		Name:     cmd.Name(),
 	}
 	if parsedForm.profile {
 		response.Profile = convertProfile(profiler)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -168,9 +168,8 @@ func (q queryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 	response := response{
-		Body:     result.Data,
-		Metadata: result.Metadata,
-		Name:     cmd.Name(),
+		CommandResult: result,
+		Name:          cmd.Name(),
 	}
 	if parsedForm.profile {
 		response.Profile = convertProfile(profiler)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -168,8 +168,9 @@ func (q queryHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 	response := response{
-		Body: result,
-		Name: cmd.Name(),
+		Body:     result.Data,
+		Metadata: result.Metadata,
+		Name:     cmd.Name(),
 	}
 	if parsedForm.profile {
 		response.Profile = convertProfile(profiler)


### PR DESCRIPTION
As a way to address issue https://github.com/square/metrics/issues/214 adds a `metadata` field to the JSON response from MQE.

The metadata map can contain information that is secondary to the result itself. Implemented here are descriptions for `select` queries (the tagsets of the resulting series are combined) and profiling information. (To maintain reverse compatibility, the original `.profile` field is still available in the JSON response, but now it is *also* available through `.metadata.profile` which will allow us to eventually move to a state where profiling information is not quite as privileged in that sense).