### PR TITLE
Add `does_not_match` field to conversion rules

### DIFF
--- a/util/rules_test.go
+++ b/util/rules_test.go
@@ -257,11 +257,11 @@ func Test_interpolateTags(t *testing.T) {
 
 }
 
-func TestDoesNotMatch(t *testing.T) {
+func TestDoNotMatchRegex(t *testing.T) {
 	rule, err := Compile(RawRule{
 		Pattern:          `%foo%.%animal%.%color%`,
 		MetricKeyPattern: `%foo%.%color%`,
-		DoesNotMatch: map[string]string{
+		DoNotMatch: map[string]string{
 			`animal`: `stuffed|teddy`,
 			`color`:  `z{4}|qy+`,
 		},


### PR DESCRIPTION
This allows you to exclude certain metrics from a conversion rule by rejecting the match if the result's tag values match their `do_not_match` field.

Golang does not support negative lookahead in its regular expression (in order to keep them more regular, as well as to ensure O(n) matching) and therefore it can be very difficult to intentionally exclude certain metrics from being matched.

It used to be that metrics were just matched in order, so that you could exclude from one rule by matching with another. However, because of danger of this introducing subtle bugs when one rule was changed, the behavior was changed so that order must not matter, and all metrics should match at most one rule.

This change makes it possible to easily exclude metrics from a particular rule, while keeping it orthogonal to all others- so that if another rule is removed or changed, it won't suddenly start capturing everything that the old one had.

TODO: check this when reversing metrics too (this is less likely to be useful, but for completeness it's not a bad idea)