### PR TITLE
Add messages describing the source of type conversion errors

### DIFF
--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -35,7 +35,7 @@ func (list SeriesList) isValid() bool {
 	return true // validation is now successful.
 }
 
-func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
+func (list SeriesList) ToSeriesList(time Timerange, description string) (SeriesList, error) {
 	return list, nil
 }
 

--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -39,14 +39,14 @@ func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
 	return list, nil
 }
 
-func (list SeriesList) ToString() (string, error) {
-	return "", ConversionError{"SeriesList", "string", "serieslist[_]"}
+func (list SeriesList) ToString(description string) (string, error) {
+	return "", ConversionError{"SeriesList", "string", description}
 }
 
-func (list SeriesList) ToScalar() (float64, error) {
-	return 0, ConversionError{"SeriesList", "scalar", "serieslist[_]"}
+func (list SeriesList) ToScalar(description string) (float64, error) {
+	return 0, ConversionError{"SeriesList", "scalar", description}
 }
 
-func (list SeriesList) ToDuration() (time.Duration, error) {
-	return 0, ConversionError{"SeriesList", "duration", "serieslist[_]"}
+func (list SeriesList) ToDuration(description string) (time.Duration, error) {
+	return 0, ConversionError{"SeriesList", "duration", description}
 }

--- a/function/expression.go
+++ b/function/expression.go
@@ -171,7 +171,7 @@ func EvaluateToSeriesList(e Expression, context *EvaluationContext) (api.SeriesL
 	if err != nil {
 		return api.SeriesList{}, err
 	}
-	return seriesValue.ToSeriesList(context.Timerange)
+	return seriesValue.ToSeriesList(context.Timerange, e.QueryString())
 }
 func EvaluateToString(e Expression, context *EvaluationContext) (string, error) {
 	stringValue, err := e.Evaluate(context)

--- a/function/expression.go
+++ b/function/expression.go
@@ -157,14 +157,14 @@ func EvaluateToScalar(e Expression, context *EvaluationContext) (float64, error)
 	if err != nil {
 		return 0, err
 	}
-	return scalarValue.ToScalar()
+	return scalarValue.ToScalar(e.QueryString())
 }
 func EvaluateToDuration(e Expression, context *EvaluationContext) (time.Duration, error) {
-	scalarValue, err := e.Evaluate(context)
+	durationValue, err := e.Evaluate(context)
 	if err != nil {
 		return 0, err
 	}
-	return scalarValue.ToDuration()
+	return durationValue.ToDuration(e.QueryString())
 }
 func EvaluateToSeriesList(e Expression, context *EvaluationContext) (api.SeriesList, error) {
 	seriesValue, err := e.Evaluate(context)
@@ -172,6 +172,13 @@ func EvaluateToSeriesList(e Expression, context *EvaluationContext) (api.SeriesL
 		return api.SeriesList{}, err
 	}
 	return seriesValue.ToSeriesList(context.Timerange)
+}
+func EvaluateToString(e Expression, context *EvaluationContext) (string, error) {
+	stringValue, err := e.Evaluate(context)
+	if err != nil {
+		return "", err
+	}
+	return stringValue.ToString(e.QueryString())
 }
 
 // EvaluateMany evaluates a list of expressions using a single EvaluationContext.

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -44,7 +44,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err // TODO: add decoration to describe it's coming from the anomaly function
 			}
-			prediction, err := predictionValue.ToSeriesList(context.Timerange)
+			prediction, err := predictionValue.ToSeriesList(context.Timerange, "prediction series")
 			if err != nil {
 				return nil, err
 			}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -156,11 +156,7 @@ func NewFilter(name string, summary func([]float64) float64, ascending bool) fun
 			if err != nil {
 				return nil, err
 			}
-			countValue, err := arguments[1].Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			countFloat, err := countValue.ToScalar()
+			countFloat, err := function.EvaluateToScalar(arguments[1], context)
 			if err != nil {
 				return nil, err
 			}
@@ -191,11 +187,7 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 			if err != nil {
 				return nil, err
 			}
-			countValue, err := arguments[1].Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			countFloat, err := countValue.ToScalar()
+			countFloat, err := function.EvaluateToScalar(arguments[1], context)
 			if err != nil {
 				return nil, err
 			}
@@ -204,11 +196,7 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 			if count < 0 {
 				return nil, fmt.Errorf("expected positive count but got %d", count)
 			}
-			durationValue, err := arguments[2].Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			duration, err := durationValue.ToDuration()
+			duration, err := function.EvaluateToDuration(arguments[2], context)
 			if err != nil {
 				return nil, err
 			}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -147,12 +147,7 @@ func NewFilter(name string, summary func([]float64) float64, ascending bool) fun
 		MinArguments: 2,
 		MaxArguments: 2,
 		Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-			value, err := arguments[0].Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			// The value must be a SeriesList.
-			list, err := value.ToSeriesList(context.Timerange)
+			list, err := function.EvaluateToSeriesList(arguments[0], context)
 			if err != nil {
 				return nil, err
 			}
@@ -178,12 +173,7 @@ func NewFilterRecent(name string, summary func([]float64) float64, ascending boo
 		MinArguments: 3,
 		MaxArguments: 3,
 		Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-			value, err := arguments[0].Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			// The value must be a SeriesList.
-			list, err := value.ToSeriesList(context.Timerange)
+			list, err := function.EvaluateToSeriesList(arguments[0], context)
 			if err != nil {
 				return nil, err
 			}
@@ -215,11 +205,7 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 		AllowsGroupBy: true,
 		Compute: func(context *function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
 			argument := args[0]
-			value, err := argument.Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			seriesList, err := value.ToSeriesList(context.Timerange)
+			seriesList, err := function.EvaluateToSeriesList(argument, context)
 			if err != nil {
 				return nil, err
 			}
@@ -234,18 +220,14 @@ func NewTransform(name string, parameterCount int, transformer func(*function.Ev
 		Name:         name,
 		MinArguments: parameterCount + 1,
 		MaxArguments: parameterCount + 1,
-		Compute: func(context *function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
-			listValue, err := args[0].Evaluate(context)
-			if err != nil {
-				return nil, err
-			}
-			list, err := listValue.ToSeriesList(context.Timerange)
+		Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+			list, err := function.EvaluateToSeriesList(arguments[0], context)
 			if err != nil {
 				return nil, err
 			}
 			parameters := make([]function.Value, parameterCount)
 			for i := range parameters {
-				parameters[i], err = args[i+1].Evaluate(context)
+				parameters[i], err = arguments[i+1].Evaluate(context)
 				if err != nil {
 					return nil, err
 				}
@@ -269,11 +251,11 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 			}
 			leftValue := evaluated[0]
 			rightValue := evaluated[1]
-			leftList, err := leftValue.ToSeriesList(context.Timerange)
+			leftList, err := leftValue.ToSeriesList(context.Timerange, args[0].QueryString())
 			if err != nil {
 				return nil, err
 			}
-			rightList, err := rightValue.ToSeriesList(context.Timerange)
+			rightList, err := rightValue.ToSeriesList(context.Timerange, args[1].QueryString())
 			if err != nil {
 				return nil, err
 			}

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -80,11 +80,7 @@ var DropFunction = function.MetricFunction{
 		if err != nil {
 			return nil, err
 		}
-		value, err := arguments[1].Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		dropTag, err := value.ToString()
+		dropTag, err := function.EvaluateToString(arguments[1], context)
 		if err != nil {
 			return nil, err
 		}
@@ -107,19 +103,11 @@ var SetFunction = function.MetricFunction{
 		if err != nil {
 			return nil, err
 		}
-		tagValue, err := arguments[1].Evaluate(context)
+		tag, err := function.EvaluateToString(arguments[1], context)
 		if err != nil {
 			return nil, err
 		}
-		tag, err := tagValue.ToString()
-		if err != nil {
-			return nil, err
-		}
-		setValue, err := arguments[2].Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		set, err := setValue.ToString()
+		set, err := function.EvaluateToString(arguments[2], context)
 		if err != nil {
 			return nil, err
 		}

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -72,11 +72,7 @@ var DropFunction = function.MetricFunction{
 	MinArguments: 2,
 	MaxArguments: 2,
 	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		result, err := arguments[0].Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		list, err := result.ToSeriesList(context.Timerange)
+		list, err := function.EvaluateToSeriesList(arguments[0], context)
 		if err != nil {
 			return nil, err
 		}
@@ -95,11 +91,7 @@ var SetFunction = function.MetricFunction{
 	MinArguments: 3,
 	MaxArguments: 3,
 	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		result, err := arguments[0].Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		list, err := result.ToSeriesList(context.Timerange)
+		list, err := function.EvaluateToSeriesList(arguments[0], context)
 		if err != nil {
 			return nil, err
 		}

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -27,18 +27,14 @@ var Timeshift = function.MetricFunction{
 	MinArguments: 2,
 	MaxArguments: 2,
 	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		value, err := arguments[1].Evaluate(context)
+		duration, err := function.EvaluateToDuration(arguments[1], context)
 		if err != nil {
 			return nil, err
 		}
-		duration, err := value.ToDuration()
-		if err != nil {
-			return nil, err
-		}
-		newContext := context
+		newContext := context.Copy()
 		newContext.Timerange = newContext.Timerange.Shift(duration)
 
-		result, err := arguments[0].Evaluate(newContext)
+		result, err := arguments[0].Evaluate(&newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -58,11 +54,7 @@ var MovingAverage = function.MetricFunction{
 	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
 
-		sizeValue, err := arguments[1].Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		size, err := sizeValue.ToDuration()
+		size, err := function.EvaluateToDuration(arguments[1], context)
 		if err != nil {
 			return nil, err
 		}
@@ -135,11 +127,7 @@ var ExponentialMovingAverage = function.MetricFunction{
 	Compute: func(context *function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
 
-		sizeValue, err := arguments[1].Evaluate(context)
-		if err != nil {
-			return nil, err
-		}
-		size, err := sizeValue.ToDuration()
+		size, err := function.EvaluateToDuration(arguments[1], context)
 		if err != nil {
 			return nil, err
 		}

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -71,13 +71,7 @@ var MovingAverage = function.MetricFunction{
 			return nil, err
 		}
 		// The new context has a timerange which is extended beyond the query's.
-		listValue, err := arguments[0].Evaluate(&newContext)
-		if err != nil {
-			return nil, err
-		}
-
-		// This value must be a SeriesList.
-		list, err := listValue.ToSeriesList(newContext.Timerange)
+		list, err := function.EvaluateToSeriesList(arguments[0], &newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -144,13 +138,7 @@ var ExponentialMovingAverage = function.MetricFunction{
 			return nil, err
 		}
 		// The new context has a timerange which is extended beyond the query's.
-		listValue, err := arguments[0].Evaluate(&newContext)
-		if err != nil {
-			return nil, err
-		}
-
-		// This value must be a SeriesList.
-		list, err := listValue.ToSeriesList(newContext.Timerange)
+		list, err := function.EvaluateToSeriesList(arguments[0], &newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -269,13 +257,7 @@ func newDerivativeBasedTransform(name string, transformer transform) function.Me
 			}
 
 			// The new context has a timerange which is extended beyond the query's.
-			listValue, err := arguments[0].Evaluate(&newContext)
-			if err != nil {
-				return nil, err
-			}
-
-			// This value must be a SeriesList.
-			list, err := listValue.ToSeriesList(newContext.Timerange)
+			list, err := function.EvaluateToSeriesList(arguments[0], &newContext)
 			if err != nil {
 				return nil, err
 			}

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -109,7 +109,7 @@ func MapMaker(fun func(float64) float64) func(*function.EvaluationContext, api.T
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
 func Default(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	defaultValue, err := parameters[0].ToScalar()
+	defaultValue, err := parameters[0].ToScalar("default value")
 	if err != nil {
 		return nil, err
 	}
@@ -154,11 +154,11 @@ func (b boundError) TokenName() string {
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
 func Bound(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	lowerBound, err := parameters[0].ToScalar()
+	lowerBound, err := parameters[0].ToScalar("lower bound")
 	if err != nil {
 		return nil, err
 	}
-	upperBound, err := parameters[1].ToScalar()
+	upperBound, err := parameters[1].ToScalar("upper bound")
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func Bound(ctx *function.EvaluationContext, series api.Timeseries, parameters []
 // LowerBound replaces values that fall below the given bound with the lower bound.
 func LowerBound(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	lowerBound, err := parameters[0].ToScalar()
+	lowerBound, err := parameters[0].ToScalar("lower bound")
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func LowerBound(ctx *function.EvaluationContext, series api.Timeseries, paramete
 // UpperBound replaces values that fall below the given bound with the lower bound.
 func UpperBound(ctx *function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	upperBound, err := parameters[0].ToScalar()
+	upperBound, err := parameters[0].ToScalar("upper bound")
 	if err != nil {
 		return nil, err
 	}

--- a/function/value.go
+++ b/function/value.go
@@ -26,7 +26,7 @@ import (
 // Value is the result of evaluating an expression.
 // They can be floating point values, strings, or series lists.
 type Value interface {
-	ToSeriesList(api.Timerange) (api.SeriesList, error)
+	ToSeriesList(api.Timerange, string) (api.SeriesList, error)
 	ToString(string) (string, error)          // takes a description of the object's expression
 	ToScalar(string) (float64, error)         // takes a description of the object's expression
 	ToDuration(string) (time.Duration, error) // takes a description of the object's expression
@@ -35,8 +35,8 @@ type Value interface {
 // A StringValue holds a string
 type StringValue string
 
-func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, api.ConversionError{"string", "SeriesList", fmt.Sprintf("%q", value)}
+func (value StringValue) ToSeriesList(time api.Timerange, description string) (api.SeriesList, error) {
+	return api.SeriesList{}, api.ConversionError{"string", "SeriesList", description}
 }
 
 func (value StringValue) ToString(description string) (string, error) {
@@ -54,7 +54,7 @@ func (value StringValue) ToDuration(description string) (time.Duration, error) {
 // A ScalarValue holds a float and can be converted to a serieslist
 type ScalarValue float64
 
-func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
+func (value ScalarValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
 
 	series := make([]float64, timerange.Slots())
 	for i := range series {
@@ -88,8 +88,8 @@ func NewDurationValue(name string, duration time.Duration) DurationValue {
 	return DurationValue{name, duration}
 }
 
-func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, api.ConversionError{"duration", "SeriesList", value.name}
+func (value DurationValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
+	return api.SeriesList{}, api.ConversionError{"duration", "SeriesList", description}
 }
 
 func (value DurationValue) ToString(description string) (string, error) {

--- a/function/value.go
+++ b/function/value.go
@@ -27,9 +27,9 @@ import (
 // They can be floating point values, strings, or series lists.
 type Value interface {
 	ToSeriesList(api.Timerange) (api.SeriesList, error)
-	ToString() (string, error)
-	ToScalar() (float64, error)
-	ToDuration() (time.Duration, error)
+	ToString(string) (string, error)          // takes a description of the object's expression
+	ToScalar(string) (float64, error)         // takes a description of the object's expression
+	ToDuration(string) (time.Duration, error) // takes a description of the object's expression
 }
 
 // A StringValue holds a string
@@ -39,16 +39,16 @@ func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error
 	return api.SeriesList{}, api.ConversionError{"string", "SeriesList", fmt.Sprintf("%q", value)}
 }
 
-func (value StringValue) ToString() (string, error) {
+func (value StringValue) ToString(description string) (string, error) {
 	return string(value), nil
 }
 
-func (value StringValue) ToScalar() (float64, error) {
-	return 0, api.ConversionError{"string", "scalar", fmt.Sprintf("%q", value)}
+func (value StringValue) ToScalar(description string) (float64, error) {
+	return 0, api.ConversionError{"string", "scalar", description}
 }
 
-func (value StringValue) ToDuration() (time.Duration, error) {
-	return 0, api.ConversionError{"string", "duration", fmt.Sprintf("%q", value)}
+func (value StringValue) ToDuration(description string) (time.Duration, error) {
+	return 0, api.ConversionError{"string", "duration", description}
 }
 
 func (value StringValue) GetName() string {
@@ -71,16 +71,16 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 	}, nil
 }
 
-func (value ScalarValue) ToString() (string, error) {
+func (value ScalarValue) ToString(description string) (string, error) {
 	return "", api.ConversionError{"scalar", "string", fmt.Sprintf("%f", value)}
 }
 
-func (value ScalarValue) ToScalar() (float64, error) {
+func (value ScalarValue) ToScalar(description string) (float64, error) {
 	return float64(value), nil
 }
 
-func (value ScalarValue) ToDuration() (time.Duration, error) {
-	return 0, api.ConversionError{"scalar", "duration", fmt.Sprintf("%f", value)}
+func (value ScalarValue) ToDuration(description string) (time.Duration, error) {
+	return 0, api.ConversionError{"scalar", "duration", description}
 }
 
 func (value ScalarValue) GetName() string {
@@ -100,15 +100,15 @@ func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList
 	return api.SeriesList{}, api.ConversionError{"duration", "SeriesList", value.name}
 }
 
-func (value DurationValue) ToString() (string, error) {
-	return "", api.ConversionError{"duration", "string", value.name}
+func (value DurationValue) ToString(description string) (string, error) {
+	return "", api.ConversionError{"duration", "string", description}
 }
 
-func (value DurationValue) ToScalar() (float64, error) {
-	return 0, api.ConversionError{"duration", "scalar", value.name}
+func (value DurationValue) ToScalar(description string) (float64, error) {
+	return 0, api.ConversionError{"duration", "scalar", description}
 }
 
-func (value DurationValue) ToDuration() (time.Duration, error) {
+func (value DurationValue) ToDuration(description string) (time.Duration, error) {
 	return time.Duration(value.duration), nil
 }
 

--- a/function/value.go
+++ b/function/value.go
@@ -51,10 +51,6 @@ func (value StringValue) ToDuration(description string) (time.Duration, error) {
 	return 0, api.ConversionError{"string", "duration", description}
 }
 
-func (value StringValue) GetName() string {
-	return string(value)
-}
-
 // A ScalarValue holds a float and can be converted to a serieslist
 type ScalarValue float64
 
@@ -83,10 +79,6 @@ func (value ScalarValue) ToDuration(description string) (time.Duration, error) {
 	return 0, api.ConversionError{"scalar", "duration", description}
 }
 
-func (value ScalarValue) GetName() string {
-	return fmt.Sprintf("%g", value)
-}
-
 type DurationValue struct {
 	name     string
 	duration time.Duration
@@ -110,10 +102,6 @@ func (value DurationValue) ToScalar(description string) (float64, error) {
 
 func (value DurationValue) ToDuration(description string) (time.Duration, error) {
 	return time.Duration(value.duration), nil
-}
-
-func (value DurationValue) GetName() string {
-	return value.name
 }
 
 var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy]|ms|hr|mo|yr)$`)

--- a/query/command.go
+++ b/query/command.go
@@ -263,7 +263,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 	case result := <-results:
 		lists := make([]api.SeriesList, len(result))
 		for i := range result {
-			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange)
+			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange, cmd.expressions[i].QueryString())
 			if err != nil {
 				return CommandResult{}, err
 			}

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -82,7 +82,7 @@ func Test_ScalarExpression(t *testing.T) {
 		},
 	} {
 		a := assert.New(t).Contextf("%+v", test)
-		result, err := evaluateToSeriesList(test.expr, &function.EvaluationContext{
+		result, err := function.EvaluateToSeriesList(test.expr, &function.EvaluationContext{
 			TimeseriesStorageAPI: FakeBackend{},
 			Timerange:            test.timerange,
 			SampleMethod:         api.SampleMean,
@@ -330,7 +330,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			continue
 		}
 
-		result, err := value.ToSeriesList(test.context.Timerange)
+		result, err := value.ToSeriesList(test.context.Timerange, "-test-")
 		if err != nil {
 			a.EqBool(err == nil, test.expectSuccess)
 			continue
@@ -371,14 +371,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		}
 
 	}
-}
-
-func evaluateToSeriesList(e function.Expression, context *function.EvaluationContext) (api.SeriesList, error) {
-	value, err := e.Evaluate(context)
-	if err != nil {
-		return api.SeriesList{}, err
-	}
-	return value.ToSeriesList(context.Timerange)
 }
 
 var _ api.TimeseriesStorageAPI = (*FakeBackend)(nil)

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -73,7 +73,7 @@ func TestMovingAverage(t *testing.T) {
 	}
 
 	backend := fakeBackend
-	result, err := evaluateToSeriesList(expression,
+	result, err := function.EvaluateToSeriesList(expression,
 		&function.EvaluationContext{
 			MetricMetadataAPI:         fakeAPI,
 			TimeseriesStorageAPI:      backend,


### PR DESCRIPTION
When a type conversion error occurs, now the query that produced the value with the wrong type is printed, instead of the value itself.

This mainly serves to fix the issue associated with removing names from SeriesLists- now when you accidentally use a serieslist as a (say) duration, the invalid argument will be identified by name in the error.

@drcapulet 
