### PR TITLE
Include raw payload

### DIFF
--- a/api/timeseries.go
+++ b/api/timeseries.go
@@ -32,6 +32,7 @@ import (
 type Timeseries struct {
 	Values []float64
 	TagSet TagSet
+	Raw    []byte
 }
 
 // MarshalJSON exists to manually encode floats.

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -28,22 +28,26 @@ type TimeseriesStorageAPI interface {
 }
 
 type FetchTimeseriesRequest struct {
-	Metric         TaggedMetric // metric to fetch.
-	SampleMethod   SampleMethod // up/downsampling behavior.
-	Timerange      Timerange    // time range to fetch data from.
-	MetricMetadata MetricMetadataAPI
-	Cancellable    Cancellable
-	Profiler       *inspect.Profiler
-	IncludeRawData bool
+	Metric                TaggedMetric // metric to fetch.
+	SampleMethod          SampleMethod // up/downsampling behavior.
+	Timerange             Timerange    // time range to fetch data from.
+	MetricMetadata        MetricMetadataAPI
+	Cancellable           Cancellable
+	Profiler              *inspect.Profiler
+	UserSpecifiableConfig UserSpecifiableConfig
 }
 
 type FetchMultipleTimeseriesRequest struct {
-	Metrics        []TaggedMetric
-	SampleMethod   SampleMethod
-	Timerange      Timerange
-	MetricMetadata MetricMetadataAPI
-	Cancellable    Cancellable
-	Profiler       *inspect.Profiler
+	Metrics               []TaggedMetric
+	SampleMethod          SampleMethod
+	Timerange             Timerange
+	MetricMetadata        MetricMetadataAPI
+	Cancellable           Cancellable
+	Profiler              *inspect.Profiler
+	UserSpecifiableConfig UserSpecifiableConfig
+}
+
+type UserSpecifiableConfig struct {
 	IncludeRawData bool
 }
 
@@ -92,12 +96,13 @@ func (r FetchMultipleTimeseriesRequest) ToSingle() []FetchTimeseriesRequest {
 	fetchSingleRequests := make([]FetchTimeseriesRequest, 0)
 	for _, metric := range r.Metrics {
 		request := FetchTimeseriesRequest{
-			Metric:         metric,
-			MetricMetadata: r.MetricMetadata,
-			Cancellable:    r.Cancellable,
-			SampleMethod:   r.SampleMethod,
-			Timerange:      r.Timerange,
-			Profiler:       r.Profiler,
+			Metric:                metric,
+			MetricMetadata:        r.MetricMetadata,
+			Cancellable:           r.Cancellable,
+			SampleMethod:          r.SampleMethod,
+			Timerange:             r.Timerange,
+			Profiler:              r.Profiler,
+			UserSpecifiableConfig: r.UserSpecifiableConfig,
 		}
 		fetchSingleRequests = append(fetchSingleRequests, request)
 	}

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -34,6 +34,7 @@ type FetchTimeseriesRequest struct {
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
 	Profiler       *inspect.Profiler
+	IncludeRawData bool
 }
 
 type FetchMultipleTimeseriesRequest struct {
@@ -43,6 +44,7 @@ type FetchMultipleTimeseriesRequest struct {
 	MetricMetadata MetricMetadataAPI
 	Cancellable    Cancellable
 	Profiler       *inspect.Profiler
+	IncludeRawData bool
 }
 
 type TimeseriesStorageErrorCode int

--- a/api/timeseries_test.go
+++ b/api/timeseries_test.go
@@ -46,7 +46,7 @@ func TestTimeseries_Downsample(t *testing.T) {
 		{[]float64{1, 2, 3, 4, 5}, Timerange{0, 4, 1}, Timerange{0, 4, 2}, max, []float64{2, 4, 5}},
 	} {
 		tagset := ParseTagSet("key=value")
-		ts := Timeseries{suite.input, tagset}
+		ts := Timeseries{Values: suite.input, TagSet: tagset}
 		sampled, err := ts.Downsample(suite.inputRange, suite.newRange, suite.sampler)
 		a.CheckError(err)
 		a.Eq(sampled.Values, suite.expected)

--- a/function/expression.go
+++ b/function/expression.go
@@ -29,11 +29,7 @@ type EvaluationContext struct {
 	OptimizationConfiguration *optimize.OptimizationConfiguration
 	EvaluationNotes           []string //Debug + numerical notes that can be added during evaluation
 	invalid                   bool     // Because these can be copied, it's best to mark a no-longer used context as dead
-	UserSpecifiableConfig     UserSpecifiableConfig
-}
-
-type UserSpecifiableConfig struct {
-	IncludeRawData bool
+	UserSpecifiableConfig     api.UserSpecifiableConfig
 }
 
 type Registry interface {

--- a/function/expression.go
+++ b/function/expression.go
@@ -29,6 +29,11 @@ type EvaluationContext struct {
 	OptimizationConfiguration *optimize.OptimizationConfiguration
 	EvaluationNotes           []string //Debug + numerical notes that can be added during evaluation
 	invalid                   bool     // Because these can be copied, it's best to mark a no-longer used context as dead
+	UserSpecifiableConfig     UserSpecifiableConfig
+}
+
+type UserSpecifiableConfig struct {
+	IncludeRawData bool
 }
 
 type Registry interface {
@@ -65,6 +70,7 @@ func (e *EvaluationContext) Copy() EvaluationContext {
 		OptimizationConfiguration: e.OptimizationConfiguration,
 		EvaluationNotes:           []string{},
 		invalid:                   false,
+		UserSpecifiableConfig:     e.UserSpecifiableConfig,
 	}
 }
 

--- a/function/join/join_test.go
+++ b/function/join/join_test.go
@@ -21,20 +21,20 @@ import (
 )
 
 var (
-	seriesA1 = api.Timeseries{[]float64{1, 2, 3}, map[string]string{"dc": "A", "host": "#1"}}
-	seriesA2 = api.Timeseries{[]float64{4, 5, 6}, map[string]string{"dc": "A", "host": "#2"}}
-	seriesB3 = api.Timeseries{[]float64{0, 1, 1}, map[string]string{"dc": "B", "host": "#3"}}
-	seriesB4 = api.Timeseries{[]float64{1, 3, 2}, map[string]string{"dc": "B", "host": "#4"}}
-	seriesC5 = api.Timeseries{[]float64{2, 2, 3}, map[string]string{"dc": "C", "host": "#5"}}
+	seriesA1 = api.Timeseries{Values: []float64{1, 2, 3}, TagSet: map[string]string{"dc": "A", "host": "#1"}}
+	seriesA2 = api.Timeseries{Values: []float64{4, 5, 6}, TagSet: map[string]string{"dc": "A", "host": "#2"}}
+	seriesB3 = api.Timeseries{Values: []float64{0, 1, 1}, TagSet: map[string]string{"dc": "B", "host": "#3"}}
+	seriesB4 = api.Timeseries{Values: []float64{1, 3, 2}, TagSet: map[string]string{"dc": "B", "host": "#4"}}
+	seriesC5 = api.Timeseries{Values: []float64{2, 2, 3}, TagSet: map[string]string{"dc": "C", "host": "#5"}}
 
-	seriesDC_A = api.Timeseries{[]float64{2, 0, 1}, map[string]string{"dc": "A"}}
-	seriesDC_B = api.Timeseries{[]float64{2, 0, 1}, map[string]string{"dc": "B"}}
-	seriesDC_C = api.Timeseries{[]float64{2, 0, 1}, map[string]string{"dc": "C"}}
+	seriesDC_A = api.Timeseries{Values: []float64{2, 0, 1}, TagSet: map[string]string{"dc": "A"}}
+	seriesDC_B = api.Timeseries{Values: []float64{2, 0, 1}, TagSet: map[string]string{"dc": "B"}}
+	seriesDC_C = api.Timeseries{Values: []float64{2, 0, 1}, TagSet: map[string]string{"dc": "C"}}
 
-	seriesENV_PROD  = api.Timeseries{[]float64{2, 0, 1}, map[string]string{"env": "production"}}
-	seriesENV_STAGE = api.Timeseries{[]float64{2, 0, 1}, map[string]string{"env": "staging"}}
+	seriesENV_PROD  = api.Timeseries{Values: []float64{2, 0, 1}, TagSet: map[string]string{"env": "production"}}
+	seriesENV_STAGE = api.Timeseries{Values: []float64{2, 0, 1}, TagSet: map[string]string{"env": "staging"}}
 
-	voidSeries = api.Timeseries{[]float64{0, 0, 0}, map[string]string{}}
+	voidSeries = api.Timeseries{Values: []float64{0, 0, 0}, TagSet: map[string]string{}}
 
 	emptyList = api.SeriesList{[]api.Timeseries{}, api.Timerange{}, "", ""}
 	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}, api.Timerange{}, "", ""}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -326,7 +326,7 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 				for j := 0; j < len(left.Values); j++ {
 					array[j] = operator(left.Values[j], right.Values[j])
 				}
-				result[i] = api.Timeseries{array, row.TagSet}
+				result[i] = api.Timeseries{Values: array, TagSet: row.TagSet}
 			}
 
 			query := fmt.Sprintf("(%s %s %s)", leftValue.GetName(), op, rightValue.GetName())

--- a/function/value.go
+++ b/function/value.go
@@ -67,7 +67,7 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 	}
 
 	return api.SeriesList{
-		Series:    []api.Timeseries{api.Timeseries{series, api.NewTagSet()}},
+		Series:    []api.Timeseries{api.Timeseries{Values: series, TagSet: api.NewTagSet()}},
 		Timerange: timerange,
 	}, nil
 }

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/square/metrics/log"
 
+	"github.com/square/metrics/api"
 	"github.com/square/metrics/function/registry"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/metric_metadata/cassandra"
@@ -86,6 +87,11 @@ func main() {
 	optimizer := optimize.NewOptimizationConfiguration()
 	optimizer.EnableMetricMetadataCaching = true
 
+	//Defaults
+	userConfig := api.UserSpecifiableConfig{
+		IncludeRawData: false,
+	}
+
 	startServer(config.UIConfig, query.ExecutionContext{
 		MetricMetadataAPI:         apiInstance,
 		TimeseriesStorageAPI:      blueflood,
@@ -93,5 +99,6 @@ func main() {
 		SlotLimit:                 5000,
 		Registry:                  registry.Default(),
 		OptimizationConfiguration: optimizer,
+		UserSpecifiableConfig:     userConfig,
 	})
 }

--- a/query/command.go
+++ b/query/command.go
@@ -37,7 +37,7 @@ type ExecutionContext struct {
 	SlotLimit                 int                                 // optional (0 => default 1000)
 	Profiler                  *inspect.Profiler                   // optional
 	OptimizationConfiguration *optimize.OptimizationConfiguration // optional
-	UserSpecifiableConfig     function.UserSpecifiableConfig      // optional. User tunable parameters for execution.
+	UserSpecifiableConfig     api.UserSpecifiableConfig           // optional. User tunable parameters for execution.
 }
 
 type CommandResult struct {

--- a/query/command.go
+++ b/query/command.go
@@ -37,6 +37,7 @@ type ExecutionContext struct {
 	SlotLimit                 int                                 // optional (0 => default 1000)
 	Profiler                  *inspect.Profiler                   // optional
 	OptimizationConfiguration *optimize.OptimizationConfiguration // optional
+	UserSpecifiableConfig     function.UserSpecifiableConfig      // optional. User tunable parameters for execution.
 }
 
 type CommandResult struct {
@@ -226,6 +227,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 		Profiler:                  context.Profiler,
 		OptimizationConfiguration: context.OptimizationConfiguration,
 		EvaluationNotes:           []string{},
+		UserSpecifiableConfig:     context.UserSpecifiableConfig,
 	}
 
 	timeout := (<-chan time.Time)(nil)

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -140,8 +140,8 @@ func TestCommand_Select(t *testing.T) {
 		{"select does_not_exist from 0 to 120 resolution 30ms", true, []api.SeriesList{}},
 		{"select series_1 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{1, 2, 3, 4, 5},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{1, 2, 3, 4, 5},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: testTimerange,
 			Name:      "series_1",
@@ -149,80 +149,80 @@ func TestCommand_Select(t *testing.T) {
 		{"select series_timeout from 0 to 120 resolution 30ms", true, []api.SeriesList{}},
 		{"select series_1 + 1 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{2, 3, 4, 5, 6},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{2, 3, 4, 5, 6},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: testTimerange,
 			Name:      "",
 		}}},
 		{"select series_1 * 2 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{2, 4, 6, 8, 10},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{2, 4, 6, 8, 10},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: testTimerange,
 			Name:      "",
 		}}},
 		{"select aggregate.max(series_2) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{3, 2, 3, 6, 5},
-				api.NewTagSet(),
+				Values: []float64{3, 2, 3, 6, 5},
+				TagSet: api.NewTagSet(),
 			}},
 			Timerange: testTimerange,
 			Name:      "series_2",
 		}}},
 		{"select (1 + series_2) | aggregate.max from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{4, 3, 4, 7, 6},
-				api.NewTagSet(),
+				Values: []float64{4, 3, 4, 7, 6},
+				TagSet: api.NewTagSet(),
 			}},
 			Timerange: testTimerange,
 			Name:      "series_2",
 		}}},
 		{"select series_1 from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{1, 2, 3},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{1, 2, 3},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}}},
 		{"select transform.timeshift(series_1,31ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{2, 3, 4},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{2, 3, 4},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}}},
 		{"select transform.timeshift(series_1,62ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{3, 4, 5},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{3, 4, 5},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}}},
 		{"select transform.timeshift(series_1,29ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{2, 3, 4},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{2, 3, 4},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: earlyTimerange,
 			Name:      "series_1",
 		}}},
 		{"select transform.timeshift(series_1,-31ms) from 60 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{2, 3, 4},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{2, 3, 4},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: lateTimerange,
 			Name:      "series_1",
 		}}},
 		{"select transform.timeshift(series_1,-29ms) from 60 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
-				[]float64{2, 3, 4},
-				api.ParseTagSet("dc=west"),
+				Values: []float64{2, 3, 4},
+				TagSet: api.ParseTagSet("dc=west"),
 			}},
 			Timerange: lateTimerange,
 			Name:      "series_1",
