### PR TITLE
Demo data and conversion rules

### DIFF
--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -68,18 +68,18 @@ type TimeseriesStorageError struct {
 }
 
 func (err TimeseriesStorageError) Error() string {
-	message := "[%s] unknown error"
+	message := "[%s %+v] unknown error"
 	switch err.Code {
 	case FetchTimeoutError:
-		message = "[%s] timeout"
+		message = "[%s %+v] timeout"
 	case InvalidSeriesError:
-		message = "[%s] invalid series"
+		message = "[%s %+v] invalid series"
 	case LimitError:
-		message = "[%s] limit reached"
+		message = "[%s %+v] limit reached"
 	case Unsupported:
-		message = "[%s] unsupported operation"
+		message = "[%s %+v] unsupported operation"
 	}
-	formatted := fmt.Sprintf(message, string(err.Metric.MetricKey))
+	formatted := fmt.Sprintf(message, string(err.Metric.MetricKey), err.Metric.TagSet)
 	if err.Message != "" {
 		formatted = formatted + " - " + err.Message
 	}

--- a/demo/conversion_rules/cpu.yaml
+++ b/demo/conversion_rules/cpu.yaml
@@ -1,0 +1,9 @@
+rules:
+  - pattern: "%app%.%host%.cpu.percentage"
+    metric_key: cpu.percentage
+    tests:
+      - sample: mqe.server140.cpu.percentage
+        expected_metric_key: cpu.percentage
+        expected_tags:
+          app: mqe
+          host: server140

--- a/demo/conversion_rules/http.yaml
+++ b/demo/conversion_rules/http.yaml
@@ -1,0 +1,17 @@
+rules:
+  - pattern: "%app%.%host%.connection.%connection-type%.latency"
+    metric_key: connection.%connection-type%.latency
+    tests:
+      - sample: mqe.server140.connection.http.latency
+        expected_metric_key: connection.http.latency
+        expected_tags:
+          app: mqe
+          host: server140
+  - pattern: "%app%.%host%.connection.%connection-type%.count"
+    metric_key: connection.%connection-type%.count
+    tests:
+      - sample: mqe.server140.connection.http.count
+        expected_metric_key: connection.http.count
+        expected_tags:
+          app: mqe
+          host: server140

--- a/demo/emit/mock.go
+++ b/demo/emit/mock.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/demo/emit/mock.go
+++ b/demo/emit/mock.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+var bluefloodAddress = flag.String("blueflood-address", "", "Specify the URL for the HTTP  Blueflood server. ex: [http://localhost:19000/v2.0/tenant-id/ingest]")
+var mqeIngestionAddress = flag.String("mqe-ingestion-address", "", "Specify the URL (including port) for the MQE Ingestion server.")
+
+type SourceMetric struct {
+	Metric string
+	Source Source
+}
+
+func main() {
+	flag.Parse()
+
+	if *bluefloodAddress == "" {
+		fmt.Printf("You must specify the blueflood address with `-blueflood-address`\n")
+		return
+	}
+	if *mqeIngestionAddress == "" {
+		fmt.Printf("You must specify the MQE ingestion address address with `-mqe-ingestion-address`\n")
+		return
+	}
+
+	//
+
+	metrics := []SourceMetric{}
+
+	{
+		sources := make([]Source, 5)
+		for i := range sources {
+			sources[i] = Generate(func(x float64) float64 {
+				return math.Max(0, math.Min(300, x+10*rand.NormFloat64()))
+			})
+		}
+		for i := 0; i < 10; i++ {
+			metrics = append(metrics, SourceMetric{
+				fmt.Sprintf("webserver.host%d.cpu.percentage", i),
+				NewLinear(sources),
+			})
+		}
+	}
+
+	{
+		sources := make([]Source, 5)
+		for i := range sources {
+			sources[i] = Generate(func(x float64) float64 {
+				return x + math.Floor(math.Max(0, math.Min(300, 20+30*rand.NormFloat64())))
+			})
+		}
+		for i := 0; i < 10; i++ {
+			scale := rand.Float64()*90 + 10
+			metrics = append(metrics, SourceMetric{
+				fmt.Sprintf("webserver.host%d.connection.http.count", i),
+				&Mapper{NewLinear(sources), func(x float64) float64 { return scale * math.Floor(x) }}, // MAP
+			})
+		}
+	}
+
+	{
+		sources := make([]Source, 5)
+		for i := range sources {
+			sources[i] = Generate(func(x float64) float64 {
+				return math.Max(0, math.Min(1000, 10*rand.NormFloat64()))
+			})
+		}
+		for i := range sources {
+			metrics = append(metrics, SourceMetric{
+				fmt.Sprintf("webserver.host%d.connection.http.latency", i),
+				&Capper{sources[i], 0, 1000},
+			})
+		}
+	}
+
+	client := &http.Client{}
+	iteration := 0
+	for range time.Tick(15 * time.Second) {
+		iteration++
+		// every 15 seconds...
+		for _, metric := range metrics {
+			metric.Source.Advance(iteration)
+			err := reportMetric(client, metric.Source.Value(), metric.Metric)
+			if err != nil {
+				fmt.Printf("Error for metric %s:\n%s\n", metric.Metric, err.Error())
+			}
+		}
+	}
+
+	//
+	/*
+		serverCount := 200
+
+		cpuPercentage := make([]float64, serverCount)
+		cpuVelocities := make([]float64, serverCount)
+		cpuQuota := make([]float64, serverCount)
+
+		apps := []string{"mqe", "example", "webserver", "blueflood"}
+
+		for i := 0; i < serverCount; i++ {
+			cpuQuota[i] = float64(rand.Intn(6)*10 + 50)
+			cpuPercentage[i] = cpuQuota[i] * rand.Float64()
+			cpuVelocities[i] = rand.Float64() * 4
+		}
+
+		client := &http.Client{}
+
+		for {
+			// Report data to both Blueflood and MQE ingestion.
+			for i := range cpuPercentage {
+				err := reportMetric(client, cpuPercentage[i], "%s.server%d.cpu.percentage", apps[i%len(apps)], i/len(apps))
+				if err != nil {
+					fmt.Printf("Error\n", err.Error())
+				}
+			}
+			for i := range cpuQuota {
+				err := reportMetric(client, cpuQuota[i], "%s.server%d.cpu.quota", apps[i%len(apps)], i/len(apps))
+				if err != nil {
+					fmt.Printf("Error\n", err.Error())
+				}
+			}
+			// Simulate changing CPU usage (with randomness + sinusoidal trends)
+			appBias := make([]float64, len(apps))
+			for i := range appBias {
+				appBias[i] = rand.NormFloat64()
+			}
+			for i := range cpuPercentage {
+				cpuVelocities[i] *= 0.99
+				cpuVelocities[i] += appBias[i%len(apps)]
+				cpuVelocities[i] += rand.NormFloat64() * 0.25
+
+				cpuPercentage[i] *= 0.99
+
+				cpuPercentage[i] += cpuVelocities[i]
+				if cpuPercentage[i] < 0 {
+					cpuPercentage[i] = 0
+				}
+				if cpuPercentage[i] > cpuQuota[i]*1.05 {
+					cpuPercentage[i] = cpuQuota[i] * 1.05
+				}
+			}
+			<-time.After(15 * time.Second)
+		}
+	*/
+}
+
+func reportMetric(client *http.Client, value float64, name string, options ...interface{}) error {
+	metricName := fmt.Sprintf(name, options...)
+	json := createPointJSON(value, metricName)
+
+	request, err := http.NewRequest("POST", *bluefloodAddress, bytes.NewBuffer([]byte(json)))
+	if err != nil {
+		return fmt.Errorf("Error creating Blueflood request: %s\n", err.Error())
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("Error performing Blueflood POST: %s\n", err.Error())
+	}
+	fmt.Println("Blueflood: ", response.Status)
+	body, _ := ioutil.ReadAll(response.Body)
+	fmt.Println(string(body))
+
+	// Next, we need to inform the ingestion service
+
+	request, err = http.NewRequest("POST", *mqeIngestionAddress, bytes.NewBuffer([]byte(metricName)))
+	if err != nil {
+		return fmt.Errorf("Error creating MQE Ingestion request: %s\n", err.Error())
+	}
+	response, err = client.Do(request)
+	if err != nil {
+		return fmt.Errorf("Error performing MQE Ingestion POST: %s\n", err.Error())
+	}
+	fmt.Println("MQE: ", response.Status)
+	body, _ = ioutil.ReadAll(response.Body)
+	fmt.Println(string(body))
+	return nil
+}
+
+func createPointJSON(value float64, metricName string) string {
+	// 10 day TTL
+	return fmt.Sprintf(`[{
+		"collectionTime": %d,
+		"ttlInSeconds": 864000,
+		"metricValue": %f,
+		"metricName": "%s"
+	}]`, time.Now().Unix()*1000, value, metricName)
+}

--- a/demo/emit/source.go
+++ b/demo/emit/source.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/demo/emit/source.go
+++ b/demo/emit/source.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"math"
+	"math/rand"
+)
+
+type Source interface {
+	Advance(int)
+	Value() float64
+}
+
+type Generator struct {
+	epoch int
+	value float64
+	next  func(float64) float64
+}
+
+func (g *Generator) Advance(epoch int) {
+	if g.epoch == epoch {
+		return
+	}
+	g.epoch = epoch
+	g.value = g.next(g.value)
+}
+func (g *Generator) Value() float64 {
+	return g.value
+}
+
+func Generate(f func(float64) float64) Source {
+	return &Generator{0, 0, f}
+}
+
+func Normal() Source {
+	return &Generator{0, 0, func(old float64) float64 {
+		return rand.NormFloat64()
+	}}
+}
+func Uniform() Source {
+	return &Generator{0, 0, func(old float64) float64 {
+		return rand.Float64()
+	}}
+}
+func Brownian() Source {
+	return &Generator{0, 0, func(old float64) float64 {
+		return old + rand.NormFloat64()
+	}}
+}
+
+type Linear struct {
+	sources []Source
+	weights []float64
+}
+
+func (linear *Linear) Advance(epoch int) {
+	for i := range linear.sources {
+		linear.sources[i].Advance(epoch)
+	}
+}
+func (linear *Linear) Value() float64 {
+	value := 0.0
+	for i := range linear.sources {
+		value += linear.weights[i] * linear.sources[i].Value()
+	}
+	return value
+}
+
+func NewLinear(sources []Source) Source {
+	weights := make([]float64, len(sources))
+	weight := 0.0
+	for i := range weights {
+		weights[i] = rand.Float64()
+		weight += weights[i]
+	}
+	for i := range weights {
+		weights[i] /= weight
+	}
+	return &Linear{sources, weights}
+}
+
+type Capper struct {
+	source Source
+	min    float64
+	max    float64
+}
+
+func (c *Capper) Advance(epoch int) {
+	c.source.Advance(epoch)
+}
+func (c *Capper) Value() float64 {
+	return math.Max(c.min, math.Min(c.max, c.source.Value()))
+}
+
+type Cumulative struct {
+	source Source
+	epoch  int
+	sum    float64
+}
+
+func (c *Cumulative) Advance(epoch int) {
+	c.source.Advance(epoch)
+	if c.epoch == epoch {
+		return
+	}
+	c.sum += c.source.Value()
+}
+func (c *Cumulative) Value() float64 {
+	return c.sum
+}
+
+type Mapper struct {
+	source Source
+	fun    func(float64) float64
+}
+
+func (m *Mapper) Advance(epoch int) {
+	m.source.Advance(epoch)
+}
+func (m *Mapper) Value() float64 {
+	return m.fun(m.source.Value())
+}
+
+func RequestSources(count int) []Source {
+	base := []Source{Normal(), Uniform(), Brownian(), Brownian(), Brownian()}
+	result := make([]Source, count)
+	for i := range result {
+		result[i] = NewLinear(base)
+	}
+	return result
+}

