### PR TITLE
Add some new features to the ruletester

### DIFF
--- a/main/ruletester/ruletester.go
+++ b/main/ruletester/ruletester.go
@@ -253,7 +253,7 @@ func GenerateReport(unmatched []string, graphiteConverter util.RuleBasedGraphite
 		if err != nil {
 			panic("Unable to create report file!")
 		}
-		f.WriteString(fmt.Sprintf("Rule: %s\n", rule.MetricKeyRegex))
+		f.WriteString(fmt.Sprintf("Rule: %s\n", rule.Description()))
 
 		for _, match := range rule.Statistics.SuccessfulMatches {
 			f.WriteString(fmt.Sprintf("%s\n", match))

--- a/util/graphite_converter.go
+++ b/util/graphite_converter.go
@@ -20,6 +20,7 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -74,18 +75,22 @@ func LoadRules(conversionRulesPath string) (RuleSet, error) {
 		log.Infof("Loading rules from %s", filename)
 		file, err := os.Open(filename)
 		if err != nil {
-			return RuleSet{}, err
+			return RuleSet{}, fmt.Errorf("error opening file %s: %s", filename, err.Error())
 		}
 		defer file.Close()
 
 		bytes, err := ioutil.ReadAll(file)
 		if err != nil {
-			return RuleSet{}, err
+			return RuleSet{}, fmt.Errorf("error reading file %s: %s", filename, err.Error())
 		}
 
 		rs, err := LoadYAML(bytes)
 		if err != nil {
-			return RuleSet{}, err
+			return RuleSet{}, fmt.Errorf("error loading YAML from file %s: %s", filename, err.Error())
+		}
+
+		for i := range rs.Rules {
+			rs.Rules[i].file = filename
 		}
 
 		ruleSet.Rules = append(ruleSet.Rules, rs.Rules...)

--- a/util/rules.go
+++ b/util/rules.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -48,6 +49,11 @@ type Rule struct {
 	graphitePatternTags  []string // tags extracted from the raw graphite string, in the order of appearance.
 	metricKeyTags        []string // tags extracted from MetricKey, in the order of appearance.
 	Statistics           RuleStatistics
+	file                 string // for diagnostic messages, the location of the rule's file
+}
+
+func (rule Rule) Description() string {
+	return fmt.Sprintf("%s\n\t=> %s\n\tfrom %s", rule.raw.Pattern, rule.raw.MetricKeyPattern, rule.file)
 }
 
 type RuleStatistics struct {


### PR DESCRIPTION
Adding a bit more information to the ruletester makes it easier to diagnose some problems.

The report files contain the full metric name from source, instead of the regex, and also list the file that the conversion rule comes from.