### PR TITLE
Context notes on function evaluation

### DIFF
--- a/function/expression.go
+++ b/function/expression.go
@@ -12,8 +12,8 @@ import (
 // EvaluationContext is the central piece of logic, providing
 // helper funcions & varaibles to evaluate a given piece of
 // metrics query.
-// * Contains Backend object, which can be used to fetch data
-// from the backend system.s
+// * Contains a TimeseriesStorageAPI object, which can be used to fetch data
+// from the backend systems.
 // * Contains current timerange being queried for - this can be
 // changed by say, application of time shift function.
 type EvaluationContext struct {
@@ -27,6 +27,7 @@ type EvaluationContext struct {
 	Registry                  Registry
 	Profiler                  *inspect.Profiler // A profiler pointer
 	OptimizationConfiguration *optimize.OptimizationConfiguration
+	EvaluationNotes           []string //Debug + numerical notes that can be added during evaluation
 }
 
 type Registry interface {
@@ -47,6 +48,11 @@ type MetricFunction struct {
 	MaxArguments  int
 	AllowsGroupBy bool // Whether the function allows a 'group by' clause.
 	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
+}
+
+func (e *EvaluationContext) AddNote(note string) {
+	fmt.Printf("Should have added a note\n")
+	e.EvaluationNotes = append(e.EvaluationNotes, note)
 }
 
 // Evaluate the given metric function.

--- a/function/expression.go
+++ b/function/expression.go
@@ -51,7 +51,12 @@ type MetricFunction struct {
 }
 
 func (e *EvaluationContext) AddNote(note string) {
-	fmt.Printf("Should have added a note\n")
+	if e == nil {
+		return
+	}
+	if e.EvaluationNotes == nil {
+		e.EvaluationNotes = []string{}
+	}
 	e.EvaluationNotes = append(e.EvaluationNotes, note)
 }
 

--- a/function/expression.go
+++ b/function/expression.go
@@ -47,7 +47,7 @@ type MetricFunction struct {
 	MinArguments  int
 	MaxArguments  int
 	AllowsGroupBy bool // Whether the function allows a 'group by' clause.
-	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
+	Compute       func(*EvaluationContext, []Expression, Groups) (Value, error)
 }
 
 func (e *EvaluationContext) AddNote(note string) {
@@ -56,7 +56,7 @@ func (e *EvaluationContext) AddNote(note string) {
 }
 
 // Evaluate the given metric function.
-func (f MetricFunction) Evaluate(context EvaluationContext,
+func (f MetricFunction) Evaluate(context *EvaluationContext,
 	arguments []Expression, groupBy []string, collapses bool) (Value, error) {
 	// preprocessing
 	length := len(arguments)
@@ -108,13 +108,13 @@ func (c FetchCounter) Consume(n int) bool {
 // Expressions correspond to the timerange in the current EvaluationContext.
 type Expression interface {
 	// Evaluate the given expression.
-	Evaluate(context EvaluationContext) (Value, error)
+	Evaluate(context *EvaluationContext) (Value, error)
 }
 
 // EvaluateMany evaluates a list of expressions using a single EvaluationContext.
 // If any evaluation errors, EvaluateMany will propagate that error. The resulting values
 // will be in the order corresponding to the provided expressions.
-func EvaluateMany(context EvaluationContext, expressions []Expression) ([]Value, error) {
+func EvaluateMany(context *EvaluationContext, expressions []Expression) ([]Value, error) {
 	type result struct {
 		index int
 		err   error

--- a/function/expression_test.go
+++ b/function/expression_test.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/square/metrics/testing_support/assert"
@@ -19,4 +20,43 @@ func Test_FetchCounter(t *testing.T) {
 	a.EqInt(c.Current(), 10)
 	a.EqBool(c.Consume(1), false)
 	a.EqInt(c.Current(), 11)
+}
+
+func TestCopy(t *testing.T) {
+	a := EvaluationContext{}
+	b := a.Copy()
+	if &a == &b {
+		t.Errorf("Evaluation context should have been a copy.")
+	}
+	a.AddNote("Blah")
+	if len(b.EvaluationNotes) != 0 {
+		t.Errorf("Evaluation context should have been a copy.")
+	}
+}
+
+func TestNoteCopy(t *testing.T) {
+	a := EvaluationContext{}
+	a.AddNote("We don't copy notes")
+	b := a.Copy()
+	if len(b.EvaluationNotes) != 0 {
+		t.Errorf("The notes were unexpectedly copied between EvaluationContexts")
+	}
+	b.AddNote("ABC")
+	a.CopyNotesFrom(&b)
+	expected := []string{"We don't copy notes", "ABC"}
+	if !reflect.DeepEqual(a.EvaluationNotes, expected) {
+		t.Errorf("The notes don't match")
+	}
+}
+
+func TestInvalidation(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected performing an evaluation on an invalid context to panic")
+		}
+	}()
+
+	ctx := EvaluationContext{}
+	ctx.Invalidate()
+	EvaluateMany(&ctx, []Expression{})
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -138,7 +138,7 @@ func NewFilter(name string, summary func([]float64) float64, ascending bool) fun
 		Name:         name,
 		MinArguments: 2,
 		MaxArguments: 2,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+		Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 			value, err := arguments[0].Evaluate(context)
 			if err != nil {
 				return nil, err
@@ -175,7 +175,7 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 		Name:         name,
 		MinArguments: 3,
 		MaxArguments: 3,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+		Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 			value, err := arguments[0].Evaluate(context)
 			if err != nil {
 				return nil, err
@@ -221,7 +221,7 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 		MinArguments:  1,
 		MaxArguments:  1,
 		AllowsGroupBy: true,
-		Compute: func(context function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
+		Compute: func(context *function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
 			argument := args[0]
 			value, err := argument.Evaluate(context)
 			if err != nil {
@@ -252,12 +252,12 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 }
 
 // NewTransform takes a named transforming function `[float64], [value] => [float64]` and makes it into a MetricFunction.
-func NewTransform(name string, parameterCount int, transformer func(function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error)) function.MetricFunction {
+func NewTransform(name string, parameterCount int, transformer func(*function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error)) function.MetricFunction {
 	return function.MetricFunction{
 		Name:         name,
 		MinArguments: parameterCount + 1,
 		MaxArguments: parameterCount + 1,
-		Compute: func(context function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
+		Compute: func(context *function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
 			listValue, err := args[0].Evaluate(context)
 			if err != nil {
 				return nil, err
@@ -299,7 +299,7 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 		Name:         op,
 		MinArguments: 2,
 		MaxArguments: 2,
-		Compute: func(context function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
+		Compute: func(context *function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
 			evaluated, err := function.EvaluateMany(context, args)
 			if err != nil {
 				return nil, err

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -252,7 +252,7 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 }
 
 // NewTransform takes a named transforming function `[float64], [value] => [float64]` and makes it into a MetricFunction.
-func NewTransform(name string, parameterCount int, transformer func([]float64, []function.Value, float64) ([]float64, error)) function.MetricFunction {
+func NewTransform(name string, parameterCount int, transformer func(function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error)) function.MetricFunction {
 	return function.MetricFunction{
 		Name:         name,
 		MinArguments: parameterCount + 1,
@@ -273,7 +273,7 @@ func NewTransform(name string, parameterCount int, transformer func([]float64, [
 					return nil, err
 				}
 			}
-			result, err := transform.ApplyTransform(list, transformer, parameters)
+			result, err := transform.ApplyTransform(context, list, transformer, parameters)
 			if err != nil {
 				return nil, err
 			}

--- a/function/registry/registry_test.go
+++ b/function/registry/registry_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/square/metrics/testing_support/assert"
 )
 
-var dummyCompute = func(function.EvaluationContext, []function.Expression, function.Groups) (function.Value, error) {
+var dummyCompute = func(*function.EvaluationContext, []function.Expression, function.Groups) (function.Value, error) {
 	return nil, errors.New("Not implemented")
 }
 

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -75,7 +75,7 @@ var DropFunction = function.MetricFunction{
 	Name:         "tag.drop",
 	MinArguments: 2,
 	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		result, err := arguments[0].Evaluate(context)
 		if err != nil {
 			return nil, err
@@ -102,7 +102,7 @@ var SetFunction = function.MetricFunction{
 	Name:         "tag.set",
 	MinArguments: 3,
 	MaxArguments: 3,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		result, err := arguments[0].Evaluate(context)
 		if err != nil {
 			return nil, err

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -27,7 +27,7 @@ var Timeshift = function.MetricFunction{
 	Name:         "transform.timeshift",
 	MinArguments: 2,
 	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		value, err := arguments[1].Evaluate(context)
 		if err != nil {
 			return nil, err
@@ -58,7 +58,7 @@ var MovingAverage = function.MetricFunction{
 	Name:         "transform.moving_average",
 	MinArguments: 2,
 	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
 
 		sizeValue, err := arguments[1].Evaluate(context)
@@ -135,7 +135,7 @@ var Alias = function.MetricFunction{
 	Name:         "transform.alias",
 	MinArguments: 2,
 	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		value, err := arguments[0].Evaluate(context)
 		if err != nil {
 			return nil, err
@@ -162,7 +162,7 @@ var Alias = function.MetricFunction{
 // This transform estimates the "change per second" between the two samples (scaled consecutive difference)
 var Derivative = newDerivativeBasedTransform("derivative", derivative)
 
-func derivative(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func derivative(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	result := make([]float64, len(values)-1)
 	for i := range values {
 		if i == 0 {
@@ -181,7 +181,7 @@ func derivative(ctx function.EvaluationContext, values []float64, parameters []f
 // differences which are at least 0, or math.Max of the newly reported value and 0
 var Rate = newDerivativeBasedTransform("rate", rate)
 
-func rate(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func rate(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	result := make([]float64, len(values)-1)
 	for i := range values {
 		if i == 0 {
@@ -209,7 +209,7 @@ func newDerivativeBasedTransform(name string, transformer transform) function.Me
 		Name:         "transform." + name,
 		MinArguments: 1,
 		MaxArguments: 1,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+		Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 			var err error
 			// Calcuate the new timerange to include one extra point to the left
 			newContext := context

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -25,11 +25,11 @@ import (
 )
 
 // A transform takes the list of values, other parameters, and the resolution (as a float64) of the query.
-type transform func(function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error)
+type transform func(*function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error)
 
 // transformTimeseries transforms an individual series (rather than an entire serieslist) taking the same parameters as a transform,
 // but with the serieslist standing in for the simplified []float64 argument.
-func transformTimeseries(ctx function.EvaluationContext, series api.Timeseries, transformFunc transform, parameters []function.Value, scale float64) (api.Timeseries, error) {
+func transformTimeseries(ctx *function.EvaluationContext, series api.Timeseries, transformFunc transform, parameters []function.Value, scale float64) (api.Timeseries, error) {
 	values, err := transformFunc(ctx, series.Values, parameters, scale)
 	if err != nil {
 		return api.Timeseries{}, err
@@ -41,7 +41,7 @@ func transformTimeseries(ctx function.EvaluationContext, series api.Timeseries, 
 }
 
 // ApplyTransform applies the given transform to the entire list of series.
-func ApplyTransform(ctx function.EvaluationContext, list api.SeriesList, transform transform, parameters []function.Value) (api.SeriesList, error) {
+func ApplyTransform(ctx *function.EvaluationContext, list api.SeriesList, transform transform, parameters []function.Value) (api.SeriesList, error) {
 	result := api.SeriesList{
 		Series:    make([]api.Timeseries, len(list.Series)),
 		Timerange: list.Timerange,
@@ -60,7 +60,7 @@ func ApplyTransform(ctx function.EvaluationContext, list api.SeriesList, transfo
 
 // Integral integrates a series whose values are "X per millisecond" to estimate "total X so far"
 // if the series represents "X in this sampling interval" instead, then you should use transformCumulative.
-func Integral(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Integral(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	result := make([]float64, len(values))
 	integral := 0.0
 	for i := range values {
@@ -78,7 +78,7 @@ func Integral(ctx function.EvaluationContext, values []float64, parameters []fun
 }
 
 // Cumulative computes the cumulative sum of the given values.
-func Cumulative(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Cumulative(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	result := make([]float64, len(values))
 	sum := 0.0
 	for i := range values {
@@ -98,8 +98,8 @@ func Cumulative(ctx function.EvaluationContext, values []float64, parameters []f
 // MapMaker can be used to use a function as a transform, such as 'math.Abs' (or similar):
 //  `MapMaker(math.Abs)` is a transform function which can be used, e.g. with ApplyTransform
 // The name is used for error-checking purposes.
-func MapMaker(fun func(float64) float64) func(function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error) {
-	return func(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func MapMaker(fun func(float64) float64) func(*function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error) {
+	return func(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 		result := make([]float64, len(values))
 		for i := range values {
 			result[i] = fun(values[i])
@@ -109,7 +109,7 @@ func MapMaker(fun func(float64) float64) func(function.EvaluationContext, []floa
 }
 
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
-func Default(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Default(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	defaultValue, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func Default(ctx function.EvaluationContext, values []float64, parameters []func
 }
 
 // NaNKeepLast will replace missing NaN data with the data before it
-func NaNKeepLast(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func NaNKeepLast(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	result := make([]float64, len(values))
 	for i := range result {
 		result[i] = values[i]
@@ -152,7 +152,7 @@ func (b boundError) TokenName() string {
 }
 
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
-func Bound(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Bound(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func Bound(ctx function.EvaluationContext, values []float64, parameters []functi
 }
 
 // LowerBound replaces values that fall below the given bound with the lower bound.
-func LowerBound(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func LowerBound(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func LowerBound(ctx function.EvaluationContext, values []float64, parameters []f
 }
 
 // UpperBound replaces values that fall below the given bound with the lower bound.
-func UpperBound(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func UpperBound(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
 	upperBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -25,34 +25,31 @@ import (
 )
 
 // A transform takes the list of values, other parameters, and the resolution (as a float64) of the query.
-type transform func(*function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error)
-
-// transformTimeseries transforms an individual series (rather than an entire serieslist) taking the same parameters as a transform,
-// but with the serieslist standing in for the simplified []float64 argument.
-func transformTimeseries(ctx *function.EvaluationContext, series api.Timeseries, transformFunc transform, parameters []function.Value, scale float64) (api.Timeseries, error) {
-	values, err := transformFunc(ctx, series.Values, parameters, scale)
-	if err != nil {
-		return api.Timeseries{}, err
-	}
-	return api.Timeseries{
-		Values: values,
-		TagSet: series.TagSet,
-	}, nil
-}
+type transform func(*function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error)
 
 // ApplyTransform applies the given transform to the entire list of series.
-func ApplyTransform(ctx *function.EvaluationContext, list api.SeriesList, transform transform, parameters []function.Value) (api.SeriesList, error) {
+func ApplyTransform(ctx *function.EvaluationContext, list api.SeriesList, transformFunc transform, parameters []function.Value) (api.SeriesList, error) {
 	result := api.SeriesList{
 		Series:    make([]api.Timeseries, len(list.Series)),
 		Timerange: list.Timerange,
 		Name:      list.Name,
 		Query:     list.Query,
 	}
+	var numResult []float64
 	var err error
 	for i, series := range list.Series {
-		result.Series[i], err = transformTimeseries(ctx, series, transform, parameters, float64(list.Timerange.ResolutionMillis())/1000)
+		//TODO(cchandler): Modify the last parameter of this type to be an actual Resolution
+		if (list.Timerange == api.Timerange{}) {
+			fmt.Printf("Current time range %+v\n", list.Timerange)
+			panic("The series list we have doesn't provide an indexed Timerange")
+		}
+		numResult, err = transformFunc(ctx, series, parameters, float64(list.Timerange.ResolutionMillis())/1000)
 		if err != nil {
 			return api.SeriesList{}, err
+		}
+		result.Series[i] = api.Timeseries{
+			Values: numResult,
+			TagSet: series.TagSet,
 		}
 	}
 	return result, nil
@@ -60,7 +57,8 @@ func ApplyTransform(ctx *function.EvaluationContext, list api.SeriesList, transf
 
 // Integral integrates a series whose values are "X per millisecond" to estimate "total X so far"
 // if the series represents "X in this sampling interval" instead, then you should use transformCumulative.
-func Integral(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Integral(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	result := make([]float64, len(values))
 	integral := 0.0
 	for i := range values {
@@ -78,7 +76,8 @@ func Integral(ctx *function.EvaluationContext, values []float64, parameters []fu
 }
 
 // Cumulative computes the cumulative sum of the given values.
-func Cumulative(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Cumulative(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	result := make([]float64, len(values))
 	sum := 0.0
 	for i := range values {
@@ -98,8 +97,9 @@ func Cumulative(ctx *function.EvaluationContext, values []float64, parameters []
 // MapMaker can be used to use a function as a transform, such as 'math.Abs' (or similar):
 //  `MapMaker(math.Abs)` is a transform function which can be used, e.g. with ApplyTransform
 // The name is used for error-checking purposes.
-func MapMaker(fun func(float64) float64) func(*function.EvaluationContext, []float64, []function.Value, float64) ([]float64, error) {
-	return func(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func MapMaker(fun func(float64) float64) func(*function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error) {
+	return func(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+		values := series.Values
 		result := make([]float64, len(values))
 		for i := range values {
 			result[i] = fun(values[i])
@@ -109,7 +109,8 @@ func MapMaker(fun func(float64) float64) func(*function.EvaluationContext, []flo
 }
 
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
-func Default(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Default(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	defaultValue, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
@@ -126,7 +127,8 @@ func Default(ctx *function.EvaluationContext, values []float64, parameters []fun
 }
 
 // NaNKeepLast will replace missing NaN data with the data before it
-func NaNKeepLast(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func NaNKeepLast(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	result := make([]float64, len(values))
 	for i := range result {
 		result[i] = values[i]
@@ -152,7 +154,8 @@ func (b boundError) TokenName() string {
 }
 
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
-func Bound(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func Bound(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
@@ -178,7 +181,8 @@ func Bound(ctx *function.EvaluationContext, values []float64, parameters []funct
 }
 
 // LowerBound replaces values that fall below the given bound with the lower bound.
-func LowerBound(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func LowerBound(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
@@ -194,7 +198,8 @@ func LowerBound(ctx *function.EvaluationContext, values []float64, parameters []
 }
 
 // UpperBound replaces values that fall below the given bound with the lower bound.
-func UpperBound(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error) {
+func UpperBound(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+	values := series.Values
 	upperBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err

--- a/function/transform/transformation_test.go
+++ b/function/transform/transformation_test.go
@@ -90,7 +90,7 @@ func TestTransformTimeseries(t *testing.T) {
 				params = []function.Value{}
 			}
 			ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-			result, err := transformTimeseries(ctx, series, transform.fun, params, test.scale)
+			result, err := transformTimeseries(&ctx, series, transform.fun, params, test.scale)
 			if err != nil {
 				t.Error(err)
 				continue
@@ -189,7 +189,7 @@ func TestApplyTransform(t *testing.T) {
 	}
 	for _, test := range testCases {
 		ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-		result, err := ApplyTransform(ctx, list, test.transform, test.parameter)
+		result, err := ApplyTransform(&ctx, list, test.transform, test.parameter)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -261,7 +261,7 @@ func TestApplyNotes(t *testing.T) {
 
 	for _, test := range testCases {
 		ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-		_, err := ApplyTransform(ctx, list, test.transform, test.parameter)
+		_, err := ApplyTransform(&ctx, list, test.transform, test.parameter)
 		fmt.Printf("%+v\n", ctx.EvaluationNotes)
 		if err != nil {
 			t.Error(err)
@@ -351,7 +351,7 @@ func TestApplyBound(t *testing.T) {
 	}
 	for _, test := range tests {
 		bounders := []struct {
-			bounder  func(ctx function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error)
+			bounder  func(ctx *function.EvaluationContext, values []float64, parameters []function.Value, scale float64) ([]float64, error)
 			params   []function.Value
 			expected map[string][]float64
 			name     string
@@ -363,7 +363,7 @@ func TestApplyBound(t *testing.T) {
 
 		for _, bounder := range bounders {
 			ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-			bounded, err := ApplyTransform(ctx, list, bounder.bounder, bounder.params)
+			bounded, err := ApplyTransform(&ctx, list, bounder.bounder, bounder.params)
 			if err != nil {
 				t.Errorf(err.Error())
 				continue
@@ -385,10 +385,10 @@ func TestApplyBound(t *testing.T) {
 		}
 	}
 	ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-	if _, err = ApplyTransform(ctx, list, Bound, []function.Value{function.ScalarValue(18), function.ScalarValue(17)}); err == nil {
+	if _, err = ApplyTransform(&ctx, list, Bound, []function.Value{function.ScalarValue(18), function.ScalarValue(17)}); err == nil {
 		t.Fatalf("Expected error on invalid bounds")
 	}
-	if _, err = ApplyTransform(ctx, list, Bound, []function.Value{function.ScalarValue(-17), function.ScalarValue(-18)}); err == nil {
+	if _, err = ApplyTransform(&ctx, list, Bound, []function.Value{function.ScalarValue(-17), function.ScalarValue(-18)}); err == nil {
 		t.Fatalf("Expected error on invalid bounds")
 	}
 }
@@ -486,7 +486,7 @@ func TestApplyTransformNaN(t *testing.T) {
 	}
 	for _, test := range tests {
 		ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-		result, err := ApplyTransform(ctx, list, test.transform, test.parameters)
+		result, err := ApplyTransform(&ctx, list, test.transform, test.parameters)
 		if err != nil {
 			t.Fatalf(fmt.Sprintf("error applying transformation %s", err))
 			return
@@ -582,7 +582,7 @@ func TestTransformIdentity(t *testing.T) {
 			result := series
 			for _, fun := range transform.transforms {
 				ctx := function.EvaluationContext{EvaluationNotes: []string{}}
-				result, err = transformTimeseries(ctx, result, fun, []function.Value{}, test.scale)
+				result, err = transformTimeseries(&ctx, result, fun, []function.Value{}, test.scale)
 				if err != nil {
 					t.Error(err)
 					break

--- a/query/command.go
+++ b/query/command.go
@@ -220,7 +220,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 	// Goroutines are never garbage collected, so we need to provide capacity so that the send always succeeds.
 	go func() {
 		// Evaluate the result, and send it along the goroutines.
-		result, err := function.EvaluateMany(evaluationContext, cmd.expressions)
+		result, err := function.EvaluateMany(&evaluationContext, cmd.expressions)
 		if err != nil {
 			errors <- err
 			return

--- a/query/command.go
+++ b/query/command.go
@@ -206,6 +206,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (interface{}, error)
 		Registry:                  r,
 		Profiler:                  context.Profiler,
 		OptimizationConfiguration: context.OptimizationConfiguration,
+		EvaluationNotes:           []string{},
 	}
 
 	timeout := (<-chan time.Time)(nil)

--- a/query/expression.go
+++ b/query/expression.go
@@ -24,19 +24,19 @@ import (
 // Implementations
 // ===============
 
-func (expr durationExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr durationExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	return function.NewDurationValue(expr.name, expr.duration), nil
 }
 
-func (expr scalarExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr scalarExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	return function.ScalarValue(expr.value), nil
 }
 
-func (expr stringExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr stringExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	return function.StringValue(expr.value), nil
 }
 
-func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr *metricFetchExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	// Merge predicates appropriately
 	var predicate api.Predicate
 	if context.Predicate == nil && expr.predicate == nil {
@@ -98,7 +98,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 	return serieslist, nil
 }
 
-func (expr *functionExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr *functionExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	fun, ok := context.Registry.GetFunction(expr.functionName)
 	if !ok {
 		return nil, SyntaxError{expr.functionName, fmt.Sprintf("no such function %s", expr.functionName)}

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -31,7 +31,7 @@ type LiteralExpression struct {
 	Values []float64
 }
 
-func (expr *LiteralExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr *LiteralExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	return api.SeriesList{
 		Series:    []api.Timeseries{api.Timeseries{expr.Values, api.NewTagSet()}},
 		Timerange: api.Timerange{},
@@ -42,7 +42,7 @@ type LiteralSeriesExpression struct {
 	list api.SeriesList
 }
 
-func (expr *LiteralSeriesExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+func (expr *LiteralSeriesExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	return expr.list, nil
 }
 
@@ -69,7 +69,7 @@ func Test_ScalarExpression(t *testing.T) {
 		},
 	} {
 		a := assert.New(t).Contextf("%+v", test)
-		result, err := evaluateToSeriesList(test.expr, function.EvaluationContext{
+		result, err := evaluateToSeriesList(test.expr, &function.EvaluationContext{
 			TimeseriesStorageAPI: FakeBackend{},
 			Timerange:            test.timerange,
 			SampleMethod:         api.SampleMean,
@@ -90,7 +90,7 @@ func Test_ScalarExpression(t *testing.T) {
 }
 
 func Test_evaluateBinaryOperation(t *testing.T) {
-	emptyContext := function.EvaluationContext{
+	emptyContext := &function.EvaluationContext{
 		TimeseriesStorageAPI: FakeBackend{},
 		MetricMetadataAPI:    nil,
 		Timerange:            api.Timerange{},
@@ -100,7 +100,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		Cancellable:          api.NewCancellable(),
 	}
 	for _, test := range []struct {
-		context              function.EvaluationContext
+		context              *function.EvaluationContext
 		functionName         string
 		left                 api.SeriesList
 		right                api.SeriesList
@@ -380,7 +380,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 	}
 }
 
-func evaluateToSeriesList(e function.Expression, context function.EvaluationContext) (api.SeriesList, error) {
+func evaluateToSeriesList(e function.Expression, context *function.EvaluationContext) (api.SeriesList, error) {
 	value, err := e.Evaluate(context)
 	if err != nil {
 		return api.SeriesList{}, err

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -74,7 +74,7 @@ func TestMovingAverage(t *testing.T) {
 
 	backend := fakeBackend
 	result, err := evaluateToSeriesList(expression,
-		function.EvaluationContext{
+		&function.EvaluationContext{
 			MetricMetadataAPI:         fakeAPI,
 			TimeseriesStorageAPI:      backend,
 			Timerange:                 timerange,
@@ -89,11 +89,12 @@ func TestMovingAverage(t *testing.T) {
 	}
 
 	expected := []float64{4, 3, 11.0 / 3, 5}
+
 	if len(result.Series) != 1 {
 		t.Fatalf("expected exactly 1 returned series")
 	}
 	if len(result.Series[0].Values) != len(expected) {
-		t.Fatalf("expected exactly %d values in returned series", len(expected))
+		t.Fatalf("expected exactly %d values in returned series, but got %d", len(expected), len(result.Series[0].Values))
 	}
 	const eps = 1e-7
 	for i := range expected {


### PR DESCRIPTION
This modifies the usage of EvaluationContext to include EvaluationNotes during function evaluation. Now that it passes a pointer around please be careful with copy semantics :-).

Example:
The non-negative derivative functionality now creates a context note like this:
  ctx.AddNote(fmt.Sprintf("Rate(%v): The underlying counter reset between %f, %f\n", series.TagSet, values[i-1], values[i]))
This passes information back to the UI that wouldn't be obvious from the processed numbers alone. It will include things like strange rounding, empty data buckets, unexpected nils, interpolation, whatever.

It also changes the signature of the transform function type to work directly on api.Timeseries instead of a simplified, contextless []float64.

A few TODOs were added that I'll address later this week. Tests were only modified to work with the new code, no numbers were modified.