### PR TITLE
Remove unnecesarry escaping for names with dots

### DIFF
--- a/query/command_names_test.go
+++ b/query/command_names_test.go
@@ -31,6 +31,11 @@ func TestQueryNaming(t *testing.T) {
 	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("dc=east,env=staging")})
 	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series-special#characters", api.ParseTagSet("dc=east,env=staging")})
 
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"foo.bar.", api.ParseTagSet("qaz=foo1")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{".foo.bar", api.ParseTagSet("qaz=foo1")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"foo.2bar", api.ParseTagSet("qaz=foo1")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"_names423.with_.dots_and_und3rsc0r3s", api.ParseTagSet("qaz=foo1")})
+
 	fakeBackend := mocks.FakeTimeseriesStorageAPI{}
 	tests := []struct {
 		query        string
@@ -128,6 +133,22 @@ func TestQueryNaming(t *testing.T) {
 		{
 			query:    "series_1[`foo-bar` = 'qaz' and `foo-bar` match 'x' and `foo-bar` in ('a', 'b')] from 0 to 0",
 			expected: "series_1[(`foo-bar` = \"qaz\" and (`foo-bar` match \"x\" and `foo-bar` in (\"a\", \"b\")))]",
+		},
+		{
+			query:    "_names423.with_.dots_and_und3rsc0r3s from 0 to 0",
+			expected: "_names423.with_.dots_and_und3rsc0r3s",
+		},
+		{
+			query:    "`foo.bar.` from 0 to 0",
+			expected: "`foo.bar.`",
+		},
+		{
+			query:    "`.foo.bar` from 0 to 0",
+			expected: "`.foo.bar`",
+		},
+		{
+			query:    "`foo.2bar` from 0 to 0",
+			expected: "`foo.2bar`",
 		},
 	}
 	for _, test := range tests {

--- a/query/node.go
+++ b/query/node.go
@@ -114,7 +114,7 @@ type metricFetchExpression struct {
 	predicate  api.Predicate
 }
 
-var OrdinaryIdentifierRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
+var OrdinaryIdentifierRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*(\.[A-Za-z_][A-Za-z_0-9]*)*$`)
 
 func EscapeIdentifier(identifier string) string {
 	if !OrdinaryIdentifierRegex.MatchString(identifier) {

--- a/query/predicate.go
+++ b/query/predicate.go
@@ -16,20 +16,10 @@ package query
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/square/metrics/api"
 )
-
-var validNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z_0-9]*$`)
-
-func escapeName(name string) string {
-	if validNameRegexp.MatchString(name) {
-		return name
-	}
-	return fmt.Sprintf("`%s`", name)
-}
 
 func (matcher *andPredicate) Apply(tagSet api.TagSet) bool {
 	for _, subPredicate := range matcher.predicates {
@@ -104,13 +94,13 @@ func (matcher *listMatcher) Apply(tagSet api.TagSet) bool {
 }
 func (matcher *listMatcher) Query() string {
 	if len(matcher.values) == 1 {
-		return fmt.Sprintf("%s = %q", escapeName(matcher.tag), matcher.values[0])
+		return fmt.Sprintf("%s = %q", EscapeIdentifier(matcher.tag), matcher.values[0])
 	}
 	quotedValues := make([]string, len(matcher.values))
 	for i, value := range matcher.values {
 		quotedValues[i] = fmt.Sprintf("%q", value)
 	}
-	return fmt.Sprintf("%s in (%s)", escapeName(matcher.tag), strings.Join(quotedValues, ", "))
+	return fmt.Sprintf("%s in (%s)", EscapeIdentifier(matcher.tag), strings.Join(quotedValues, ", "))
 }
 
 func (matcher *regexMatcher) Apply(tagSet api.TagSet) bool {
@@ -120,7 +110,7 @@ func (matcher *regexMatcher) Apply(tagSet api.TagSet) bool {
 	return matcher.regex.MatchString(tagSet[matcher.tag])
 }
 func (matcher *regexMatcher) Query() string {
-	return fmt.Sprintf("%s match %q", escapeName(matcher.tag), matcher.regex.String())
+	return fmt.Sprintf("%s match %q", EscapeIdentifier(matcher.tag), matcher.regex.String())
 }
 
 func matchPrecondition(matcherTag string, tagSet api.TagSet) bool {


### PR DESCRIPTION
A recent change which allowed the query labels to correctly escape their contents was overzealous. In particulae, `foo.bar` would always be escaped because of the `.`, even though this is a legal identifier.

This PR updates the identifier regex used in escaping to reflect this, and updates the tests to correct this oversight.

@drcapulet 