### PR TITLE
Bugfix for transform.rate

### DIFF
--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -194,6 +194,11 @@ func rate(ctx *function.EvaluationContext, series api.Timeseries, parameters []f
 		// Scaled difference
 		result[i-1] = (values[i] - values[i-1]) / scale
 		if result[i-1] < 0 {
+			result[i-1] = 0
+		}
+		if i+1 < len(values) && values[i-1] > values[i] && values[i] <= values[i+1] {
+			// Downsampling may cause a drop from 1000 to 0 to look like [1000, 500, 0] instead of [1000, 1001, 0].
+			// So we check the next, in addition to the previous.
 			ctx.AddNote(fmt.Sprintf("Rate(%v): The underlying counter reset between %f, %f\n", series.TagSet, values[i-1], values[i]))
 			// values[i] is our best approximatation of the delta between i-1 and i
 			// Why? This should only be used on counters, so if v[i] - v[i-1] < 0 then


### PR DESCRIPTION
Fixes a bug when using `transform.rate`.

Downsampling can cause sudden drops to be smeared out over several slots in the timeseries. The result was mis-reporting many resets over the interval of time that the downsampling occurred.

Since the resets were only partial, the values looked really, really large for long-running counters, and, consequently, caused enormous spikes.

This change requires that the next point show an increase (in addition to decreasing from the previous) to be considered a reset. 