### PR TITLE
Add some helpful diagnostic information to some blueflood errors

### DIFF
--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -68,18 +68,18 @@ type TimeseriesStorageError struct {
 }
 
 func (err TimeseriesStorageError) Error() string {
-	message := "[%s] unknown error"
+	message := "[%s %+v] unknown error"
 	switch err.Code {
 	case FetchTimeoutError:
-		message = "[%s] timeout"
+		message = "[%s %+v] timeout"
 	case InvalidSeriesError:
-		message = "[%s] invalid series"
+		message = "[%s %+v] invalid series"
 	case LimitError:
-		message = "[%s] limit reached"
+		message = "[%s %+v] limit reached"
 	case Unsupported:
-		message = "[%s] unsupported operation"
+		message = "[%s %+v] unsupported operation"
 	}
-	formatted := fmt.Sprintf(message, string(err.Metric.MetricKey))
+	formatted := fmt.Sprintf(message, string(err.Metric.MetricKey), err.Metric.TagSet)
 	if err.Message != "" {
 		formatted = formatted + " - " + err.Message
 	}

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -358,7 +358,7 @@ func (b *Blueflood) fetch(request api.FetchTimeseriesRequest, queryUrl *url.URL)
 		err = json.Unmarshal(body, &parsedJson)
 		// Construct a Timeseries from the result:
 		if err != nil {
-			failure <- api.TimeseriesStorageError{request.Metric, api.FetchIOError, "error while fetching - json decoding"}
+			failure <- api.TimeseriesStorageError{request.Metric, api.FetchIOError, "error while fetching - json decoding\nBody: " + string(body) + "\nError: " + err.Error() + "\nURL: " + queryUrl.String()}
 			return
 		}
 		success <- parsedJson


### PR DESCRIPTION
Found some less-than-stellar error messages when trying to set up from scratch. Some extra diagnostic information, like the Blueflood URL when failing to connect, was pretty helpful.