--- a/demo/example-config.yaml
+++ b/demo/example-config.yaml
@@ -1,0 +1,21 @@
+
+blueflood:
+  base_url: http://localhost:1777  # the URL of the Blueflood server
+  tenant_id: "example-tenant"      # the tenant-ID (you can have independent tenants that share the same Blueflood server)
+  ttls:
+    FULL: 10                       # the number of days that FULL (30s) resolution data has to live
+  timeout: 2e10                    # the timeout (in nanoseconds) for connecting to Blueflood
+  full_resolution_overlap: 10000   # the amount of time (in milliseconds) 
+  simultaneous_requests: 10        # the number of simultaneously concurrent requests that MQE is allowed to make to Blueflood
+
+api:
+  conversion_rules_path: demo/conversion_rules  # the directory for the conversion rules
+  hosts:
+    - localhost                                 # the IP addresses/hostnames for the Cassandra nodes
+  keyspace: metrics_indexer                     # the keyspace for MQE indexing
+
+ui:
+  port: 9007                 # The port that the HTTP UI is served on. Visit http://localhost:9007 to see the UI.
+  timeout: 2000              # The timeout before a connection is dropped over the UI.
+  config:
+    static_dir: main/static  # The directory that the HTTP server presents. You can fork the provided UI and use your own by placing it in a different directory.

