### PR TITLE
Converter API Change

### DIFF
--- a/api/converter.go
+++ b/api/converter.go
@@ -18,8 +18,8 @@ package api
 // Allowing it to act on arbitrary byte sequences gives a client greater freedom in representing their
 // metric names.
 type MetricConverter interface {
-	ToTagged([]byte) (TaggedMetric, error)
-	ToUntagged(TaggedMetric) ([]byte, error)
+	ToTagged(string) (TaggedMetric, error)
+	ToUntagged(TaggedMetric) (string, error)
 }
 
 /*

--- a/api/converter.go
+++ b/api/converter.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// MetricConverter is an interface that converts metrics from a slice of bytes into a TaggedMetric form.
+// Allowing it to act on arbitrary byte sequences gives a client greater freedom in representing their
+// metric names.
+type MetricConverter interface {
+	ToTagged([]byte) (TaggedMetric, error)
+	ToUntagged(TaggedMetric) ([]byte, error)
+}
+
+/*
+Some notes:
+Having an abstract representation for conversion would be a good idea, since in practice it would be helpful
+to be able to easily switch to an alternate converter.
+
+But where exactly is it being used? We have TimeseriesStorageAPI for example:
+Blueflood needs a GraphiteConverter to know what it's doing with the Tagged metrics.
+Maybe it should be given pre-converted values instead?
+
+This would simplify the logic that Blueflood has to do, making its design a LOT more orthogonal to everything else.
+*/

--- a/api/converter.go
+++ b/api/converter.go
@@ -21,15 +21,3 @@ type MetricConverter interface {
 	ToTagged(string) (TaggedMetric, error)
 	ToUntagged(TaggedMetric) (string, error)
 }
-
-/*
-Some notes:
-Having an abstract representation for conversion would be a good idea, since in practice it would be helpful
-to be able to easily switch to an alternate converter.
-
-But where exactly is it being used? We have TimeseriesStorageAPI for example:
-Blueflood needs a GraphiteConverter to know what it's doing with the Tagged metrics.
-Maybe it should be given pre-converted values instead?
-
-This would simplify the logic that Blueflood has to do, making its design a LOT more orthogonal to everything else.
-*/

--- a/api/metric_metadata_api.go
+++ b/api/metric_metadata_api.go
@@ -25,13 +25,16 @@ type MetricMetadataAPIContext struct {
 	Profiler *inspect.Profiler
 }
 
