### PR TITLE
Add notes to metadata return and improve profiling result for blueflood

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -19,6 +19,10 @@
 
 package api
 
+import (
+	"fmt"
+)
+
 // list of data types throughout the code.
 
 // TaggedMetric is composition of a MetricKey and a TagSet.
@@ -26,4 +30,8 @@ package api
 type TaggedMetric struct {
 	MetricKey MetricKey
 	TagSet    TagSet
+}
+
+func (t *TaggedMetric) String() string {
+	return fmt.Sprintf("%+v [%s]\n", t.MetricKey, t.TagSet.Serialize())
 }

--- a/inspect/profile.go
+++ b/inspect/profile.go
@@ -49,6 +49,19 @@ func (p *Profiler) Record(name string) func() {
 	}
 }
 
+func (p *Profiler) RecordWithDescription(name string, description string) func() {
+	if p == nil {
+		// If the profiler instance doesn't exist, then don't attempt to operate on it.
+		return func() {}
+	}
+	start := p.now()
+	return func() {
+		p.mutex.Lock()
+		defer p.mutex.Unlock()
+		p.profiles = append(p.profiles, Profile{name: name, description: description, startTime: start, finishTime: p.now()})
+	}
+}
+
 // All retrieves all the profiling information collected by the profiler.
 func (p *Profiler) All() []Profile {
 	if p == nil {
@@ -73,14 +86,19 @@ func (p *Profiler) Flush() []Profile {
 
 // A Profile is a single data point collected by the profiler.
 type Profile struct {
-	name       string    // name identifies the measured quantity ("fetchSingle() or api.GetAllMetrics()")
-	startTime  time.Time // the start time of the task
-	finishTime time.Time // the end time of the task
+	name        string // name identifies the measured quantity ("fetchSingle() or api.GetAllMetrics()")
+	description string
+	startTime   time.Time // the start time of the task
+	finishTime  time.Time // the end time of the task
 }
 
 // Name is the name of the profile.
 func (p Profile) Name() string {
 	return p.name
+}
+
+func (p Profile) Description() string {
+	return p.description
 }
 
 // Start is the start time of the profile.

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -537,7 +537,7 @@ function convertProfileResponse(object) {
   };
   for (var i = 0; i < object.profile.length; i++) {
     var profile = object.profile[i];
-    var row = [ profile.name , normalize(profile.start), normalize(profile.finish) ];
+    var row = [ profile.name + " - " + profile.description , normalize(profile.start), normalize(profile.finish) ];
     dataTable.addRows([row]);
   }
   return dataTable;

--- a/query/command.go
+++ b/query/command.go
@@ -282,6 +282,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 			Body: lists,
 			Metadata: map[string]interface{}{
 				"description": description,
+				"notes":       evaluationContext.EvaluationNotes,
 			},
 		}, nil
 	}

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -220,7 +220,7 @@ func (b *Blueflood) FetchMultipleTimeseries(request api.FetchMultipleTimeseriesR
 }
 
 func (b *Blueflood) FetchSingleTimeseries(request api.FetchTimeseriesRequest) (api.Timeseries, error) {
-	defer request.Profiler.Record("Blueflood FetchSingleTimeseries")()
+	defer request.Profiler.Record(fmt.Sprintf("Blueflood FetchSingleTimeseries (%s)", request.Metric))()
 	sampler, ok := samplerMap[request.SampleMethod]
 	if !ok {
 		return api.Timeseries{}, fmt.Errorf("unsupported SampleMethod %s", request.SampleMethod.String())

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -220,7 +220,7 @@ func (b *Blueflood) FetchMultipleTimeseries(request api.FetchMultipleTimeseriesR
 }
 
 func (b *Blueflood) FetchSingleTimeseries(request api.FetchTimeseriesRequest) (api.Timeseries, error) {
-	defer request.Profiler.Record(fmt.Sprintf("Blueflood FetchSingleTimeseries (%s)", request.Metric))()
+	defer request.Profiler.RecordWithDescription("Blueflood FetchSingleTimeseries", request.Metric.String())()
 	sampler, ok := samplerMap[request.SampleMethod]
 	if !ok {
 		return api.Timeseries{}, fmt.Errorf("unsupported SampleMethod %s", request.SampleMethod.String())

--- a/ui/data.go
+++ b/ui/data.go
@@ -36,7 +36,8 @@ type response struct {
 }
 
 type profileJSON struct {
-	Name   string `json:"name"`
-	Start  int64  `json:"start"`  // ms since Unix epoch
-	Finish int64  `json:"finish"` // ms since Unix epoch
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Start       int64  `json:"start"`  // ms since Unix epoch
+	Finish      int64  `json:"finish"` // ms since Unix epoch
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -118,9 +118,10 @@ func convertProfile(profiler *inspect.Profiler) []profileJSON {
 	result := make([]profileJSON, len(profiles))
 	for i, p := range profiles {
 		result[i] = profileJSON{
-			Name:   p.Name(),
-			Start:  p.Start().UnixNano() / int64(time.Millisecond),
-			Finish: p.Finish().UnixNano() / int64(time.Millisecond),
+			Name:        p.Name(),
+			Description: p.Description(),
+			Start:       p.Start().UnixNano() / int64(time.Millisecond),
+			Finish:      p.Finish().UnixNano() / int64(time.Millisecond),
 		}
 	}
 	return result


### PR DESCRIPTION
This will add evaluation notes to the metadata response. It also now uniquely identifies FetchSingle requests in the response.
<img width="1018" alt="metrics_query_engine" src="https://cloud.githubusercontent.com/assets/26321/10205900/d24b73fc-6778-11e5-97fa-a8f14c097017.png">
