### PR TITLE
Add gaps in cumulative transform results

### DIFF
--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -118,7 +118,7 @@ var MovingAverage = function.MetricFunction{
 				}
 				// Numerical error could (possibly) cause count == 0 but sum != 0.
 				if i-limit+1 >= 0 {
-					if count == 0 {
+					if count == 0 || math.IsNaN(series.Values[i]) {
 						results[i-limit+1] = math.NaN()
 					} else {
 						results[i-limit+1] = sum / float64(count)

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -62,14 +62,16 @@ func Integral(ctx *function.EvaluationContext, series api.Timeseries, parameters
 	result := make([]float64, len(values))
 	integral := 0.0
 	for i := range values {
+		if math.IsNaN(values[i]) {
+			// Gaps in the original remain gaps in the integral version.
+			result[i] = math.NaN()
+			continue
+		}
 		// Skip the 0th element since thats not technically part of our timerange
 		if i == 0 {
 			continue
 		}
-
-		if !math.IsNaN(values[i]) {
-			integral += values[i]
-		}
+		integral += values[i]
 		result[i] = integral * scale
 	}
 	return result, nil
@@ -82,13 +84,14 @@ func Cumulative(ctx *function.EvaluationContext, series api.Timeseries, paramete
 	sum := 0.0
 	for i := range values {
 		// Skip the 0th element since thats not technically part of our timerange
+		if math.IsNaN(values[i]) {
+			result[i] = math.NaN()
+			continue
+		}
 		if i == 0 {
 			continue
 		}
-
-		if !math.IsNaN(values[i]) {
-			sum += values[i]
-		}
+		sum += values[i]
 		result[i] = sum
 	}
 	return result, nil

--- a/function/transform/transformation_test.go
+++ b/function/transform/transformation_test.go
@@ -456,9 +456,9 @@ func TestApplyTransformNaN(t *testing.T) {
 			transform:  Integral,
 			parameters: []function.Value{},
 			expected: map[string][]float64{
-				"A": {0, 1 * 30, 1 * 30, 4 * 30, 8 * 30, 13 * 30},
-				"B": {0, 0, 0, 0, 3 * 30, 6 * 30},
-				"C": {0, 1 * 30, 3 * 30, 3 * 30, 5 * 30, 6 * 30},
+				"A": {0, 1 * 30, nan, 4 * 30, 8 * 30, 13 * 30},
+				"B": {0, nan, nan, nan, 3 * 30, 6 * 30},
+				"C": {0, 1 * 30, 3 * 30, nan, 5 * 30, 6 * 30},
 			},
 		},
 		{
@@ -474,9 +474,9 @@ func TestApplyTransformNaN(t *testing.T) {
 			transform:  Cumulative,
 			parameters: []function.Value{},
 			expected: map[string][]float64{
-				"A": {0, 1, 1, 4, 8, 13},
-				"B": {0, 0, 0, 0, 3, 6},
-				"C": {0, 1, 3, 3, 5, 6},
+				"A": {0, 1, nan, 4, 8, 13},
+				"B": {0, nan, nan, nan, 3, 6},
+				"C": {0, 1, 3, nan, 5, 6},
 			},
 		},
 		{


### PR DESCRIPTION
This change is tentative. It changes the behavior of `transform.integral`, `transform.cumulative`, and `transform.moving_average` in the following way:

Values that are missing in the input and missing in the output. The results are otherwise the same (missing values treated as 0 for integrals/sums, and treated as missing for transform.moving_average).

The result is that the `transform.integral` function will no longer hide missing data- the missing data will visible as gaps in the result.

To obtain the previous behavior, instead use something like `transform.nan_keep_last(transform.integral(series))` which will fill the empty segments with the flat values.

This doesn't affect aggregations or filters. However, series produced with `transform.(integral|cumulative|moving_average)` may be sorted in a different order by `filter.*` (since the input has changed, the sort order may change).

A concrete example:

Consider input of the form `transform.cumulative([3, NaN, 4, NaN, NaN, 2, NaN])`

Old behavior: `[3, 3, 7, 7, 7, 9, 9]`

New behavior: `[3, NaN, 7, NaN, NaN, 9, NaN]`
