### PR TITLE
Return errors when adding metrics to Cassandra API

### DIFF
--- a/function/expression.go
+++ b/function/expression.go
@@ -181,13 +181,11 @@ func EvaluateMany(context *EvaluationContext, expressions []Expression) ([]Value
 			}(i, expr)
 		}
 		array := make([]Value, length)
-		for i := 0; i < length; i++ {
-			result := <-results
+		for result := range results {
 			if result.err != nil {
 				return nil, result.err
-			} else {
-				array[result.index] = result.value
 			}
+			array[result.index] = result.value
 		}
 		return array, nil
 	}

--- a/metric_metadata/cassandra/cassandra.go
+++ b/metric_metadata/cassandra/cassandra.go
@@ -131,10 +131,10 @@ func (db *cassandraDatabase) AddMetricNames(metrics []api.TaggedMetric) error {
 
 	boundQueries := make(chan *gocql.Query, 10)
 	done := make(chan bool)
-	errors := make(error, 1)
+	errors := make(chan error, 1)
 	go func() {
 		for boundQuery := range boundQueries {
-			err = boundQuery.Exec()
+			err := boundQuery.Exec()
 			if err != nil && len(errors) < cap(errors) {
 				errors <- err
 			}

--- a/metric_metadata/cassandra/cassandra.go
+++ b/metric_metadata/cassandra/cassandra.go
@@ -63,8 +63,7 @@ func (a *CassandraMetricMetadataAPI) AddMetric(metric api.TaggedMetric, context 
 
 func (a *CassandraMetricMetadataAPI) AddMetrics(metrics []api.TaggedMetric, context api.MetricMetadataAPIContext) error {
 	defer context.Profiler.Record("Cassandra AddMetrics")()
-	a.db.AddMetricNames(metrics)
-	return nil
+	return a.db.AddMetricNames(metrics)
 }
 
 func (a *CassandraMetricMetadataAPI) GetAllTags(metricKey api.MetricKey, context api.MetricMetadataAPIContext) ([]api.TagSet, error) {
@@ -130,17 +129,17 @@ func (db *cassandraDatabase) AddMetricNames(metrics []api.TaggedMetric) error {
 	queryInsert := "INSERT INTO metric_names (metric_key, tag_set) VALUES (?, ?)"
 	queryUpdate := "UPDATE metric_name_set SET metric_names = metric_names + ? WHERE shard = ?"
 
-	c := make(chan *gocql.Query, 10)
+	boundQueries := make(chan *gocql.Query, 10)
 	done := make(chan bool)
+	errors := make(error, 1)
 	go func() {
-		for {
-			boundQuery, more := <-c
-			if !more {
-				done <- true
-				return
+		for boundQuery := range boundQueries {
+			err = boundQuery.Exec()
+			if err != nil && len(errors) < cap(errors) {
+				errors <- err
 			}
-			_ = boundQuery.Exec()
 		}
+		done <- true
 	}()
 
 	//For every query queue up an insert and a shard update and start streaming them.
@@ -152,7 +151,7 @@ func (db *cassandraDatabase) AddMetricNames(metrics []api.TaggedMetric) error {
 			return data, nil
 		})
 		boundQuery.Consistency(gocql.One)
-		c <- boundQuery
+		boundQueries <- boundQuery
 
 		boundQuery = db.session.Bind(queryUpdate, func(q *gocql.QueryInfo) ([]interface{}, error) {
 			data := make([]interface{}, 2)
@@ -161,11 +160,15 @@ func (db *cassandraDatabase) AddMetricNames(metrics []api.TaggedMetric) error {
 			return data, nil
 		})
 		boundQuery.Consistency(gocql.One)
-		c <- boundQuery
+		boundQueries <- boundQuery
 	}
-	close(c)
+	close(boundQueries)
 
 	<-done
+
+	if len(errors) > 0 {
+		return <-errors
+	}
 	return nil
 }
 

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -333,8 +333,8 @@ func (b *Blueflood) constructURL(
 // fetches from the backend. on error, it returns an instance of api.TimeseriesStorageError
 func (b *Blueflood) fetch(request api.FetchTimeseriesRequest, queryUrl *url.URL) (queryResponse, []byte, error) {
 	log.Debugf("Blueflood fetch: %s", queryUrl.String())
-	success := make(chan queryResponse)
-	failure := make(chan error)
+	success := make(chan queryResponse, 1)
+	failure := make(chan error, 1)
 	timeout := time.After(b.config.Timeout)
 	var rawResponse []byte
 	go func() {


### PR DESCRIPTION
Previously, errors were ignored, always returning `nil`.