@@ -230,192 +230,192 @@ func TestCommand_Select(t *testing.T) {
 		{"select series_3 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(3, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(2, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(1, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(3, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(4, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(70, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(2, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(1, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_highest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 				{
-					[]float64{5, 5, 5, 2, 2},
-					api.ParseTagSet("dc=east"),
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 				{
-					[]float64{1, 1, 1, 4, 4},
-					api.ParseTagSet("dc=west"),
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
 				},
 			},
 		}}},
 		{"select series_3 | filter.recent_lowest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
-					[]float64{3, 3, 3, 3, 3},
-					api.ParseTagSet("dc=north"),
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
 				},
 			},
 		}}},

--- a/query/expression.go
+++ b/query/expression.go
@@ -85,6 +85,7 @@ func (expr *metricFetchExpression) Evaluate(context *function.EvaluationContext)
 			context.MetricMetadataAPI,
 			context.Cancellable,
 			context.Profiler,
+			context.UserSpecifiableConfig.IncludeRawData,
 		},
 	)
 

--- a/query/expression.go
+++ b/query/expression.go
@@ -85,7 +85,7 @@ func (expr *metricFetchExpression) Evaluate(context *function.EvaluationContext)
 			context.MetricMetadataAPI,
 			context.Cancellable,
 			context.Profiler,
