### PR TITLE
Add 'tolerate' feature to autocom

### DIFF
--- a/main/static/script.js
+++ b/main/static/script.js
@@ -226,14 +226,18 @@ module.run(function($http) {
     if (data.body.functions) {
       autocom.options = autocom.options.concat( data.body.functions );
     }
+    var tolerate = [];
     if (data.body.metrics) {
       autocom.options = autocom.options.concat( data.body.metrics.map(function(name) {
         if (name.indexOf("-") >= 0) {
           return "`" + name + "`";
+        } else {
+          tolerate.push("`" + name + "`");
         }
         return name;
       }));
     }
+    autocom.tolerate = tolerate;
   });
 });
 
@@ -635,4 +639,3 @@ function makeLabel(onlySingleSeries, serieslist, series) {
 function hasProfiling(data) {
   return data && data.profile;
 }
-


### PR DESCRIPTION
If a user has something like
```
    `cpu.percent`^
```
where the `^` is the cursor, and press enter they get

```
    cpu.percent^
```

instead of what they (probably) expect,

```
    `cpu.percent`
    ^
```

This PR fixes this issue.

In addition, it offers a slight performance improvement when there's a large number of options, by calling the autocompletion function about 3x less.

@drcapulet 

(Tested locally)