--- a/demo/example-config.yaml
+++ b/demo/example-config.yaml
@@ -5,13 +5,13 @@ blueflood:
   ttls:
     FULL: 10                       # the number of days that FULL (30s) resolution data has to live
   timeout: 2e10                    # the timeout (in nanoseconds) for connecting to Blueflood
-  full_resolution_overlap: 10000   # the amount of time (in milliseconds) 
+  full_resolution_overlap: 10000   # the amount of time (in milliseconds)
   simultaneous_requests: 10        # the number of simultaneously concurrent requests that MQE is allowed to make to Blueflood
 
 api:
   conversion_rules_path: demo/conversion_rules  # the directory for the conversion rules
   hosts:
-    - localhost                                 # the IP addresses/hostnames for the Cassandra nodes
+    - localhost:9160                            # the IP addresses/hostnames for the Cassandra nodes (9160 is the default port, and can be omitted)
   keyspace: metrics_indexer                     # the keyspace for MQE indexing
 
 ui:

--- a/demo/ingest/ingest.go
+++ b/demo/ingest/ingest.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/demo/ingest/ingest.go
+++ b/demo/ingest/ingest.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/metric_metadata/cassandra"
+	"github.com/square/metrics/util"
+)
+
+const rulePath = "conversion_rules" // relative to execution
+
+func main() {
+	rules, err := util.LoadRules(rulePath)
+	if err != nil {
+		fmt.Printf("Error loading rules; %+v", err.Error())
+		return
+	}
+
+	converter := util.RuleBasedGraphiteConverter{Ruleset: rules}
+
+	cassandra, err := cassandra.NewCassandraMetricMetadataAPI(cassandra.CassandraMetricMetadataConfig{
+		Hosts:    []string{"127.0.0.1"}, // using the default port
+		Keyspace: "metrics_indexer",     // from schema in github.com/square/metrics/schema
+	})
+	if err != nil {
+		fmt.Printf("Error encountered while creating Cassandra API instance: %+v", err.Error())
+		return
+	}
+	fmt.Printf("Successfully connected to the Cassandra database.\n")
+
+	// Now we'll create an HTTP service which can be provided metric names.
+	// It will deliver them to Cassandra through this api
+
+	http.HandleFunc("/ingest", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Printf("Received request.\n")
+		body := req.Body
+
+		bytes, err := ioutil.ReadAll(body)
+		if err != nil {
+			log.Printf("Error reading body %s", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf("Error reading body: %s", err.Error())))
+		}
+
+		metrics := []util.GraphiteMetric{} // TODO: apply conversion rules
+
+		for _, metric := range strings.Split(string(bytes), "\n") {
+			metric = strings.TrimSpace(metric)
+			if metric != "" {
+				metrics = append(metrics, util.GraphiteMetric(metric))
+			}
+		}
+
+		if len(metrics) == 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("received no metrics"))
+			return
+		}
+
+		// Now, convert them
+
+		converted := []api.TaggedMetric{}
+
+		messages := []string{}
+
+		for _, metric := range metrics {
+			result, err := converter.ToTaggedName(metric)
+			if err != nil {
+				messages = append(messages, err.Error())
+				continue
+			}
+			converted = append(converted, result)
+		}
+
+		err = cassandra.AddMetrics(converted, api.MetricMetadataAPIContext{})
+
+		if err != nil {
+			log.Printf("Error sending metrics to Cassandra: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("error connecting to cassandra %s", err.Error())))
+			return
+		}
+		err = body.Close()
+		if err != nil {
+			log.Printf("Error closing body: %s", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		for _, message := range messages {
+			w.Write([]byte("Error: "))
+			w.Write([]byte(message))
+			w.Write([]byte("\n"))
+		}
+	})
+
+	err = http.ListenAndServe(":7774", nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}

--- a/demo/ingest/ingest.go
+++ b/demo/ingest/ingest.go
@@ -31,7 +31,7 @@ import (
 var rulePath = flag.String("rule-path", "", "Specify the directory of the conversion rule files. [example: metrics/demo/conversion_rules]")
 
 // cassandraHost specifies the IP of the Cassandra host that MQE uses.
-// You can use 127.0.0.1 (which will use Cassandra's default port (TODO: look this up)) if you set it up on your local machine.
+// You can use 127.0.0.1 (which will use Cassandra's default port 9160) if you set it up on your local machine.
 var cassandraHost = flag.String("cassandra-host", "", "Specify the IP of MQE's Cassandra host. [example: 127.0.0.1]")
 
 // listenOnPort specifies the port to listen on for ingestion.

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -358,7 +358,7 @@ func (b *Blueflood) fetch(request api.FetchTimeseriesRequest, queryUrl *url.URL)
 		err = json.Unmarshal(body, &parsedJson)
 		// Construct a Timeseries from the result:
 		if err != nil {
-			failure <- api.TimeseriesStorageError{request.Metric, api.FetchIOError, "error while fetching - json decoding"}
+			failure <- api.TimeseriesStorageError{request.Metric, api.FetchIOError, "error while fetching - json decoding\nBody: " + string(body) + "\nError: " + err.Error() + "\nURL: " + queryUrl.String()}
 			return
 		}
 		success <- parsedJson


### PR DESCRIPTION
This PR makes it easier to start up a local instance of MQE and start indexing metrics.

`/demo/emit` has a program which emits sample metric data over HTTP to a Blueflood instance and to a metric indexe.r

`/demo/ingest` has a program which collects metric metdata over an HTTP endpoint and stores the metsdata in a cassandra instance,

The `/demo/conversion_rules` has conversion rules for the demo metrics.

The `/demo/example-config.yaml` file has an example of a configuration file to start the MQE UI.

Detailed documentation for starting and using the server will be made available on the GitHub Wiki for this project.

@cchandler @drcapulet @syamp 