### PR TITLE
Add errors to AddMetrics calls for Cassandra API

### DIFF
--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -333,8 +333,8 @@ func (b *Blueflood) constructURL(
 // fetches from the backend. on error, it returns an instance of api.TimeseriesStorageError
 func (b *Blueflood) fetch(request api.FetchTimeseriesRequest, queryUrl *url.URL) (queryResponse, []byte, error) {
 	log.Debugf("Blueflood fetch: %s", queryUrl.String())
-	success := make(chan queryResponse)
-	failure := make(chan error)
+	success := make(chan queryResponse, 1)
+	failure := make(chan error, 1)
 	timeout := time.After(b.config.Timeout)
 	var rawResponse []byte
 	go func() {


### PR DESCRIPTION
Previously, calls to `AddMetrics` in the Cassandra API instances always returned `nil` to indicate error, even if there was an error. This was because they didn't actually check errors returned by query execution, for example.

This pull request adds error checking. It also fixes a very small space leak which would cause some goroutines to hang forever in the event of a query timeout.