### PR TITLE
Remove checks for future queries

### DIFF
--- a/query/parser.go
+++ b/query/parser.go
@@ -115,9 +115,6 @@ func parseDate(date string, now time.Time) (int64, error) {
 	relativeTime, err := function.StringToDuration(date)
 	if err == nil {
 		// A relative date.
-		if relativeTime > 0 {
-			return -1, fmt.Errorf("relative times should be negative: %s", date)
-		}
 		return now.Add(relativeTime).Unix() * 1000, nil
 	}
 

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -40,7 +40,7 @@ func Test_parseRelativeTime(t *testing.T) {
 		{"-1y", 1381785866000, true},
 		{"1s", 1413321867000, true},
 		{"+1s", 1413321867000, true},
-		{"5d", 1413322298000, true},
+		{"5d", 1413753866000, true},
 		// Bad relative timestamps
 		{"5dd", -1, false},
 		{"-5dd", -1, false},

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -38,10 +38,10 @@ func Test_parseRelativeTime(t *testing.T) {
 		{"-3w", 1411507466000, true},
 		{"-1M", 1410729866000, true},
 		{"-1y", 1381785866000, true},
+		{"1s", 1413321867000, true},
+		{"+1s", 1413321867000, true},
+		{"5d", 1413322298000, true},
 		// Bad relative timestamps
-		{"1s", -1, false},
-		{"+1s", -1, false},
-		{" 5d", -1, false},
 		{"5dd", -1, false},
 		{"-5dd", -1, false},
 		{"-5z", -1, false},


### PR DESCRIPTION
In anticipation of https://github.com/square/metrics/pull/233, removes the restriction that relative fetches (`from -1d to now`) must be in the past. So you can now write `from now to +3d`