-type MetricMetadataAPI interface {
+type MetricMetadataModifier interface {
 	// AddMetric adds the metric to the system.
 	AddMetric(metric TaggedMetric, context MetricMetadataAPIContext) error
 	// Bulk metrics addition
 	AddMetrics(metric []TaggedMetric, context MetricMetadataAPIContext) error
 	// RemoveMetric removes the metric from the system.
 	RemoveMetric(metric TaggedMetric, context MetricMetadataAPIContext) error
+}
+
+type MetricMetadataAPI interface {
 	// For a given MetricKey, retrieve all the tagsets associated with it.
 	GetAllTags(metricKey MetricKey, context MetricMetadataAPIContext) ([]TagSet, error)
 	// GetAllMetrics returns all metrics managed by the system.
@@ -39,4 +42,9 @@ type MetricMetadataAPI interface {
 	// For a given tag key-value pair, obtain the list of all the MetricKeys
 	// associated with them.
 	GetMetricsForTag(tagKey, tagValue string, context MetricMetadataAPIContext) ([]MetricKey, error)
+}
+
+type MetricMetadataInterface interface {
+	MetricMetadataModifier
+	MetricMetadataAPI
 }

--- a/api/metric_metadata_api.go
+++ b/api/metric_metadata_api.go
@@ -22,7 +22,8 @@ package api
 import "github.com/square/metrics/inspect"
 
 type MetricMetadataAPIContext struct {
-	Profiler *inspect.Profiler
+	Profiler        *inspect.Profiler
+	EvaluationNotes *inspect.EvaluationNotes
 }
 
 type MetricMetadataModifier interface {

--- a/api/timerange.go
+++ b/api/timerange.go
@@ -164,3 +164,7 @@ func (tr Timerange) ExtendBefore(length time.Duration) Timerange {
 func (tr Timerange) Slots() int {
 	return int((tr.end-tr.start)/tr.resolution) + 1
 }
+
+func (tr Timerange) Index(t time.Time) int {
+	return int(t.Sub(tr.StartTime()) / tr.Resolution())
+}

--- a/api/timeseries.go
+++ b/api/timeseries.go
@@ -21,7 +21,6 @@ package api
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -33,7 +32,6 @@ import (
 type Timeseries struct {
 	Values []float64
 	TagSet TagSet
-	Raw    [][]byte
 }
 
 // MarshalJSON exists to manually encode floats.
@@ -48,27 +46,6 @@ func (ts Timeseries) MarshalJSON() ([]byte, error) {
 	}
 	buffer.Write(tagset)
 	buffer.WriteByte(',')
-
-	if ts.Raw != nil {
-		buffer.WriteString("\"raw\":")
-		buffer.WriteByte('[')
-		first := true
-		for _, raw := range ts.Raw {
-			if !first {
-				buffer.WriteByte(',')
-			}
-			buffer.WriteByte('[')
-			buffer.WriteByte('"')
-			base64Wrapped := base64.StdEncoding.EncodeToString(raw)
-			buffer.WriteString(base64Wrapped)
-			buffer.WriteByte('"')
-			buffer.WriteByte(']')
-			first = false
-		}
-		// raw, _ := json.Marshal(ts.Raw)
-		buffer.WriteByte(']')
-		buffer.WriteByte(',')
-	}
 
 	// buffer.WriteByte(',')
 	buffer.WriteString("\"values\":")

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -28,7 +28,7 @@ type TimeseriesStorageAPI interface {
 }
 
 type FetchTimeseriesRequest struct {
-	Metric                []byte       // metric to fetch.
+	Metric                string       // metric to fetch.
 	SampleMethod          SampleMethod // up/downsampling behavior.
 	Timerange             Timerange    // time range to fetch data from.
 	Cancellable           Cancellable
@@ -37,7 +37,7 @@ type FetchTimeseriesRequest struct {
 }
 
 type FetchMultipleTimeseriesRequest struct {
-	Metrics               [][]byte
+	Metrics               []string
 	SampleMethod          SampleMethod
 	Timerange             Timerange
 	Cancellable           Cancellable
@@ -60,7 +60,7 @@ const (
 )
 
 type TimeseriesStorageError struct {
-	Metric  []byte
+	Metric  string
 	Code    TimeseriesStorageErrorCode
 	Message string
 }

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -66,20 +66,20 @@ type TimeseriesStorageError struct {
 }
 
 func (err TimeseriesStorageError) Error() string {
-	message := "[%s %+v] unknown error"
+	message := "unknown error"
 	switch err.Code {
 	case FetchTimeoutError:
-		message = "[%s %+v] timeout"
+		message = "timeout"
 	case InvalidSeriesError:
-		message = "[%s %+v] invalid series"
+		message = "invalid series"
 	case LimitError:
-		message = "[%s %+v] limit reached"
+		message = "limit reached"
 	case Unsupported:
-		message = "[%s %+v] unsupported operation"
+		message = "unsupported operation"
 	}
-	formatted := fmt.Sprintf(message, string(err.Metric))
+	formatted := fmt.Sprintf("metric [%s] %s", string(err.Metric), message)
 	if err.Message != "" {
-		formatted = formatted + " - " + err.Message
+		formatted += " - " + err.Message
 	}
 	return formatted
 }

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -33,6 +33,7 @@ type FetchTimeseriesRequest struct {
 	Timerange             Timerange    // time range to fetch data from.
 	Cancellable           Cancellable
 	Profiler              *inspect.Profiler
+	EvaluationNotes       *inspect.EvaluationNotes
 	UserSpecifiableConfig UserSpecifiableConfig
 }
 
@@ -42,6 +43,7 @@ type FetchMultipleTimeseriesRequest struct {
 	Timerange             Timerange
 	Cancellable           Cancellable
 	Profiler              *inspect.Profiler
+	EvaluationNotes       *inspect.EvaluationNotes
 	UserSpecifiableConfig UserSpecifiableConfig
 }
 
@@ -99,6 +101,7 @@ func (r FetchMultipleTimeseriesRequest) ToSingle() []FetchTimeseriesRequest {
 			SampleMethod:          r.SampleMethod,
 			Timerange:             r.Timerange,
 			Profiler:              r.Profiler,
+			EvaluationNotes:       r.EvaluationNotes,
 			UserSpecifiableConfig: r.UserSpecifiableConfig,
 		}
 	}

--- a/api/timeseries_storage_api.go
+++ b/api/timeseries_storage_api.go
@@ -23,12 +23,12 @@ import (
 
 type TimeseriesStorageAPI interface {
 	ChooseResolution(requested Timerange, smallestResolution time.Duration) time.Duration
-	FetchSingleTimeseries(request FetchTimeseriesRequest) (Timeseries, error)
-	FetchMultipleTimeseries(request FetchMultipleTimeseriesRequest) (SeriesList, error)
+	FetchSingleTimeseries(request FetchTimeseriesRequest) ([]float64, error)
+	FetchMultipleTimeseries(request FetchMultipleTimeseriesRequest) ([][]float64, error)
 }
 
 type FetchTimeseriesRequest struct {
-	Metric                TaggedMetric // metric to fetch.
+	Metric                []byte       // metric to fetch.
 	SampleMethod          SampleMethod // up/downsampling behavior.
 	Timerange             Timerange    // time range to fetch data from.
 	Cancellable           Cancellable
@@ -37,7 +37,7 @@ type FetchTimeseriesRequest struct {
 }
 
 type FetchMultipleTimeseriesRequest struct {
-	Metrics               []TaggedMetric
+	Metrics               [][]byte
 	SampleMethod          SampleMethod
 	Timerange             Timerange
 	Cancellable           Cancellable
@@ -60,7 +60,7 @@ const (
 )
 
 type TimeseriesStorageError struct {
-	Metric  TaggedMetric
+	Metric  []byte
 	Code    TimeseriesStorageErrorCode
 	Message string
 }
@@ -77,7 +77,7 @@ func (err TimeseriesStorageError) Error() string {
 	case Unsupported:
 		message = "[%s %+v] unsupported operation"
 	}
-	formatted := fmt.Sprintf(message, string(err.Metric.MetricKey), err.Metric.TagSet)
+	formatted := fmt.Sprintf(message, string(err.Metric))
 	if err.Message != "" {
 		formatted = formatted + " - " + err.Message
 	}
@@ -85,7 +85,7 @@ func (err TimeseriesStorageError) Error() string {
 }
 
 func (err TimeseriesStorageError) TokenName() string {
-	return string(err.Metric.MetricKey)
+	return string(err.Metric)
 }
 
 // ToSingle very simply decompose the FetchMultipleTimeseriesRequest into single

--- a/api/types.go
+++ b/api/types.go
@@ -32,6 +32,6 @@ type TaggedMetric struct {
 	TagSet    TagSet
 }
 
-func (t *TaggedMetric) String() string {
+func (t TaggedMetric) String() string {
 	return fmt.Sprintf("%+v [%s]\n", t.MetricKey, t.TagSet.Serialize())
 }

--- a/convert/graphite_pattern/errors.go
+++ b/convert/graphite_pattern/errors.go
@@ -1,4 +1,4 @@
-package util
+package graphite_pattern
 
 // List of errors returnd by the application
 

--- a/convert/graphite_pattern/regex_converter.go
+++ b/convert/graphite_pattern/regex_converter.go
@@ -17,7 +17,7 @@
 // https://docs.google.com/a/squareup.com/document/d/1k0Wgi2wnJPQoyDyReb9dyIqRrD8-v0u8hz37S282ii4/edit
 // for the terminology.
 
-package util
+package graphite_pattern
 
 import (
 	"fmt"
@@ -30,14 +30,16 @@ import (
 	"github.com/square/metrics/log"
 )
 
-// GraphiteMetric is a flat, dot-separated identifier to a series of metric.
-type GraphiteMetric string
-
-type GraphiteConverterConfig struct {
-	ConversionRulesPath string `yaml:"conversion_rules_path"`
+func NewConverter(conversionRulesPath string) (api.MetricConverter, error) {
+	ruleset, err := LoadRules(conversionRulesPath)
+	if err != nil {
+		return nil, err
+	}
+	return &RuleBasedGraphiteConverter{ruleset}, nil
 }
 
-// var _ GraphiteConverter = (*RuleBasedGraphiteConverter)(nil) // TODO: reeavluate this
+// GraphiteMetric is a flat, dot-separated identifier to a series of metric.
+type GraphiteMetric string
 
 type RuleBasedGraphiteConverter struct {
 	Ruleset RuleSet
@@ -97,13 +99,4 @@ func LoadRules(conversionRulesPath string) (RuleSet, error) {
 	}
 
 	return ruleSet, nil
-}
-
-type GraphiteConverter interface {
-	// Convert the given tag-based metric name to graphite metric name,
-	// using the configured rules. May error out.
-	ToGraphiteName(metric api.TaggedMetric) (GraphiteMetric, error)
-	// Converts the given graphite metric to the tag-based meric,
-	// using the configured rules. May error out.
-	ToTaggedName(metric GraphiteMetric) (api.TaggedMetric, error)
 }

--- a/convert/graphite_pattern/regex_converter.go
+++ b/convert/graphite_pattern/regex_converter.go
@@ -38,9 +38,6 @@ func NewConverter(conversionRulesPath string) (api.MetricConverter, error) {
 	return &RuleBasedGraphiteConverter{ruleset}, nil
 }
 
-// GraphiteMetric is a flat, dot-separated identifier to a series of metric.
-type GraphiteMetric string
-
 type RuleBasedGraphiteConverter struct {
 	Ruleset RuleSet
 }

--- a/convert/graphite_pattern/rules.go
+++ b/convert/graphite_pattern/rules.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package graphite_pattern
 
 import (
 	"bytes"

--- a/convert/graphite_pattern/rules_test.go
+++ b/convert/graphite_pattern/rules_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package graphite_pattern
 
 import (
 	"testing"

--- a/demo/ingest/ingest.go
+++ b/demo/ingest/ingest.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/square/metrics/api"
+	"github.com/square/metrics/convert/graphite_pattern"
 	"github.com/square/metrics/metric_metadata/cassandra"
-	"github.com/square/metrics/util"
 )
 
 // rulePath specifies the directory to look for the conversion rule files *.yaml
@@ -43,13 +43,13 @@ func main() {
 		flag.Usage()
 		return
 	}
-	rules, err := util.LoadRules(*rulePath)
+	rules, err := graphite_pattern.LoadRules(*rulePath)
 	if err != nil {
 		fmt.Printf("Error loading rules; %+v", err.Error())
 		return
 	}
 
-	converter := util.RuleBasedGraphiteConverter{Ruleset: rules}
+	converter := graphite_pattern.RuleBasedGraphiteConverter{Ruleset: rules}
 
 	cassandra, err := cassandra.NewCassandraMetricMetadataAPI(cassandra.Config{
 		Hosts:    []string{*cassandraHost}, // using the default port

--- a/demo/ingest/ingest.go
+++ b/demo/ingest/ingest.go
@@ -87,10 +87,10 @@ func main() {
 		}
 
 		// Split the body into lines, and trim whitespace for each metric.
-		metrics := []util.GraphiteMetric{}
+		metrics := []string{}
 		for _, metric := range strings.Split(string(bytes), "\n") {
 			if metric := strings.TrimSpace(metric); metric != "" {
-				metrics = append(metrics, util.GraphiteMetric(metric))
+				metrics = append(metrics, metric)
 			}
 		}
 
@@ -106,7 +106,7 @@ func main() {
 
 		for _, metric := range metrics {
 			// If conversion fails because no rule is applicable, then err will be non-nil.
-			result, err := converter.ToTaggedName(metric)
+			result, err := converter.ToTagged(metric)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(fmt.Sprintf("Error converting metric `%s`; %s\n", metric, err.Error())))

--- a/demo/ingest/ingest.go
+++ b/demo/ingest/ingest.go
@@ -51,7 +51,7 @@ func main() {
 
 	converter := graphite_pattern.RuleBasedGraphiteConverter{Ruleset: rules}
 
-	cassandra, err := cassandra.NewCassandraMetricMetadataAPI(cassandra.Config{
+	cassandra, err := cassandra.NewMetricMetadataInterface(cassandra.Config{
 		Hosts:    []string{*cassandraHost}, // using the default port
 		Keyspace: "metrics_indexer",        // from schema in github.com/square/metrics/schema
 	})

--- a/function/expression.go
+++ b/function/expression.go
@@ -66,6 +66,29 @@ func (e EvaluationContext) WithTimerange(t api.Timerange) EvaluationContext {
 	return e
 }
 
+func (e EvaluationContext) FetchSingleMetric(metric string) api.FetchTimeseriesRequest {
+	return api.FetchTimeseriesRequest{
+		Metric:                metric,
+		SampleMethod:          e.SampleMethod,
+		Timerange:             e.Timerange,
+		Cancellable:           e.Cancellable,
+		Profiler:              e.Profiler,
+		EvaluationNotes:       e.EvaluationNotes,
+		UserSpecifiableConfig: e.UserSpecifiableConfig,
+	}
+}
+func (e EvaluationContext) FetchMultipleRequest(metrics []string) api.FetchMultipleTimeseriesRequest {
+	return api.FetchMultipleTimeseriesRequest{
+		Metrics:               metrics,
+		SampleMethod:          e.SampleMethod,
+		Timerange:             e.Timerange,
+		Cancellable:           e.Cancellable,
+		Profiler:              e.Profiler,
+		EvaluationNotes:       e.EvaluationNotes,
+		UserSpecifiableConfig: e.UserSpecifiableConfig,
+	}
+}
+
 // Evaluate the given metric function.
 func (f MetricFunction) Evaluate(context EvaluationContext,
 	arguments []Expression, groupBy []string, collapses bool) (Value, error) {

--- a/function/expression.go
+++ b/function/expression.go
@@ -21,6 +21,7 @@ import (
 type EvaluationContext struct {
 	TimeseriesStorageAPI      api.TimeseriesStorageAPI // Backend to fetch data from
 	MetricMetadataAPI         api.MetricMetadataAPI    // Api to obtain metadata from
+	MetricConverter           api.MetricConverter      // API to convert metrics
 	Timerange                 api.Timerange            // Timerange to fetch data from
 	SampleMethod              api.SampleMethod         // SampleMethod to use when up/downsampling to match the requested resolution
 	Predicate                 api.Predicate            // Predicate to apply to TagSets prior to fetching

--- a/function/expression.go
+++ b/function/expression.go
@@ -2,7 +2,6 @@ package function
 
 import (
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,32 +27,10 @@ type EvaluationContext struct {
 	FetchLimit                FetchCounter             // A limit on the number of fetches which may be performed
 	Cancellable               api.Cancellable
 	Registry                  Registry
-	Profiler                  *inspect.Profiler // A profiler pointer
+	Profiler                  *inspect.Profiler        // A profiler pointer
+	EvaluationNotes           *inspect.EvaluationNotes //Debug + numerical notes that can be added during evaluation
 	OptimizationConfiguration *optimize.OptimizationConfiguration
-	EvaluationNotes           *EvaluationNotes //Debug + numerical notes that can be added during evaluation
 	UserSpecifiableConfig     api.UserSpecifiableConfig
-}
-
-type EvaluationNotes struct {
-	mutex sync.Mutex
-	notes []string
-}
-
-func (notes *EvaluationNotes) AddNote(note string) {
-	if notes == nil {
-		return
-	}
-	notes.mutex.Lock()
-	defer notes.mutex.Unlock()
-	notes.notes = append(notes.notes, note)
-}
-func (notes *EvaluationNotes) Notes() []string {
-	if notes == nil {
-		return nil
-	}
-	notes.mutex.Lock()
-	defer notes.mutex.Unlock()
-	return notes.notes
 }
 
 type Registry interface {

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -79,7 +79,6 @@ var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
 		for seriesIndex, series := range seriesList.Series {
 			result.Series[seriesIndex] = api.Timeseries{
 				TagSet: series.TagSet,
-				Raw:    series.Raw,
 				Values: RollingMultiplicativeHoltWinters(series.Values, samples, levelLearningRate, trendLearningRate, seasonalLearningRate)[extraSlots:], // Slice to drop the first few extra slots from the result
 			}
 		}
@@ -135,7 +134,6 @@ var FunctionRollingSeasonal = function.MetricFunction{
 		for seriesIndex, series := range seriesList.Series {
 			result.Series[seriesIndex] = api.Timeseries{
 				TagSet: series.TagSet,
-				Raw:    series.Raw,
 				Values: RollingSeasonal(series.Values, samples, seasonalLearningRate)[extraSlots:], // Slice to drop the first few extra slots from the result
 			}
 		}
@@ -179,7 +177,6 @@ var FunctionForecastLinear = function.MetricFunction{
 		for seriesIndex, series := range seriesList.Series {
 			result.Series[seriesIndex] = api.Timeseries{
 				TagSet: series.TagSet,
-				Raw:    series.Raw,
 				Values: ForecastLinear(series.Values)[extraSlots:], // Slice to drop the first few extra slots from the result
 			}
 		}

--- a/function/transform/transformation_test.go
+++ b/function/transform/transformation_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
+	"github.com/square/metrics/inspect"
 	"github.com/square/metrics/testing_support/assert"
 )
 
@@ -267,7 +268,7 @@ func TestApplyNotes(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ctx := function.EvaluationContext{EvaluationNotes: new(function.EvaluationNotes)}
+		ctx := function.EvaluationContext{EvaluationNotes: &inspect.EvaluationNotes{}}
 		_, err := ApplyTransform(ctx, list, test.transform, test.parameter)
 		if err != nil {
 			t.Error(err)

--- a/inspect/evaluation_notes.go
+++ b/inspect/evaluation_notes.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect
+
+import "sync"
+
+// EvaluationNotes stores a list of notes from the evaluation.
+type EvaluationNotes struct {
+	mutex sync.Mutex
+	notes []string
+}
+
+func (notes *EvaluationNotes) AddNote(note string) {
+	if notes == nil {
+		return
+	}
+	notes.mutex.Lock()
+	defer notes.mutex.Unlock()
+	notes.notes = append(notes.notes, note)
+}
+func (notes *EvaluationNotes) Notes() []string {
+	if notes == nil {
+		return nil
+	}
+	notes.mutex.Lock()
+	defer notes.mutex.Unlock()
+	return notes.notes
+}

--- a/main/common/common.go
+++ b/main/common/common.go
@@ -82,7 +82,7 @@ func ExitWithMessage(message string) {
 
 // NewMetricMetadataAPI creates a new instance of the API.
 func NewMetricMetadataAPI(config cassandra.Config) api.MetricMetadataAPI {
-	apiInstance, err := cassandra.NewCassandraMetricMetadataAPI(config)
+	apiInstance, err := cassandra.NewMetricMetadataInterface(config)
 	if err != nil {
 		ExitWithMessage(fmt.Sprintf("Cannot instantiate a new API from %#v: %s\n", config, err.Error()))
 	}

--- a/main/query/query.go
+++ b/main/query/query.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 
 	"github.com/peterh/liner"
+	"github.com/square/metrics/convert/graphite_pattern"
 	"github.com/square/metrics/main/common"
 	"github.com/square/metrics/query"
 	"github.com/square/metrics/timeseries_storage/blueflood"
-	"github.com/square/metrics/util"
 )
 
 func main() {
@@ -34,11 +34,11 @@ func main() {
 
 	apiInstance := common.NewMetricMetadataAPI(config.Cassandra)
 
-	ruleset, err := util.LoadRules(config.ConversionRulesPath)
+	ruleset, err := graphite_pattern.LoadRules(config.ConversionRulesPath)
 	if err != nil {
 		//Blah
 	}
-	graphite := &util.RuleBasedGraphiteConverter{Ruleset: ruleset}
+	graphite := &graphite_pattern.RuleBasedGraphiteConverter{Ruleset: ruleset}
 
 	blueflood := blueflood.NewBlueflood(config.Blueflood)
 

--- a/main/query/query.go
+++ b/main/query/query.go
@@ -38,8 +38,7 @@ func main() {
 	if err != nil {
 		//Blah
 	}
-	graphite := util.RuleBasedGraphiteConverter{Ruleset: ruleset}
-	config.Blueflood.GraphiteMetricConverter = &graphite
+	graphite := &util.RuleBasedGraphiteConverter{Ruleset: ruleset}
 
 	blueflood := blueflood.NewBlueflood(config.Blueflood)
 
@@ -66,7 +65,12 @@ func main() {
 		}
 		fmt.Println(query.PrintNode(n))
 
-		result, err := cmd.Execute(query.ExecutionContext{TimeseriesStorageAPI: blueflood, MetricMetadataAPI: apiInstance, FetchLimit: 1000})
+		result, err := cmd.Execute(query.ExecutionContext{
+			MetricConverter:      graphite,
+			TimeseriesStorageAPI: blueflood,
+			MetricMetadataAPI:    apiInstance,
+			FetchLimit:           1000,
+		})
 		if err != nil {
 			fmt.Println("execution error:", err.Error())
 			continue

--- a/main/ruletester/ruletester.go
+++ b/main/ruletester/ruletester.go
@@ -131,12 +131,12 @@ const (
 )
 
 func ClassifyMetric(metric string, graphiteConverter util.RuleBasedGraphiteConverter) ConversionStatus {
-	graphiteMetric := util.GraphiteMetric(metric)
-	taggedMetric, err := graphiteConverter.ToTaggedName(graphiteMetric)
+	graphiteMetric := metric
+	taggedMetric, err := graphiteConverter.ToTagged(graphiteMetric)
 	if err != nil {
 		return Unmatched
 	}
-	reversedMetric, err := graphiteConverter.ToGraphiteName(taggedMetric)
+	reversedMetric, err := graphiteConverter.ToUntagged(taggedMetric)
 	if err != nil {
 		return ReverseFailed
 	}

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -75,8 +75,7 @@ func main() {
 		fmt.Printf("Error loading conversion rules: %s", err.Error())
 		return
 	}
-
-	config.Blueflood.GraphiteMetricConverter = &util.RuleBasedGraphiteConverter{Ruleset: ruleset}
+	graphite := &util.RuleBasedGraphiteConverter{Ruleset: ruleset}
 
 	blueflood := blueflood.NewBlueflood(config.Blueflood)
 
@@ -89,6 +88,7 @@ func main() {
 	}
 
 	startServer(config.UI, query.ExecutionContext{
+		MetricConverter:           graphite,
 		MetricMetadataAPI:         apiInstance,
 		TimeseriesStorageAPI:      blueflood,
 		FetchLimit:                1500,

--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/square/metrics/convert/graphite_pattern"
 	"github.com/square/metrics/log"
 
 	"github.com/square/metrics/api"
@@ -33,7 +34,6 @@ import (
 	"github.com/square/metrics/query"
 	"github.com/square/metrics/timeseries_storage/blueflood"
 	"github.com/square/metrics/ui"
-	"github.com/square/metrics/util"
 )
 
 func startServer(config ui.Config, context query.ExecutionContext) {
@@ -70,12 +70,12 @@ func main() {
 
 	apiInstance := common.NewMetricMetadataAPI(config.Cassandra)
 
-	ruleset, err := util.LoadRules(config.ConversionRulesPath)
+	ruleset, err := graphite_pattern.LoadRules(config.ConversionRulesPath)
 	if err != nil {
 		fmt.Printf("Error loading conversion rules: %s", err.Error())
 		return
 	}
-	graphite := &util.RuleBasedGraphiteConverter{Ruleset: ruleset}
+	graphite := &graphite_pattern.RuleBasedGraphiteConverter{Ruleset: ruleset}
 
 	blueflood := blueflood.NewBlueflood(config.Blueflood)
 

--- a/metric_metadata/cassandra/cassandra.go
+++ b/metric_metadata/cassandra/cassandra.go
@@ -25,7 +25,7 @@ type CassandraMetricMetadataAPI struct {
 	db cassandraDatabase
 }
 
-var _ api.MetricMetadataAPI = (*CassandraMetricMetadataAPI)(nil)
+var _ api.MetricMetadataInterface = (*CassandraMetricMetadataAPI)(nil)
 
 type Config struct {
 	Hosts    []string `yaml:"hosts"`
@@ -33,7 +33,7 @@ type Config struct {
 }
 
 // NewCassandraMetricMetadataAPI creates a new instance of API from the given configuration.
-func NewCassandraMetricMetadataAPI(config Config) (api.MetricMetadataAPI, error) {
+func NewMetricMetadataInterface(config Config) (api.MetricMetadataInterface, error) {
 	clusterConfig := gocql.NewCluster()
 	clusterConfig.Consistency = gocql.One
 	clusterConfig.Hosts = config.Hosts

--- a/metric_metadata/cassandra/cassandra_api_test.go
+++ b/metric_metadata/cassandra/cassandra_api_test.go
@@ -30,7 +30,7 @@ func newCassandraAPI(t *testing.T) (*CassandraMetricMetadataAPI, api.MetricMetad
 		t.Fatalf("Attempted to create new database without cleaning up the old one.")
 	}
 	cassandraClean = false
-	cassandraInterface, err := NewCassandraMetricMetadataAPI(Config{
+	cassandraInterface, err := NewMetricMetadataInterface(Config{
 		Hosts:    []string{"localhost"},
 		Keyspace: "metrics_indexer_test",
 	})

--- a/metric_metadata/metadata_map/map.go
+++ b/metric_metadata/metadata_map/map.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeseries_map

--- a/metric_metadata/metadata_map/map.go
+++ b/metric_metadata/metadata_map/map.go
@@ -12,4 +12,86 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package timeseries_map
+package metadata_map
+
+import (
+	"sync"
+
+	"github.com/square/metrics/api"
+)
+
+type MetadataMap struct {
+	Mutex         sync.Mutex
+	TagsOfMetric  map[api.MetricKey][]api.TagSet
+	AllMetrics    []api.MetricKey
+	MetricsForTag map[string]map[string][]api.MetricKey
+}
+
+func NewMetadataMap() api.MetricMetadataInterface {
+	return &MetadataMap{
+		TagsOfMetric:  map[api.MetricKey][]api.TagSet{},
+		MetricsForTag: map[string]map[string][]api.MetricKey{},
+	}
+}
+
+func addUniqueMetricKey(keys []api.MetricKey, newKey api.MetricKey) []api.MetricKey {
+	for _, key := range keys {
+		if key == newKey {
+			return keys
+		}
+	}
+	return append(keys, newKey)
+}
+func addUniqueTagSet(tagsets []api.TagSet, newTagset api.TagSet) []api.TagSet {
+	for _, tagset := range tagsets {
+		if tagset.Equals(newTagset) {
+			return tagsets
+		}
+	}
+	return append(tagsets, newTagset)
+}
+
+func (m *MetadataMap) AddMetric(metric api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	defer context.Profiler.Record("MetadataMap AddMetric")()
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
+	m.TagsOfMetric[metric.MetricKey] = addUniqueTagSet(m.TagsOfMetric[metric.MetricKey], metric.TagSet)
+	m.AllMetrics = addUniqueMetricKey(m.AllMetrics, metric.MetricKey)
+	for key, value := range metric.TagSet {
+		if m.MetricsForTag[key] == nil {
+			m.MetricsForTag[key] = map[string][]api.MetricKey{}
+		}
+		m.MetricsForTag[key][value] = addUniqueMetricKey(m.MetricsForTag[key][value], metric.MetricKey)
+	}
+	return nil
+}
+
+func (m *MetadataMap) AddMetrics(metrics []api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	for _, metric := range metrics {
+		err := m.AddMetric(metric, context)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MetadataMap) RemoveMetric(metric api.TaggedMetric, context api.MetricMetadataAPIContext) error {
+	// TODO: implement this
+	return nil
+}
+
+func (m *MetadataMap) GetAllTags(metricKey api.MetricKey, context api.MetricMetadataAPIContext) ([]api.TagSet, error) {
+	return append([]api.TagSet{}, m.TagsOfMetric[metricKey]...), nil
+}
+
+func (m *MetadataMap) GetAllMetrics(context api.MetricMetadataAPIContext) ([]api.MetricKey, error) {
+	return append([]api.MetricKey{}, m.AllMetrics...), nil
+}
+
+func (m *MetadataMap) GetMetricsForTag(tagKey, tagValue string, context api.MetricMetadataAPIContext) ([]api.MetricKey, error) {
+	if lookup := m.MetricsForTag[tagKey]; lookup != nil {
+		return append([]api.MetricKey{}, lookup[tagValue]...), nil
+	}
+	return nil, nil
+}

--- a/query/command.go
+++ b/query/command.go
@@ -29,8 +29,9 @@ import (
 
 // ExecutionContext is the context supplied when invoking a command.
 type ExecutionContext struct {
+	MetricConverter           api.MetricConverter                 // the metric converter
 	TimeseriesStorageAPI      api.TimeseriesStorageAPI            // the backend
-	MetricMetadataAPI         api.MetricMetadataAPI               // the api
+	MetricMetadataAPI         api.MetricMetadataAPI               // the metadata api
 	FetchLimit                int                                 // the maximum number of fetches
 	Timeout                   time.Duration                       // optional
 	Registry                  function.Registry                   // optional
@@ -225,7 +226,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 		MetricMetadataAPI:         context.MetricMetadataAPI,
 		FetchLimit:                function.NewFetchCounter(context.FetchLimit),
 		TimeseriesStorageAPI:      context.TimeseriesStorageAPI,
-		MetricConverter:           nil, // TODO: set this to something
+		MetricConverter:           context.MetricConverter,
 		Predicate:                 cmd.predicate,
 		SampleMethod:              cmd.context.SampleMethod,
 		Timerange:                 chosenTimerange,

--- a/query/command.go
+++ b/query/command.go
@@ -234,7 +234,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 		Registry:                  r,
 		Profiler:                  context.Profiler,
 		OptimizationConfiguration: context.OptimizationConfiguration,
-		EvaluationNotes:           new(function.EvaluationNotes),
+		EvaluationNotes:           &inspect.EvaluationNotes{},
 		UserSpecifiableConfig:     context.UserSpecifiableConfig,
 	}
 

--- a/query/command.go
+++ b/query/command.go
@@ -225,6 +225,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 		MetricMetadataAPI:         context.MetricMetadataAPI,
 		FetchLimit:                function.NewFetchCounter(context.FetchLimit),
 		TimeseriesStorageAPI:      context.TimeseriesStorageAPI,
+		MetricConverter:           nil, // TODO: set this to something
 		Predicate:                 cmd.predicate,
 		SampleMethod:              cmd.context.SampleMethod,
 		Timerange:                 chosenTimerange,

--- a/query/command_select_test.go
+++ b/query/command_select_test.go
@@ -513,7 +513,7 @@ func TestTag(t *testing.T) {
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),
 		})
 		if err != nil {
-			t.Errorf("Unexpected error while exucting query %q: %s", test.query, err.Error())
+			t.Errorf("Unexpected error while executing query %q: %s", test.query, err.Error())
 			continue
 		}
 		seriesListList, ok := rawResult.Body.([]QuerySeriesList)

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -26,10 +26,10 @@ import (
 
 func TestCommand_Describe(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=production,host=a")})
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=staging,host=b")})
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=production,host=c")})
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=staging,host=d")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=production,host=a")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=staging,host=b")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=production,host=c")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=staging,host=d")})
 
 	for _, test := range []struct {
 		query          string
@@ -71,10 +71,10 @@ func TestCommand_Describe(t *testing.T) {
 
 func TestCommand_DescribeAll(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("")})
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_1", api.ParseTagSet("")})
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_2", api.ParseTagSet("")})
-	fakeAPI.InsertMetric(api.TaggedMetric{"series_3", api.ParseTagSet("")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_0", api.ParseTagSet("")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_1", api.ParseTagSet("")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_2", api.ParseTagSet("")})
+	fakeAPI.MockMetric(api.TaggedMetric{"series_3", api.ParseTagSet("")})
 
 	for _, test := range []struct {
 		query          string

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -22,10 +22,7 @@ import (
 	"github.com/square/metrics/optimize"
 	"github.com/square/metrics/testing_support/assert"
 	"github.com/square/metrics/testing_support/mocks"
-	"github.com/square/metrics/util"
 )
-
-var emptyGraphiteName = util.GraphiteMetric("")
 
 func TestCommand_Describe(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
@@ -98,7 +95,6 @@ func TestCommand_DescribeAll(t *testing.T) {
 		a.EqString(command.Name(), "describe all")
 		fakeMulti := mocks.FakeTimeseriesStorageAPI{}
 		rawResult, err := command.Execute(ExecutionContext{
-			MetricConverter:           &mocks.FakeGraphiteConverter{},
 			TimeseriesStorageAPI:      fakeMulti,
 			MetricMetadataAPI:         test.metricmetadata,
 			FetchLimit:                1000,

--- a/query/command_test.go
+++ b/query/command_test.go
@@ -29,10 +29,10 @@ var emptyGraphiteName = util.GraphiteMetric("")
 
 func TestCommand_Describe(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=production,host=a")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=staging,host=b")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=production,host=c")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=staging,host=d")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=production,host=a")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=staging,host=b")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=production,host=c")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=staging,host=d")})
 
 	for _, test := range []struct {
 		query          string
@@ -60,6 +60,7 @@ func TestCommand_Describe(t *testing.T) {
 		a.EqString(command.Name(), "describe")
 		fakeTimeseriesStorage := mocks.FakeTimeseriesStorageAPI{}
 		rawResult, err := command.Execute(ExecutionContext{
+			MetricConverter:           &mocks.FakeGraphiteConverter{},
 			TimeseriesStorageAPI:      fakeTimeseriesStorage,
 			MetricMetadataAPI:         test.metricmetadata,
 			FetchLimit:                1000,
@@ -73,10 +74,10 @@ func TestCommand_Describe(t *testing.T) {
 
 func TestCommand_DescribeAll(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.ParseTagSet("")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_3", api.ParseTagSet("")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_0", api.ParseTagSet("")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_1", api.ParseTagSet("")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_2", api.ParseTagSet("")})
+	fakeAPI.InsertMetric(api.TaggedMetric{"series_3", api.ParseTagSet("")})
 
 	for _, test := range []struct {
 		query          string
@@ -97,6 +98,7 @@ func TestCommand_DescribeAll(t *testing.T) {
 		a.EqString(command.Name(), "describe all")
 		fakeMulti := mocks.FakeTimeseriesStorageAPI{}
 		rawResult, err := command.Execute(ExecutionContext{
+			MetricConverter:           &mocks.FakeGraphiteConverter{},
 			TimeseriesStorageAPI:      fakeMulti,
 			MetricMetadataAPI:         test.metricmetadata,
 			FetchLimit:                1000,

--- a/query/expression.go
+++ b/query/expression.go
@@ -80,12 +80,13 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 
 	valuelist, err := context.TimeseriesStorageAPI.FetchMultipleTimeseries(
 		api.FetchMultipleTimeseriesRequest{
-			metrics,
-			context.SampleMethod,
-			context.Timerange,
-			context.Cancellable,
-			context.Profiler,
-			context.UserSpecifiableConfig,
+			Metrics:               metrics,
+			SampleMethod:          context.SampleMethod,
+			Timerange:             context.Timerange,
+			Cancellable:           context.Cancellable,
+			Profiler:              context.Profiler,
+			EvaluationNotes:       context.EvaluationNotes,
+			UserSpecifiableConfig: context.UserSpecifiableConfig,
 		},
 	)
 	if err != nil {

--- a/query/expression.go
+++ b/query/expression.go
@@ -78,17 +78,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 		metrics[i] = metric
 	}
 
-	valuelist, err := context.TimeseriesStorageAPI.FetchMultipleTimeseries(
-		api.FetchMultipleTimeseriesRequest{
-			Metrics:               metrics,
-			SampleMethod:          context.SampleMethod,
-			Timerange:             context.Timerange,
-			Cancellable:           context.Cancellable,
-			Profiler:              context.Profiler,
-			EvaluationNotes:       context.EvaluationNotes,
-			UserSpecifiableConfig: context.UserSpecifiableConfig,
-		},
-	)
+	valuelist, err := context.TimeseriesStorageAPI.FetchMultipleTimeseries(context.FetchMultipleRequest(metrics))
 	if err != nil {
 		return nil, err
 	}

--- a/query/expression.go
+++ b/query/expression.go
@@ -91,12 +91,9 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 	if err != nil {
 		return nil, err
 	}
-	if len(valuelist) != len(filtered) {
-		return nil, fmt.Errorf("INTERNAL SERVER ERROR: Requested %d timeseries for metric %s, but got %d", len(filtered), expr.metricName, len(valuelist))
-	}
 
 	if len(valuelist) != len(filtered) {
-		return nil, fmt.Errorf("Internal Server Error - Attempted to fetch %d but received only %d (without any indicated error).", len(filtered), len(valuelist))
+		return nil, fmt.Errorf("Internal Server Error: Attempted to fetch %d time-series but received only %d (without any indicated error).", len(filtered), len(valuelist))
 	}
 
 	serieslist := api.SeriesList{

--- a/query/expression.go
+++ b/query/expression.go
@@ -68,7 +68,7 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 		return nil, err
 	}
 
-	metrics := make([][]byte, len(filtered))
+	metrics := make([]string, len(filtered))
 	for i := range metrics {
 		metric, err := context.MetricConverter.ToUntagged(api.TaggedMetric{api.MetricKey(expr.metricName), filtered[i]})
 		if err != nil {

--- a/query/expression.go
+++ b/query/expression.go
@@ -91,6 +91,9 @@ func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) 
 	if err != nil {
 		return nil, err
 	}
+	if len(valuelist) != len(filtered) {
+		return nil, fmt.Errorf("INTERNAL SERVER ERROR: Requested %d timeseries for metric %s, but got %d", len(filtered), expr.metricName, len(valuelist))
+	}
 
 	if len(valuelist) != len(filtered) {
 		return nil, fmt.Errorf("Internal Server Error - Attempted to fetch %d but received only %d (without any indicated error).", len(filtered), len(valuelist))

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -84,6 +84,7 @@ func Test_ScalarExpression(t *testing.T) {
 		a := assert.New(t).Contextf("%+v", test)
 		result, err := function.EvaluateToSeriesList(test.expr, function.EvaluationContext{
 			TimeseriesStorageAPI: FakeBackend{},
+			MetricConverter:      nil, // TODO: fill this with something
 			Timerange:            test.timerange,
 			SampleMethod:         api.SampleMean,
 			FetchLimit:           function.NewFetchCounter(1000),

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/square/metrics/function"
 	"github.com/square/metrics/function/registry"
 	"github.com/square/metrics/testing_support/assert"
-	"github.com/square/metrics/testing_support/mocks"
 )
 
 type FakeBackend struct {
@@ -85,7 +84,6 @@ func Test_ScalarExpression(t *testing.T) {
 		a := assert.New(t).Contextf("%+v", test)
 		result, err := function.EvaluateToSeriesList(test.expr, function.EvaluationContext{
 			TimeseriesStorageAPI: FakeBackend{},
-			MetricConverter:      &mocks.FakeGraphiteConverter{},
 			Timerange:            test.timerange,
 			SampleMethod:         api.SampleMean,
 			FetchLimit:           function.NewFetchCounter(1000),

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/square/metrics/function"
 	"github.com/square/metrics/function/registry"
 	"github.com/square/metrics/testing_support/assert"
+	"github.com/square/metrics/testing_support/mocks"
 )
 
 type FakeBackend struct {
@@ -84,7 +85,7 @@ func Test_ScalarExpression(t *testing.T) {
 		a := assert.New(t).Contextf("%+v", test)
 		result, err := function.EvaluateToSeriesList(test.expr, function.EvaluationContext{
 			TimeseriesStorageAPI: FakeBackend{},
-			MetricConverter:      nil, // TODO: fill this with something
+			MetricConverter:      &mocks.FakeGraphiteConverter{},
 			Timerange:            test.timerange,
 			SampleMethod:         api.SampleMean,
 			FetchLimit:           function.NewFetchCounter(1000),

--- a/query/inspect_test.go
+++ b/query/inspect_test.go
@@ -25,42 +25,22 @@ import (
 )
 
 func TestProfilerIntegration(t *testing.T) {
-	myAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeTimeStorage := mocks.FakeTimeseriesStorageAPI{}
-	// 	myAPI := fakeAPI{
-	// 	tagSets: map[string][]api.TagSet{"A": []api.TagSet{
-	// 		{"x": "1", "y": "2"},
-	// 		{"x": "2", "y": "2"},
-	// 		{"x": "3", "y": "1"},
-	// 	},
-	// 		"B": []api.TagSet{
-	// 			{"q": "foo"},
-	// 			{"q": "bar"},
-	// 		},
-	// 		"C": []api.TagSet{
-	// 			{"c": "1"},
-	// 			{"c": "2"},
-	// 			{"c": "3"},
-	// 			{"c": "4"},
-	// 			{"c": "5"},
-	// 			{"c": "6"},
-	// 		},
-	// 	},
-	// }
+	fakeConverter, fakeAPI := mocks.NewFakeGraphiteConverter([]api.TaggedMetric{
+		{"A", api.TagSet{"x": "1", "y": "2"}},
+		{"A", api.TagSet{"x": "2", "y": "2"}},
+		{"A", api.TagSet{"x": "3", "y": "1"}},
 
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=1,y=2")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=2,y=2")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=3,y=1")})
+		{"B", api.TagSet{"q": "foo"}},
+		{"B", api.TagSet{"q": "bar"}},
 
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.ParseTagSet("q=foo")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.ParseTagSet("q=bar")})
-
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=1")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=2")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=3")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=4")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=5")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=6")})
+		{"C", api.TagSet{"c": "1"}},
+		{"C", api.TagSet{"c": "2"}},
+		{"C", api.TagSet{"c": "3"}},
+		{"C", api.TagSet{"c": "4"}},
+		{"C", api.TagSet{"c": "5"}},
+		{"C", api.TagSet{"c": "6"}},
+	})
+	fakeTimeStorage := mocks.FakeTimeseriesStorageAPI{AlwaysReturnData: true}
 
 	testCases := []struct {
 		query    string
@@ -142,8 +122,9 @@ func TestProfilerIntegration(t *testing.T) {
 		profilingCommand := NewProfilingCommandWithProfiler(cmd, profiler)
 
 		_, err = profilingCommand.Execute(ExecutionContext{
+			MetricConverter:           fakeConverter,
 			TimeseriesStorageAPI:      fakeTimeStorage,
-			MetricMetadataAPI:         myAPI,
+			MetricMetadataAPI:         fakeAPI,
 			FetchLimit:                10000,
 			Timeout:                   time.Second * 4,
 			OptimizationConfiguration: optimize.NewOptimizationConfiguration(),

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -28,36 +28,12 @@ import (
 	"github.com/square/metrics/testing_support/mocks"
 )
 
-type movingAverageBackend struct{ mocks.FakeTimeseriesStorageAPI }
-
-func (b movingAverageBackend) FetchSingleTimeseries(r api.FetchTimeseriesRequest) (api.Timeseries, error) {
-	t := r.Timerange
-	values := []float64{9, 2, 1, 6, 4, 5}
-	startIndex := t.Start()/100 - 10
-	result := make([]float64, t.Slots())
-	for i := range result {
-		result[i] = values[i+int(startIndex)]
-	}
-	return api.Timeseries{Values: values, TagSet: api.NewTagSet()}, nil
-}
-
-func (b movingAverageBackend) FetchMultipleTimeseries(r api.FetchMultipleTimeseriesRequest) (api.SeriesList, error) {
-	timeseries := make([]api.Timeseries, 0)
-	singleRequests := r.ToSingle()
-	for _, request := range singleRequests {
-		series, _ := b.FetchSingleTimeseries(request)
-		timeseries = append(timeseries, series)
-	}
-	return api.SeriesList{
-		Series: timeseries,
-	}, nil
-}
-
 func TestMovingAverage(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
 	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series", api.NewTagSet()})
 
-	fakeBackend := movingAverageBackend{}
+	fakeBackend := mocks.FakeTimeseriesStorageAPI{}
+
 	timerange, err := api.NewTimerange(1200, 1500, 100)
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -43,7 +43,7 @@ func NewFakeMetricMetadataAPI() *FakeMetricMetadataAPI {
 	}
 }
 
-func (fa *FakeMetricMetadataAPI) InsertMetric(tm api.TaggedMetric) {
+func (fa *FakeMetricMetadataAPI) MockMetric(tm api.TaggedMetric) {
 	fa.metricTagSets[tm.MetricKey] = append(fa.metricTagSets[tm.MetricKey], tm.TagSet)
 	for key, value := range tm.TagSet {
 		index := struct {
@@ -132,7 +132,7 @@ func NewFakeGraphiteConverter(metrics []api.TaggedMetric) (FakeGraphiteConverter
 			name += "." + tag + "." + metric.TagSet[tag]
 		}
 		result.ConversionMap[name] = metric
-		fakeAPI.InsertMetric(metric)
+		fakeAPI.MockMetric(metric)
 	}
 	return result, fakeAPI
 }

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -112,17 +112,17 @@ type FakeGraphiteConverter struct {
 
 var _ api.MetricConverter = (*FakeGraphiteConverter)(nil)
 
-func (fa *FakeGraphiteConverter) ToUntagged(metric api.TaggedMetric) ([]byte, error) {
+func (fa *FakeGraphiteConverter) ToUntagged(metric api.TaggedMetric) (string, error) {
 	for k, v := range fa.MetricMap {
 		if reflect.DeepEqual(v, metric) {
-			return []byte(k), nil
+			return k, nil
 		}
 	}
-	return nil, fmt.Errorf("No mapping for tagged metric %+v to tagged metric", metric)
+	return "", fmt.Errorf("No mapping for tagged metric %+v to tagged metric", metric)
 }
 
-func (fa *FakeGraphiteConverter) ToTagged(metric []byte) (api.TaggedMetric, error) {
-	tm, exists := fa.MetricMap[string(metric)]
+func (fa *FakeGraphiteConverter) ToTagged(metric string) (api.TaggedMetric, error) {
+	tm, exists := fa.MetricMap[metric]
 	if !exists {
 		return api.TaggedMetric{}, fmt.Errorf("No mapping for graphite metric %+s to graphite metric", string(metric))
 	}

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -227,7 +227,7 @@ func (b *Blueflood) FetchSingleTimeseries(request api.FetchTimeseriesRequest) ([
 		return nil, err
 	}
 	if request.UserSpecifiableConfig.IncludeRawData {
-		request.EvaluationNotes.AddNote(fmt.Sprintf("Blueflood query resolution %s : %s", request.Metric, rawResult))
+		request.EvaluationNotes.AddNote(fmt.Sprintf("Blueflood (query resolution) %s: %s", request.Metric, rawResult))
 	}
 
 	// combinedResult contains the requested data, along with higher-resolution data intended to fill in gaps.
@@ -260,7 +260,7 @@ func (b *Blueflood) FetchSingleTimeseries(request api.FetchTimeseriesRequest) ([
 			return nil
 		}
 		if request.UserSpecifiableConfig.IncludeRawData {
-			request.EvaluationNotes.AddNote(fmt.Sprintf("Blueflood full resolution %s : %s", request.Metric, rawResult))
+			request.EvaluationNotes.AddNote(fmt.Sprintf("Blueflood (full resolution) %s: %s", request.Metric, rawResult))
 		}
 		// The higher-resolution data will likely overlap with the requested data.
 		// This isn't a problem - the requested, higher-resolution data will be downsampled by this code.

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/log"
-	"github.com/square/metrics/util"
 )
 
 type Blueflood struct {
@@ -57,7 +56,6 @@ type Config struct {
 	Ttls                    map[string]int64 `yaml:"ttls"` // Ttl in days
 	Timeout                 time.Duration    `yaml:"timeout"`
 	FullResolutionOverlap   int64            `yaml:"full_resolution_overlap"` // overlap to draw full resolution in seconds
-	GraphiteMetricConverter util.GraphiteConverter
 	HttpClient              httpClient
 	TimeSource              TimeSource
 	MaxSimultaneousRequests int `yaml:"simultaneous_requests"`
@@ -325,7 +323,7 @@ func (b *Blueflood) fetch(request api.FetchTimeseriesRequest, queryUrl *url.URL)
 	go func() {
 		resp, err := b.client.Get(queryUrl.String())
 		if err != nil {
-			failure <- api.TimeseriesStorageError{request.Metric, api.FetchIOError, "error while fetching - http connection"}
+			failure <- api.TimeseriesStorageError{request.Metric, api.FetchIOError, fmt.Sprintf("error while fetching - http connection: %s", err.Error())}
 			return
 		}
 		defer resp.Body.Close()

--- a/timeseries_storage/blueflood/blueflood.go
+++ b/timeseries_storage/blueflood/blueflood.go
@@ -273,7 +273,7 @@ func (b *Blueflood) FetchSingleTimeseries(request api.FetchTimeseriesRequest) ([
 	values := processResult(combinedResult, request.Timerange, sampler, queryResolution)
 	log.Debugf("Constructed timeseries from result: %v", values)
 
-	return values, nil // TODO: include raw results
+	return values, nil
 
 }
 

--- a/timeseries_storage/blueflood/blueflood_raw_test.go
+++ b/timeseries_storage/blueflood/blueflood_raw_test.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blueflood
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
+	"github.com/square/metrics/testing_support/mocks"
+)
+
+func TestIncludeRawPayload(t *testing.T) {
+	now := time.Unix(1438734300000, 0)
+
+	baseTime := now.Unix() * 1000
+	timeSource := func() time.Time { return now }
+
+	queryTimerange, err := api.NewSnappedTimerange(
+		int64(baseTime)-300*1000*10, // 50 minutes ago
+		int64(baseTime)-300*1000*4,  // 20 minutes ago
+		300*1000,                    // 5 minute resolution
+	)
+
+	// The queries have to be relative to "now"
+	defaultClientConfig := Config{
+		BaseUrl:               "https://blueflood.url",
+		TenantId:              "square",
+		Ttls:                  make(map[string]int64),
+		Timeout:               time.Millisecond,
+		FullResolutionOverlap: 14400,
+		TimeSource:            timeSource,
+	}
+
+	regularQueryURL := fmt.Sprintf(
+		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=MIN5&select=numPoints%%2Caverage&to=%d",
+		queryTimerange.Start(),
+		queryTimerange.End()+queryTimerange.ResolutionMillis(),
+	)
+
+	fullResolutionQueryURL := fmt.Sprintf(
+		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=FULL&select=numPoints%%2Caverage&to=%d",
+		queryTimerange.Start(),
+		queryTimerange.End()+queryTimerange.ResolutionMillis(),
+	)
+
+	regularResponse := fmt.Sprintf(`{
+	  "unit": "unknown",
+	  "values": [
+	    {
+	      "numPoints": 28,
+	      "timestamp": %d,
+	      "average": 100
+	    },
+	    {
+	      "numPoints": 29,
+	      "timestamp": %d,
+	      "average": 142
+	    },
+	    {
+	      "numPoints": 27,
+	      "timestamp": %d,
+	      "average": 138
+	    },
+	    {
+	      "numPoints": 28,
+	      "timestamp": %d,
+	      "average": 182
+	    }
+	  ],
+	  "metadata": {
+	    "limit": null,
+	    "next_href": null,
+	    "count": 4,
+	    "marker": null
+	  }
+	}`,
+		baseTime-300*1000*10, // 50 minutes ago
+		baseTime-300*1000*9,  // 45 minutes ago
+		baseTime-300*1000*8,  // 40 minutes ago
+		baseTime-300*1000*7,  // 35 minutes ago
+	)
+
+	fakeHttpClient := mocks.NewFakeHttpClient()
+	fakeHttpClient.SetResponse(regularQueryURL, mocks.Response{regularResponse, 0, http.StatusOK})
+	// Note that the following is cheating, since it's not a reasonable response for that query.
+	// It still tests this aspect of the raw_test, however, so it's kept.
+	fakeHttpClient.SetResponse(fullResolutionQueryURL, mocks.Response{regularResponse, 0, http.StatusOK})
+	defaultClientConfig.HttpClient = fakeHttpClient
+	defaultClientConfig.TimeSource = timeSource
+
+	b := NewBlueflood(defaultClientConfig)
+	if err != nil {
+		t.Fatalf("timerange error: %s", err.Error())
+	}
+
+	userConfig := api.UserSpecifiableConfig{
+		IncludeRawData: true,
+	}
+
+	evaluationNotes := &inspect.EvaluationNotes{}
+
+	if _, err := b.FetchSingleTimeseries(api.FetchTimeseriesRequest{
+		Metric:                "some.key.value",
+		SampleMethod:          api.SampleMean,
+		Timerange:             queryTimerange,
+		Cancellable:           api.NewCancellable(),
+		EvaluationNotes:       evaluationNotes,
+		UserSpecifiableConfig: userConfig,
+	}); err != nil {
+		t.Fatalf("Expected success, but got error: %s", err.Error())
+	}
+
+	notes := evaluationNotes.Notes()
+
+	if len(notes) != 2 {
+		t.Fatalf("Expected 2 evaluation notes: for this series, one for full resolution and one for query resolution, but got %d: %+v", len(notes), notes)
+	}
+	if expected := "Blueflood (query resolution) some.key.value: " + regularResponse; notes[0] != expected {
+		t.Errorf("Didn't fill in notes[0] correctly, got\n%s\n but expected \n%s\n", notes[0], expected)
+	}
+	if expected := "Blueflood (full resolution) some.key.value: " + regularResponse; notes[1] != expected {
+		t.Errorf("Didn't fill in notes[1] correctly, got\n%s\n but expected \n%s\n", notes[1], expected)
+	}
+
+}

--- a/timeseries_storage/blueflood/blueflood_test.go
+++ b/timeseries_storage/blueflood/blueflood_test.go
@@ -369,7 +369,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	}
 
 	seriesList, err := b.FetchSingleTimeseries(api.FetchTimeseriesRequest{
-		Metric:       []byte("some.key.value"), // TODO: get converter working with this
+		Metric:       "some.key.value", // TODO: get converter working with this
 		SampleMethod: api.SampleMean,
 		Timerange:    queryTimerange,
 		Cancellable:  api.NewCancellable(),

--- a/timeseries_storage/blueflood/blueflood_test.go
+++ b/timeseries_storage/blueflood/blueflood_test.go
@@ -34,8 +34,8 @@ func Test_Blueflood(t *testing.T) {
 	}
 
 	graphite := mocks.FakeGraphiteConverter{
-		MetricMap: map[util.GraphiteMetric]api.TaggedMetric{
-			util.GraphiteMetric("some.key.graphite"): api.TaggedMetric{
+		MetricMap: map[string]api.TaggedMetric{
+			"some.key.graphite": api.TaggedMetric{
 				MetricKey: api.MetricKey("some.key"),
 				TagSet:    api.ParseTagSet("tag=value"),
 			},
@@ -43,12 +43,11 @@ func Test_Blueflood(t *testing.T) {
 	}
 
 	defaultClientConfig := Config{
-		BaseUrl:                 "https://blueflood.url",
-		TenantId:                "square",
-		Ttls:                    make(map[string]int64),
-		Timeout:                 time.Millisecond,
-		FullResolutionOverlap:   0,
-		GraphiteMetricConverter: &graphite,
+		BaseUrl:               "https://blueflood.url",
+		TenantId:              "square",
+		Ttls:                  make(map[string]int64),
+		Timeout:               time.Millisecond,
+		FullResolutionOverlap: 0,
 	}
 	// Not really MIN1440, but that's what default TTLs will get with the Timerange we use
 	defaultQueryUrl := "https://blueflood.url/v2.0/square/views/some.key.graphite?from=12000&resolution=MIN1440&select=numPoints%2Caverage&to=14000"
@@ -157,8 +156,11 @@ func Test_Blueflood(t *testing.T) {
 		b := NewBlueflood(test.clientConfig).(*Blueflood)
 		b.client = fakeHttpClient
 
+		untaggedQueryMetric, err := graphite.ToUntagged(test.queryMetric)
+		a.CheckError(err)
+
 		seriesList, err := b.FetchSingleTimeseries(api.FetchTimeseriesRequest{
-			Metric:       test.queryMetric,
+			Metric:       untaggedQueryMetric,
 			SampleMethod: test.sampleMethod,
 			Timerange:    test.timerange,
 			Cancellable:  api.NewCancellable(),
@@ -182,115 +184,6 @@ func Test_Blueflood(t *testing.T) {
 			}
 			a.Eq(seriesList, test.expectedSeriesList)
 		}
-	}
-}
-
-func TestIncludeRawPayload(t *testing.T) {
-	graphite := mocks.FakeGraphiteConverter{
-		MetricMap: map[util.GraphiteMetric]api.TaggedMetric{
-			util.GraphiteMetric("some.key.value"): api.TaggedMetric{
-				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
-			},
-		},
-	}
-
-	now := time.Unix(1438734300000, 0)
-
-	baseTime := now.Unix() * 1000
-	timeSource := func() time.Time { return now }
-
-	queryTimerange, err := api.NewSnappedTimerange(
-		int64(baseTime)-300*1000*10, // 50 minutes ago
-		int64(baseTime)-300*1000*4,  // 20 minutes ago
-		300*1000,                    // 5 minute resolution
-	)
-
-	// The queries have to be relative to "now"
-	defaultClientConfig := Config{
-		BaseUrl:                 "https://blueflood.url",
-		TenantId:                "square",
-		Ttls:                    make(map[string]int64),
-		Timeout:                 time.Millisecond,
-		FullResolutionOverlap:   14400,
-		GraphiteMetricConverter: &graphite,
-		TimeSource:              timeSource,
-	}
-
-	regularQueryURL := fmt.Sprintf(
-		"https://blueflood.url/v2.0/square/views/some.key.value?from=%d&resolution=MIN5&select=numPoints%%2Caverage&to=%d",
-		queryTimerange.Start(),
-		queryTimerange.End()+queryTimerange.ResolutionMillis(),
-	)
-
-	regularResponse := fmt.Sprintf(`{
-	  "unit": "unknown",
-	  "values": [
-	    {
-	      "numPoints": 28,
-	      "timestamp": %d,
-	      "average": 100
-	    },
-	    {
-	      "numPoints": 29,
-	      "timestamp": %d,
-	      "average": 142
-	    },
-	    {
-	      "numPoints": 27,
-	      "timestamp": %d,
-	      "average": 138
-	    },
-	    {
-	      "numPoints": 28,
-	      "timestamp": %d,
-	      "average": 182
-	    }
-	  ],
-	  "metadata": {
-	    "limit": null,
-	    "next_href": null,
-	    "count": 4,
-	    "marker": null
-	  }
-	}`,
-		baseTime-300*1000*10, // 50 minutes ago
-		baseTime-300*1000*9,  // 45 minutes ago
-		baseTime-300*1000*8,  // 40 minutes ago
-		baseTime-300*1000*7,  // 35 minutes ago
-	)
-
-	fakeHttpClient := mocks.NewFakeHttpClient()
-	fakeHttpClient.SetResponse(regularQueryURL, mocks.Response{regularResponse, 0, http.StatusOK})
-	// fakeHttpClient.SetResponse(fullResolutionQueryURL, mocks.Response{fullResolutionResponse, 0, http.StatusOK})
-	defaultClientConfig.HttpClient = fakeHttpClient
-	defaultClientConfig.TimeSource = timeSource
-
-	b := NewBlueflood(defaultClientConfig)
-	if err != nil {
-		t.Fatalf("timerange error: %s", err.Error())
-	}
-
-	userConfig := api.UserSpecifiableConfig{
-		IncludeRawData: true,
-	}
-
-	timeSeries, err := b.FetchSingleTimeseries(api.FetchTimeseriesRequest{
-		Metric: api.TaggedMetric{
-			MetricKey: api.MetricKey("some.key"),
-			TagSet:    api.ParseTagSet("tag=value"),
-		},
-		SampleMethod:          api.SampleMean,
-		Timerange:             queryTimerange,
-		Cancellable:           api.NewCancellable(),
-		UserSpecifiableConfig: userConfig,
-	})
-	if err != nil {
-		t.Fatalf("Expected success, but got error: %s", err.Error())
-	}
-
-	if timeSeries.Raw == nil || string(timeSeries.Raw[0]) != regularResponse {
-		t.Fatalf("Didn't fill in the raw result correctly, got: %s\n", string(timeSeries.Raw[0]))
 	}
 }
 
@@ -348,13 +241,14 @@ func TestSeriesFromMetricPoints(t *testing.T) {
 
 func TestFullResolutionDataFilling(t *testing.T) {
 	graphite := mocks.FakeGraphiteConverter{
-		MetricMap: map[util.GraphiteMetric]api.TaggedMetric{
-			util.GraphiteMetric("some.key.value"): api.TaggedMetric{
+		MetricMap: map[string]api.TaggedMetric{
+			"some.key.value": api.TaggedMetric{
 				MetricKey: api.MetricKey("some.key"),
 				TagSet:    api.ParseTagSet("tag=value"),
 			},
 		},
 	}
+	panic(graphite) // TODO: use this somewhere
 
 	now := time.Unix(1438734300000, 0)
 
@@ -369,13 +263,12 @@ func TestFullResolutionDataFilling(t *testing.T) {
 
 	// The queries have to be relative to "now"
 	defaultClientConfig := Config{
-		BaseUrl:                 "https://blueflood.url",
-		TenantId:                "square",
-		Ttls:                    make(map[string]int64),
-		Timeout:                 time.Millisecond,
-		FullResolutionOverlap:   14400,
-		GraphiteMetricConverter: &graphite,
-		TimeSource:              timeSource,
+		BaseUrl:               "https://blueflood.url",
+		TenantId:              "square",
+		Ttls:                  make(map[string]int64),
+		Timeout:               time.Millisecond,
+		FullResolutionOverlap: 14400,
+		TimeSource:            timeSource,
 	}
 
 	regularQueryURL := fmt.Sprintf(
@@ -476,10 +369,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	}
 
 	seriesList, err := b.FetchSingleTimeseries(api.FetchTimeseriesRequest{
-		Metric: api.TaggedMetric{
-			MetricKey: api.MetricKey("some.key"),
-			TagSet:    api.ParseTagSet("tag=value"),
-		},
+		Metric:       []byte("some.key.value"), // TODO: get converter working with this
 		SampleMethod: api.SampleMean,
 		Timerange:    queryTimerange,
 		Cancellable:  api.NewCancellable(),
@@ -488,11 +378,11 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		t.Fatalf("Expected success, but got error: %s", err.Error())
 	}
 	expected := []float64{100, 142, 138, 182, 13, 16, 19}
-	if len(seriesList.Values) != len(expected) {
+	if len(seriesList) != len(expected) {
 		t.Fatalf("Expected %+v but got %+v", expected, seriesList)
 	}
 	for i, expect := range expected {
-		if seriesList.Values[i] != expect {
+		if seriesList[i] != expect {
 			t.Fatalf("Expected %+v but got %+v", expected, seriesList)
 		}
 	}

--- a/timeseries_storage/timeseries_map/map.go
+++ b/timeseries_storage/timeseries_map/map.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeseries_map
+
+import (
+	"math"
+	"time"
+
+	"github.com/square/metrics/api"
+)
+
+type Point struct {
+	Time  time.Time
+	Value float64
+}
+
+type PointMap struct {
+	Points []Point
+}
+
+type PointDatabase struct {
+	Map map[string]PointMap
+}
+
+func (p PointDatabase) ChooseResolution(requested api.Timerange, smallestResolution time.Duration) time.Duration {
+	return requested.Resolution()
+}
+func (p PointDatabase) fetch(request api.FetchTimeseriesRequest) []float64 {
+	result := make([]float64, request.Timerange.Slots())
+	for i := range result {
+		result[i] = math.NaN()
+	}
+	for _, point := range p.Map[request.Metric].Points {
+		i := request.Timerange.Index(point.Time)
+		if 0 <= i && i < len(result) {
+			result[i] = point.Value
+		}
+	}
+	return result
+}
+func (p PointDatabase) FetchSingleTimeseries(request api.FetchTimeseriesRequest) ([]float64, error) {
+	return p.fetch(request), nil
+}
+func (p PointDatabase) FetchMultipleTimeseries(requests api.FetchMultipleTimeseriesRequest) ([][]float64, error) {
+	list := requests.ToSingle()
+	result := make([][]float64, len(list))
+	for i, request := range list {
+		result[i] = p.fetch(request)
+	}
+	return result, nil
+}

--- a/timeseries_storage/timeseries_map/map.go
+++ b/timeseries_storage/timeseries_map/map.go
@@ -21,19 +21,23 @@ import (
 	"github.com/square/metrics/api"
 )
 
+// Point is a single point of data in a time series.
 type Point struct {
 	Time  time.Time
 	Value float64
 }
 
+// PointMap is a collection of points belonging to a time series.
 type PointMap struct {
 	Points []Point
 }
 
+// PointDatabase is a collection of time series belonging to a given name.
 type PointDatabase struct {
 	Map map[string]PointMap
 }
 
+// ChooseResolution echoes whatever resolution was requested, since PointDatabase doesn't care.
 func (p PointDatabase) ChooseResolution(requested api.Timerange, smallestResolution time.Duration) time.Duration {
 	return requested.Resolution()
 }

--- a/util/graphite_converter.go
+++ b/util/graphite_converter.go
@@ -37,7 +37,7 @@ type GraphiteConverterConfig struct {
 	ConversionRulesPath string `yaml:"conversion_rules_path"`
 }
 
-var _ GraphiteConverter = (*RuleBasedGraphiteConverter)(nil)
+// var _ GraphiteConverter = (*RuleBasedGraphiteConverter)(nil) // TODO: reeavluate this
 
 type RuleBasedGraphiteConverter struct {
 	Ruleset RuleSet
@@ -47,12 +47,12 @@ func (g *RuleBasedGraphiteConverter) EnableStats() {
 	g.Ruleset.EnableStats()
 }
 
-func (g *RuleBasedGraphiteConverter) ToGraphiteName(metric api.TaggedMetric) (GraphiteMetric, error) {
+func (g *RuleBasedGraphiteConverter) ToUntagged(metric api.TaggedMetric) (string, error) {
 	return g.Ruleset.ToGraphiteName(metric)
 }
 
-func (g *RuleBasedGraphiteConverter) ToTaggedName(metric GraphiteMetric) (api.TaggedMetric, error) {
-	match, matched := g.Ruleset.MatchRule(string(metric))
+func (g *RuleBasedGraphiteConverter) ToTagged(metric string) (api.TaggedMetric, error) {
+	match, matched := g.Ruleset.MatchRule(metric)
 	if matched {
 		return match, nil
 	}

--- a/util/rules.go
+++ b/util/rules.go
@@ -186,7 +186,7 @@ func (rule *Rule) MatchRule(input string) (api.TaggedMetric, bool) {
 }
 
 // ToGraphiteName transforms the given tagged metric back to its graphite metric.
-func (rule Rule) ToGraphiteName(taggedMetric api.TaggedMetric) (GraphiteMetric, error) {
+func (rule Rule) ToGraphiteName(taggedMetric api.TaggedMetric) (string, error) {
 	extractedTagSet := extractTagValues(rule.MetricKeyRegex, rule.metricKeyTags, string(taggedMetric.MetricKey))
 	if extractedTagSet == nil {
 		// no match found. not a correct rule to interpolate.
@@ -208,7 +208,7 @@ func (rule Rule) ToGraphiteName(taggedMetric api.TaggedMetric) (GraphiteMetric, 
 		return "", err
 	}
 
-	return GraphiteMetric(interpolated), nil
+	return interpolated, nil
 }
 
 // MatchRule sees if a given graphite string matches
@@ -252,7 +252,7 @@ func (rule Rule) GraphitePatternTags() []string {
 
 // ToGraphiteName transforms the given tagged metric back to its graphite name,
 // checking against all the rules.
-func (ruleSet RuleSet) ToGraphiteName(taggedMetric api.TaggedMetric) (GraphiteMetric, error) {
+func (ruleSet RuleSet) ToGraphiteName(taggedMetric api.TaggedMetric) (string, error) {
 	for _, rule := range ruleSet.Rules {
 		reversed, err := rule.ToGraphiteName(taggedMetric)
 		if err == nil {


### PR DESCRIPTION
This PR is now ready for review.

Previously, things were organized like this:

* `MetricMetadaAPI` (Cassandra) stores metadata, without worrying about Graphite tags
* `TimeseriesStorageAPI` (Blueflood) stores time-series data, and converts from tagged metrics to graphite metrics

Now, things are organized like this:

* `MetricMetadaInterface` (Cassandra) stores metadata, without worrying about Graphite tags
  * `MetricMetadataAPI` sub-interface that's only able to perform queries
  * `MetricMetadataModifier` sub-interface that's only able to insert and remove items
* `TimeseriesStorageAPI` (Blueflood) stores time-series data, without worrying about tagged metrics
* `MetricConverter` (Graphite-Regex-Rules) converts between the two kinds

This PR makes the conversion of metrics from tagged to untagged form orthogonal to other parts of the system, namely the Timeseries storage API.

In practical terms, what this means is that the implementation for `Blueflood` no longer bothers doing any conversion. It is given "graphite" metrics, so those are all it needs to know about. Hypothetically, you could transparently switch from storing metrics as graphite names to compressed gzipped strings, and all you'd do is switch out the converter, without modifying Blueflood or its configuration.

**Changes to Testing**

Since `MetricConverter`s are now needed to perform query tests, the mock converter popped up in a lot of places. And since it contains the same information as the mock `MetricMetadataAPI`, I wrote a function in the `mock` package that gives you one of each, by asking for a list of `TaggedMetric`s.

Many tests were switched to this new form, since it was the easiest way to populate the mock `MetricConverter`.

**Raw Timeseries Values**

Raw timeseries values are no longer stored in timeseries. They are instead reported in the Evaluation Notes for an execution.

**Changes to `MetricMetadataAPI`**

`MetricMetadataAPI` is renamed to `MetricMetadataInterface`

`MetricMetadataAPI` is now an interface which only has the subset of methods used for querying (`GetAllMetricForTag`, `GetAllMetrics`)

`MetricMetadataModifier` is now an interface which has only the subset of methods used for adding/removing metrics.

The evaluation context uses a `MetricMetadataAPI`, so it can't be used to modify the database.

@drcapulet 