-			context.UserSpecifiableConfig.IncludeRawData,
+			context.UserSpecifiableConfig,
 		},
 	)
 

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -33,7 +33,7 @@ type LiteralExpression struct {
 
 func (expr *LiteralExpression) Evaluate(context *function.EvaluationContext) (function.Value, error) {
 	return api.SeriesList{
-		Series:    []api.Timeseries{api.Timeseries{expr.Values, api.NewTagSet()}},
+		Series:    []api.Timeseries{api.Timeseries{Values: expr.Values, TagSet: api.NewTagSet()}},
 		Timerange: api.Timerange{},
 	}, nil
 }
@@ -62,8 +62,8 @@ func Test_ScalarExpression(t *testing.T) {
 			timerangeA,
 			[]api.Timeseries{
 				api.Timeseries{
-					[]float64{5.0, 5.0, 5.0, 5.0, 5.0, 5.0},
-					api.NewTagSet(),
+					Values: []float64{5.0, 5.0, 5.0, 5.0, 5.0, 5.0},
+					TagSet: api.NewTagSet(),
 				},
 			},
 		},
@@ -170,22 +170,22 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			api.SeriesList{
 				[]api.Timeseries{
 					api.Timeseries{
-						[]float64{1, 2, 3},
-						api.TagSet{
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{
 							"env":  "production",
 							"host": "#1",
 						},
 					},
 					api.Timeseries{
-						[]float64{7, 7, 7},
-						api.TagSet{
+						Values: []float64{7, 7, 7},
+						TagSet: api.TagSet{
 							"env":  "staging",
 							"host": "#2",
 						},
 					},
 					api.Timeseries{
-						[]float64{1, 0, 2},
-						api.TagSet{
+						Values: []float64{1, 0, 2},
+						TagSet: api.TagSet{
 							"env":  "staging",
 							"host": "#3",
 						},
@@ -198,14 +198,14 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			api.SeriesList{
 				[]api.Timeseries{
 					api.Timeseries{
-						[]float64{5, 5, 5},
-						api.TagSet{
+						Values: []float64{5, 5, 5},
+						TagSet: api.TagSet{
 							"env": "staging",
 						},
 					},
 					api.Timeseries{
-						[]float64{10, 100, 1000},
-						api.TagSet{
+						Values: []float64{10, 100, 1000},
+						TagSet: api.TagSet{
 							"env": "production",
 						},
 					},
@@ -224,22 +224,22 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			api.SeriesList{
 				[]api.Timeseries{
 					api.Timeseries{
-						[]float64{1, 2, 3},
-						api.TagSet{
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{
 							"env":  "production",
 							"host": "#1",
 						},
 					},
 					api.Timeseries{
-						[]float64{4, 5, 6},
-						api.TagSet{
+						Values: []float64{4, 5, 6},
+						TagSet: api.TagSet{
 							"env":  "staging",
 							"host": "#2",
 						},
 					},
 					api.Timeseries{
-						[]float64{7, 8, 9},
-						api.TagSet{
+						Values: []float64{7, 8, 9},
+						TagSet: api.TagSet{
 							"env":  "staging",
 							"host": "#3",
 						},
@@ -252,14 +252,14 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			api.SeriesList{
 				[]api.Timeseries{
 					api.Timeseries{
-						[]float64{2, 2, 2},
-						api.TagSet{
+						Values: []float64{2, 2, 2},
+						TagSet: api.TagSet{
 							"env": "staging",
 						},
 					},
 					api.Timeseries{
-						[]float64{3, 3, 3},
-						api.TagSet{
+						Values: []float64{3, 3, 3},
+						TagSet: api.TagSet{
 							"env": "staging",
 						},
 					},
@@ -278,22 +278,22 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			api.SeriesList{
 				[]api.Timeseries{
 					api.Timeseries{
-						[]float64{103, 103, 103},
-						api.TagSet{
+						Values: []float64{103, 103, 103},
+						TagSet: api.TagSet{
 							"env":  "production",
 							"host": "#1",
 						},
 					},
 					api.Timeseries{
-						[]float64{203, 203, 203},
-						api.TagSet{
+						Values: []float64{203, 203, 203},
+						TagSet: api.TagSet{
 							"env":  "staging",
 							"host": "#2",
 						},
 					},
 					api.Timeseries{
-						[]float64{303, 303, 303},
-						api.TagSet{
+						Values: []float64{303, 303, 303},
+						TagSet: api.TagSet{
 							"env":  "staging",
 							"host": "#3",
 						},
@@ -306,14 +306,14 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			api.SeriesList{
 				[]api.Timeseries{
 					api.Timeseries{
-						[]float64{1, 2, 3},
-						api.TagSet{
+						Values: []float64{1, 2, 3},
+						TagSet: api.TagSet{
 							"env": "staging",
 						},
 					},
 					api.Timeseries{
-						[]float64{3, 0, 3},
-						api.TagSet{
+						Values: []float64{3, 0, 3},
+						TagSet: api.TagSet{
 							"env": "production",
 						},
 					},

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -146,9 +146,9 @@ func (f FakeTimeseriesStorageAPI) ChooseResolution(requested api.Timerange, smal
 func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request api.FetchTimeseriesRequest) (api.Timeseries, error) {
 	defer request.Profiler.Record("Mock FetchSingleTimeseries")()
 	metricMap := map[api.MetricKey][]api.Timeseries{
-		"series_1": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}},
-		"series_2": {{[]float64{1, 2, 3, 4, 5}, api.ParseTagSet("dc=west")}, {[]float64{3, 0, 3, 6, 2}, api.ParseTagSet("dc=east")}},
-		"series_3": {{[]float64{1, 1, 1, 4, 4}, api.ParseTagSet("dc=west")}, {[]float64{5, 5, 5, 2, 2}, api.ParseTagSet("dc=east")}, {[]float64{3, 3, 3, 3, 3}, api.ParseTagSet("dc=north")}},
+		"series_1": {{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.ParseTagSet("dc=west")}},
+		"series_2": {{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.ParseTagSet("dc=west")}, {Values: []float64{3, 0, 3, 6, 2}, TagSet: api.ParseTagSet("dc=east")}},
+		"series_3": {{Values: []float64{1, 1, 1, 4, 4}, TagSet: api.ParseTagSet("dc=west")}, {Values: []float64{5, 5, 5, 2, 2}, TagSet: api.ParseTagSet("dc=east")}, {Values: []float64{3, 3, 3, 3, 3}, TagSet: api.ParseTagSet("dc=north")}},
 	}
 	if string(request.Metric.MetricKey) == "series_timeout" {
 		<-make(chan struct{}) // block forever
@@ -164,7 +164,7 @@ func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request api.FetchTimeser
 			for i := range values {
 				values[i] = series.Values[i+int(request.Timerange.Start())/30]
 			}
-			return api.Timeseries{values, series.TagSet}, nil
+			return api.Timeseries{Values: values, TagSet: series.TagSet}, nil
 		}
 	}
 	return api.Timeseries{}, errors.New("internal error")


### PR DESCRIPTION
I've added a flag on the query string called 'raw'. If set to true it will base64 all the original payload results from the underlying TimeseriesStorageAPI onto the response body. Testing this week has revealed several cases in which I wished I had direct access to the underlying data.

I'll add some tests in the morning.