### PR TITLE
Filter Threshold & Filter Count Functions

### DIFF
--- a/api/timerange.go
+++ b/api/timerange.go
@@ -59,7 +59,7 @@ func (tr Timerange) EndMillis() int64 {
 // End returns the time.Time value corresponding to the end of the timerange (inclusive).
 func (tr Timerange) End() time.Time {
 	seconds := tr.end / 1000
-	nanoseconds := (tr.start % 1000) * 1000000
+	nanoseconds := (tr.end % 1000) * 1000000
 	return time.Unix(seconds, nanoseconds)
 }
 

--- a/api/timerange.go
+++ b/api/timerange.go
@@ -174,3 +174,17 @@ func (tr Timerange) ExtendBefore(length time.Duration) Timerange {
 func (tr Timerange) Slots() int {
 	return int((tr.end-tr.start)/tr.resolution) + 1
 }
+
+// TimeOfIndex returns the point in time corresponding to a (possibly out-of-range)
+func (tr Timerange) TimeOfIndex(point int) time.Time {
+	return tr.Start().Add(time.Duration(point) * tr.Resolution())
+}
+
+// IndexOfTime returns the index of the point in time (possibly out-of-range).
+// 0 corresponds to [tr.Start(), tr.Start().Add(tr.Resolution()))
+func (tr Timerange) IndexOfTime(point time.Time) int {
+	if tr.Resolution() == 0 {
+		return 0
+	}
+	return int(point.Sub(tr.Start()) / tr.Resolution())
+}

--- a/api/timerange.go
+++ b/api/timerange.go
@@ -176,12 +176,13 @@ func (tr Timerange) Slots() int {
 }
 
 // TimeOfIndex returns the point in time corresponding to a (possibly out-of-range)
+// index. N corresponds to tr.Start + N*tr.Resolution.
 func (tr Timerange) TimeOfIndex(point int) time.Time {
 	return tr.Start().Add(time.Duration(point) * tr.Resolution())
 }
 
 // IndexOfTime returns the index of the point in time (possibly out-of-range).
-// 0 corresponds to [tr.Start(), tr.Start().Add(tr.Resolution()))
+// 0 corresponds to any time in the interval [tr.Start, tr.Start + tr.Resolution)
 func (tr Timerange) IndexOfTime(point time.Time) int {
 	if tr.Resolution() == 0 {
 		return 0

--- a/api/timerange.go
+++ b/api/timerange.go
@@ -176,7 +176,7 @@ func (tr Timerange) Slots() int {
 }
 
 // TimeOfIndex returns the point in time corresponding to a (possibly out-of-range)
-// index. N corresponds to tr.Start + N*tr.Resolution.
+// index. point corresponds to tr.Start + point*tr.Resolution.
 func (tr Timerange) TimeOfIndex(point int) time.Time {
 	return tr.Start().Add(time.Duration(point) * tr.Resolution())
 }

--- a/api/timerange.go
+++ b/api/timerange.go
@@ -59,8 +59,7 @@ func (tr Timerange) EndMillis() int64 {
 // End returns the time.Time value corresponding to the end of the timerange (inclusive).
 func (tr Timerange) End() time.Time {
 	seconds := tr.end / 1000
-	milliseconds := tr.start % 1000
-	nanoseconds := milliseconds * 1000000
+	nanoseconds := (tr.start % 1000) * 1000000
 	return time.Unix(seconds, nanoseconds)
 }
 

--- a/function/filter/filter.go
+++ b/function/filter/filter.go
@@ -32,11 +32,11 @@ func (list filterList) Len() int {
 	return len(list.index)
 }
 func (list filterList) Less(i, j int) bool {
-	if math.IsNaN(list.value[j]) && !math.IsNaN(list.value[i]) {
-		return true
+	if math.IsNaN(list.value[i]) {
+		return false // NaN must go second
 	}
 	if math.IsNaN(list.value[j]) {
-		return true
+		return true // NaN must go second
 	}
 	if list.ascending {
 		return list.value[i] < list.value[j]

--- a/function/filter/filter.go
+++ b/function/filter/filter.go
@@ -94,19 +94,19 @@ func FilterByRecent(list api.SeriesList, count int, summary func([]float64) floa
 
 // FilterThresholdBy reduces the number of things in the series `list` to those whose `summar` is at at least/at most the threshold.
 // However, it only considers the data points as recent as the duration permits.
-func FilterThresholdByRecent(list api.SeriesList, threshold float64, summary func([]float64) float64, lowest bool, duration time.Duration) api.SeriesList {
+func FilterThresholdByRecent(list api.SeriesList, threshold float64, summary func([]float64) float64, below bool, duration time.Duration) api.SeriesList {
 	slots := int(duration / list.Timerange.Resolution())
 	if slots > list.Timerange.Slots() {
 		slots = list.Timerange.Slots()
 	}
 	sorted, values := sortSeries(list.Series, func(values []float64) float64 {
 		return summary(values[len(values)-slots:])
-	}, lowest)
+	}, below)
 
 	result := []api.Timeseries{}
 	for i := range sorted {
 		// Since the series are sorted, once one of them falls outside the threshold, we can stop.
-		if (lowest && values[i] > threshold) || (!lowest && values[i] < threshold) {
+		if (below && values[i] > threshold) || (!below && values[i] < threshold) {
 			break
 		}
 		result = append(result, sorted[i])

--- a/function/filter/filter.go
+++ b/function/filter/filter.go
@@ -35,6 +35,9 @@ func (list filterList) Less(i, j int) bool {
 	if math.IsNaN(list.value[j]) && !math.IsNaN(list.value[i]) {
 		return true
 	}
+	if math.IsNaN(list.value[j]) {
+		return true
+	}
 	if list.ascending {
 		return list.value[i] < list.value[j]
 	} else {
@@ -62,7 +65,7 @@ func sortSeries(series []api.Timeseries, summary func([]float64) float64, lowest
 	weights := make([]float64, len(series))
 	for i, index := range array.index {
 		result[i] = series[index]
-		weights[i] = array.value[index]
+		weights[i] = array.value[i]
 	}
 	return result, weights
 }

--- a/function/filter/filter_test.go
+++ b/function/filter/filter_test.go
@@ -50,7 +50,7 @@ func TestFilter(t *testing.T) {
 			},
 		},
 		"D": {
-			Values: []float64{4, 4, 3, 4, 3},
+			Values: []float64{4, 4, 3.01, 4, 3.01},
 			TagSet: api.TagSet{
 				"name": "D",
 			},
@@ -62,96 +62,111 @@ func TestFilter(t *testing.T) {
 		Timerange: timerange,
 	}
 	tests := []struct {
-		summary func([]float64) float64
-		lowest  bool
-		count   int
-		expect  []string
+		summary     func([]float64) float64
+		lowest      bool
+		count       int
+		expect      []string
+		description string
 	}{
 		{
-			summary: aggregate.Sum,
-			lowest:  true,
-			count:   6,
-			expect:  []string{"A", "B", "C", "D"},
+			summary:     aggregate.Sum,
+			lowest:      true,
+			count:       6,
+			expect:      []string{"B", "A", "C", "D"},
+			description: "sum",
 		},
 
 		{
-			summary: aggregate.Sum,
-			lowest:  false,
-			count:   6,
-			expect:  []string{"A", "B", "C", "D"},
+			summary:     aggregate.Sum,
+			lowest:      false,
+			count:       6,
+			expect:      []string{"D", "C", "A", "B"},
+			description: "sum",
 		},
 
 		{
-			summary: aggregate.Sum,
-			lowest:  true,
-			count:   4,
-			expect:  []string{"A", "B", "C", "D"},
+			summary:     aggregate.Sum,
+			lowest:      true,
+			count:       4,
+			expect:      []string{"B", "A", "C", "D"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  true,
-			count:   3,
-			expect:  []string{"A", "B", "C"},
+			summary:     aggregate.Sum,
+			lowest:      true,
+			count:       3,
+			expect:      []string{"B", "A", "C"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  true,
-			count:   2,
-			expect:  []string{"A", "B"},
+			summary:     aggregate.Sum,
+			lowest:      true,
+			count:       2,
+			expect:      []string{"B", "A"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  true,
-			count:   1,
-			expect:  []string{"B"},
+			summary:     aggregate.Sum,
+			lowest:      true,
+			count:       1,
+			expect:      []string{"B"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  false,
-			count:   4,
-			expect:  []string{"A", "B", "C", "D"},
+			summary:     aggregate.Sum,
+			lowest:      false,
+			count:       4,
+			expect:      []string{"D", "C", "A", "B"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  false,
-			count:   3,
-			expect:  []string{"A", "C", "D"},
+			summary:     aggregate.Sum,
+			lowest:      false,
+			count:       3,
+			expect:      []string{"D", "C", "A"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  false,
-			count:   2,
-			expect:  []string{"C", "D"},
+			summary:     aggregate.Sum,
+			lowest:      false,
+			count:       2,
+			expect:      []string{"D", "C"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Sum,
-			lowest:  false,
-			count:   1,
-			expect:  []string{"D"},
+			summary:     aggregate.Sum,
+			lowest:      false,
+			count:       1,
+			expect:      []string{"D"},
+			description: "sum",
 		},
 		{
-			summary: aggregate.Max,
-			lowest:  false,
-			count:   1,
-			expect:  []string{"C"},
+			summary:     aggregate.Max,
+			lowest:      false,
+			count:       1,
+			expect:      []string{"C"},
+			description: "max",
 		},
 		{
-			summary: aggregate.Max,
-			lowest:  false,
-			count:   2,
-			expect:  []string{"C", "D"},
+			summary:     aggregate.Max,
+			lowest:      false,
+			count:       2,
+			expect:      []string{"C", "D"},
+			description: "max",
 		},
 		{
-			summary: aggregate.Min,
-			lowest:  false,
-			count:   2,
-			expect:  []string{"A", "D"},
+			summary:     aggregate.Min,
+			lowest:      false,
+			count:       2,
+			expect:      []string{"D", "A"},
+			description: "min",
 		},
 		{
-			summary: aggregate.Min,
-			lowest:  false,
-			count:   3,
-			expect:  []string{"A", "C", "D"},
+			summary:     aggregate.Min,
+			lowest:      false,
+			count:       3,
+			expect:      []string{"D", "A", "C"},
+			description: "min",
 		},
 	}
 	for _, test := range tests {
@@ -162,22 +177,20 @@ func TestFilter(t *testing.T) {
 			t.Errorf("Expected only %d in results but got %d", len(test.expect), len(filtered.Series))
 			continue
 		}
-		for _, s := range filtered.Series {
+		for i, s := range filtered.Series {
 			original, ok := series[s.TagSet["name"]]
 			if !ok {
 				t.Fatalf("Result tagset called '%s' is not an original", s.TagSet["name"])
 			}
-			a.EqFloatArray(original.Values, s.Values, 1e-7)
-		}
-		names := map[string]bool{}
-		for _, name := range test.expect {
-			names[name] = true
-		}
-		for _, s := range filtered.Series {
-			if !names[s.TagSet["name"]] {
-				t.Fatalf("TagSets %+v aren't expected; %+v are\nin test %+v", filtered.Series, test.expect, test)
+			if s.TagSet["name"] != test.expect[i] {
+				testOrder := "highest"
+				if test.lowest {
+					testOrder = "lowest"
+				}
+				t.Errorf("((%s %d %s)) Expected filtered sets to be %+v but were:\n%+v", testOrder, test.count, test.description, test.expect, filtered.Series)
+				break
 			}
-			names[s.TagSet["name"]] = false // Use up the name so that a seocnd Series can't also use it.
+			a.EqFloatArray(original.Values, s.Values, 1e-7)
 		}
 	}
 }

--- a/function/filter/filter_test.go
+++ b/function/filter/filter_test.go
@@ -155,7 +155,7 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		filtered := FilterBy(list, test.count, test.summary, test.lowest)
+		filtered := FilterByRecent(list, test.count, test.summary, test.lowest, list.Timerange.Duration()*10)
 		// Verify that every series in the result is from the original.
 		// Also verify that we only get the ones we expect.
 		if len(filtered.Series) != len(test.expect) {
@@ -175,7 +175,7 @@ func TestFilter(t *testing.T) {
 		}
 		for _, s := range filtered.Series {
 			if !names[s.TagSet["name"]] {
-				t.Fatalf("TagSets %+v aren't expected; %+v are", filtered.Series, test.expect)
+				t.Fatalf("TagSets %+v aren't expected; %+v are\nin test %+v", filtered.Series, test.expect, test)
 			}
 			names[s.TagSet["name"]] = false // Use up the name so that a seocnd Series can't also use it.
 		}
@@ -267,7 +267,7 @@ func TestFilterRecent(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		filtered := FilterRecentBy(list, test.count, test.summary, test.lowest, test.duration)
+		filtered := FilterByRecent(list, test.count, test.summary, test.lowest, test.duration)
 		// Verify that they're all unique and expected and unchanged
 		a.EqInt(len(filtered.Series), len(test.expect))
 		// Next, verify that the names are the same.

--- a/query/tests/command_select_filter_range_test.go
+++ b/query/tests/command_select_filter_range_test.go
@@ -1,0 +1,216 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration test for the query execution.
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/query/command"
+	"github.com/square/metrics/query/parser"
+	"github.com/square/metrics/testing_support/assert"
+	"github.com/square/metrics/testing_support/mocks"
+)
+
+func TestCommandSelectFilterRange(t *testing.T) {
+	a := assert.New(t)
+	timerange, err := api.NewSnappedTimerange(3000000, 3270000, 30000) // 10 slots
+	if err != nil {
+		t.Fatalf("Error constructing test timerange: %s", err.Error())
+	}
+	comboAPI := mocks.NewComboAPI(
+		timerange,
+		// Metric A
+		api.Timeseries{
+			Values: []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			TagSet: api.TagSet{"metric": "A", "foo": "rising"},
+		},
+		api.Timeseries{
+			Values: []float64{7, 5, 6, 4, 8, 4, 5, 4, 6, 5},
+			TagSet: api.TagSet{"metric": "A", "foo": "medium"},
+		},
+		api.Timeseries{
+			Values: []float64{6, 8, 8, 8, 8, 8, 7, 8, 6, 7},
+			TagSet: api.TagSet{"metric": "A", "foo": "high"},
+		},
+		api.Timeseries{
+			Values: []float64{9, 7, 7, 5, 5, 4, 2, 1, 1, -1},
+			TagSet: api.TagSet{"metric": "A", "foo": "falling"},
+		},
+		// Metric B
+		api.Timeseries{
+			Values: []float64{0, 1, 1, 0, 1, 4, 7, 8, 6, 9},
+			TagSet: api.TagSet{"metric": "B", "foo": "low-high"},
+		},
+		api.Timeseries{
+			Values: []float64{5, 8, 9, 7, 9, 0, 1, 1, 0, 1},
+			TagSet: api.TagSet{"metric": "B", "foo": "high-low"},
+		},
+		api.Timeseries{
+			Values: []float64{6, 8, 8, 8, 8, 8, 7, 8, 6, 7},
+			TagSet: api.TagSet{"metric": "B", "foo": "high"},
+		},
+		api.Timeseries{
+			Values: []float64{9, 9, 7, 7, 6, 6, 4, 4, 2, -1},
+			TagSet: api.TagSet{"metric": "B", "foo": "falling"},
+		},
+	)
+	type Test struct {
+		Query    string
+		Expected []string
+	}
+	tests := []Test{
+		// Highest mean (A)
+		{
+			Query:    `select A | filter.highest_mean(4) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "medium", "rising", "falling"},
+		},
+		{
+			Query:    `select A | filter.highest_mean(3) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "medium", "rising"},
+		},
+		{
+			Query:    `select A | filter.highest_mean(2) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "medium"},
+		},
+		{
+			Query:    `select A | filter.highest_mean(1) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high"},
+		},
+		// Lowest mean (A)
+		{
+			Query:    `select A | filter.lowest_mean(4) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling", "rising", "medium", "high"},
+		},
+		{
+			Query:    `select A | filter.lowest_mean(3) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling", "rising", "medium"},
+		},
+		{
+			Query:    `select A | filter.lowest_mean(2) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling", "rising"},
+		},
+		{
+			Query:    `select A | filter.lowest_mean(1) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling"},
+		},
+		// Highest recent mean vs. highest mean (B)
+		{
+			Query:    `select B | filter.highest_mean(4) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "falling", "high-low", "low-high"},
+		},
+		{ // 3000s is more than the request interval, so it will not change the answer.
+			Query:    `select B | filter.highest_mean(4, 3000s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "falling", "high-low", "low-high"},
+		},
+		{ // 150s is only the second half.
+			Query:    `select B | filter.highest_mean(4, 150s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "low-high", "falling", "high-low"},
+		},
+		// Now use "above" and "below" instead of "count"
+		// Mean above (A)
+		{
+			Query:    `select A | filter.mean_above(0) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "medium", "rising", "falling"},
+		},
+		{
+			Query:    `select A | filter.mean_above(4.45) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "medium", "rising"},
+		},
+		{
+			Query:    `select A | filter.mean_above(4.55) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "medium"},
+		},
+		{
+			Query:    `select A | filter.mean_above(7) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high"},
+		},
+		{
+			Query:    `select A | filter.mean_above(12) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{},
+		},
+		// Mean below (A)
+		{
+			Query:    `select A | filter.mean_below(0) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{},
+		},
+		{
+			Query:    `select A | filter.mean_below(4.45) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling"},
+		},
+		{
+			Query:    `select A | filter.mean_below(4.55) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling", "rising"},
+		},
+		{
+			Query:    `select A | filter.mean_below(7) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling", "rising", "medium"},
+		},
+		{
+			Query:    `select A | filter.mean_below(12) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"falling", "rising", "medium", "high"},
+		},
+		// Mean above recent (B)
+		{
+			Query:    `select B | filter.mean_above(0, 150s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "low-high", "falling", "high-low"},
+		},
+		{
+			Query:    `select B | filter.mean_above(1, 150s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "low-high", "falling", "high-low"},
+		},
+		{
+			Query:    `select B | filter.mean_above(1, 120s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "low-high", "falling"},
+		},
+		{
+			Query:    `select B | filter.mean_above(4.45, 150s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high", "low-high"},
+		},
+		{
+			Query:    `select B | filter.mean_above(7, 150s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{"high"},
+		},
+		{
+			Query:    `select B | filter.mean_above(12, 150s) from 3000000 to 3270000 resolution 30s`,
+			Expected: []string{},
+		},
+	}
+	for _, test := range tests {
+		testCommand, err := parser.Parse(test.Query)
+		if err != nil {
+			t.Errorf("Error parsing test query %q: %s", test.Query, err.Error())
+			continue
+		}
+		rawResult, err := testCommand.Execute(command.ExecutionContext{
+			TimeseriesStorageAPI: comboAPI,
+			MetricMetadataAPI:    comboAPI,
+			FetchLimit:           1000,
+			Timeout:              100 * time.Millisecond,
+		})
+		if err != nil {
+			t.Errorf("Error evaluating query %q: %s", test.Query, err.Error())
+			continue
+		}
+		list := rawResult.Body.([]command.QuerySeriesList)[0]
+		tags := make([]string, len(list.Series))
+		for i, series := range list.Series {
+			tags[i] = series.TagSet["foo"]
+		}
+		a.Contextf("Query %q", test.Query).Eq(tags, test.Expected)
+	}
+}

--- a/query/tests/command_select_test.go
+++ b/query/tests/command_select_test.go
@@ -150,7 +150,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(3, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.highest_max(3, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
@@ -166,7 +166,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(2, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.highest_max(2, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
@@ -178,7 +178,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(1, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.highest_max(1, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
@@ -186,23 +186,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_lowest_max(3, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
-			Series: []api.Timeseries{
-				{
-					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
-				},
-				{
-					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
-				},
-				{
-					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
-				},
-			},
-		}}},
-		{"select series_3 | filter.recent_lowest_max(4, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(3, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
@@ -218,7 +202,23 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(70, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(4, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+			Series: []api.Timeseries{
+				{
+					Values: []float64{5, 5, 5, 2, 2},
+					TagSet: api.ParseTagSet("dc=east"),
+				},
+				{
+					Values: []float64{3, 3, 3, 3, 3},
+					TagSet: api.ParseTagSet("dc=north"),
+				},
+				{
+					Values: []float64{1, 1, 1, 4, 4},
+					TagSet: api.ParseTagSet("dc=west"),
+				},
+			},
+		}}},
+		{"select series_3 | filter.highest_max(70, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
@@ -234,7 +234,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_lowest_max(2, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(2, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
@@ -246,7 +246,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_lowest_max(1, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(1, 30ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
@@ -254,7 +254,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.highest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
@@ -270,7 +270,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.highest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
@@ -282,7 +282,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_highest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.highest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
@@ -290,7 +290,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_lowest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(3, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{3, 3, 3, 3, 3},
@@ -306,7 +306,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_lowest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(2, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{3, 3, 3, 3, 3},
@@ -318,7 +318,7 @@ func TestCommand_Select(t *testing.T) {
 				},
 			},
 		}}},
-		{"select series_3 | filter.recent_lowest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
+		{"select series_3 | filter.lowest_max(1, 3000ms) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{3, 3, 3, 3, 3},

--- a/testing_support/mocks/combo_api.go
+++ b/testing_support/mocks/combo_api.go
@@ -70,7 +70,7 @@ var _ metadata.MetricAPI = FakeComboAPI{}
 
 func (fapi FakeComboAPI) ChooseResolution(requested api.Timerange, smallestResolution time.Duration) time.Duration {
 	if fapi.timerange.Resolution() < smallestResolution {
-		//	panic("ChooseResolution is too coarse for FakeComboAPI instance.")
+		panic("ChooseResolution is too coarse for FakeComboAPI instance.")
 	}
 	return fapi.timerange.Resolution()
 }

--- a/testing_support/mocks/combo_api.go
+++ b/testing_support/mocks/combo_api.go
@@ -1,0 +1,135 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/metric_metadata"
+	"github.com/square/metrics/timeseries"
+)
+
+type FakeComboAPI struct {
+	timerange api.Timerange
+	metrics   map[api.MetricKey][]api.Timeseries
+}
+
+func (fapi FakeComboAPI) AddMetric(metric api.TaggedMetric, context metadata.Context) error {
+	return fmt.Errorf("cannot add metrics to FakeComboAPI")
+}
+func (fapi FakeComboAPI) AddMetrics(metrics []api.TaggedMetric, context metadata.Context) error {
+	return fmt.Errorf("cannot add metrics to FakeComboAPI")
+}
+func (fapi FakeComboAPI) GetAllTags(metric api.MetricKey, context metadata.Context) ([]api.TagSet, error) {
+	list := fapi.metrics[metric]
+	tagsets := []api.TagSet{}
+	for _, timeseries := range list {
+		tagsets = append(tagsets, timeseries.TagSet)
+	}
+	return tagsets, nil
+}
+func (fapi FakeComboAPI) GetAllMetrics(context metadata.Context) ([]api.MetricKey, error) {
+	metrics := []api.MetricKey{}
+	for metric := range fapi.metrics {
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}
+func (fapi FakeComboAPI) GetMetricsForTag(tagKey string, tagValue string, context metadata.Context) ([]api.MetricKey, error) {
+	metrics := []api.MetricKey{}
+	for metric, list := range fapi.metrics {
+		for _, series := range list {
+			if series.TagSet[tagKey] == tagValue {
+				metrics = append(metrics, metric)
+				break
+			}
+		}
+	}
+	return metrics, nil
+}
+func (fapi FakeComboAPI) CheckHealthy() error {
+	return nil
+}
+
+var _ metadata.MetricAPI = FakeComboAPI{}
+
+func (fapi FakeComboAPI) ChooseResolution(requested api.Timerange, smallestResolution time.Duration) time.Duration {
+	if fapi.timerange.Resolution() < smallestResolution {
+		//	panic("ChooseResolution is too coarse for FakeComboAPI instance.")
+	}
+	return fapi.timerange.Resolution()
+}
+
+func (fapi FakeComboAPI) FetchSingleTimeseries(request timeseries.FetchRequest) (api.Timeseries, error) {
+	for _, series := range fapi.metrics[request.Metric.MetricKey] {
+		if !series.TagSet.Equals(request.Metric.TagSet) {
+			continue
+		}
+		result := api.Timeseries{
+			Values: make([]float64, request.Timerange.Slots()),
+			TagSet: request.Metric.TagSet,
+		}
+		// Initialize to NaN.
+		for i := range result.Values {
+			result.Values[i] = math.NaN()
+		}
+		// Iterate over the series, and assign each point in the result.
+		for i := range series.Values {
+			ri := request.Timerange.IndexOfTime(fapi.timerange.TimeOfIndex(i))
+			if ri >= 0 && ri < len(result.Values) {
+				result.Values[ri] = series.Values[i]
+			}
+		}
+		return result, nil
+	}
+	return api.Timeseries{}, fmt.Errorf("no such metric %s with tagset %+v", request.Metric.MetricKey, request.Metric.TagSet)
+}
+
+func (fapi FakeComboAPI) FetchMultipleTimeseries(multiRequest timeseries.FetchMultipleRequest) (api.SeriesList, error) {
+	requests := multiRequest.ToSingle()
+	seriesList := api.SeriesList{
+		Series:    make([]api.Timeseries, len(requests)),
+		Timerange: multiRequest.Timerange,
+	}
+	for i, request := range requests {
+		timeseries, err := fapi.FetchSingleTimeseries(request)
+		if err != nil {
+			return api.SeriesList{}, err
+		}
+		seriesList.Series[i] = timeseries
+	}
+	return seriesList, nil
+}
+
+func NewComboAPI(timerange api.Timerange, timeseries ...api.Timeseries) FakeComboAPI {
+	result := FakeComboAPI{
+		timerange,
+		map[api.MetricKey][]api.Timeseries{},
+	}
+	for _, series := range timeseries {
+		if len(series.Values) != timerange.Slots() {
+			panic("NewComboAPI given series with wrong number of values.")
+		}
+		if _, ok := series.TagSet["metric"]; !ok {
+			panic("NewCombiAPI expects that every series has a `metric` tag")
+		}
+		result.metrics[api.MetricKey(series.TagSet["metric"])] = append(result.metrics[api.MetricKey(series.TagSet["metric"])], series)
+		delete(series.TagSet, "metric")
+	}
+	return result
+}


### PR DESCRIPTION
# Threshold Filtering

You can now say:

```
select
cpu | filter.mean_above(25, 1hr)
```

to select all CPU timeseries whose mean in the last hour is above 25. Or, just

```
select
cpu | filter.mean_above(25)
```

to only use the currently queried time interval.

# This is a breaking change!

Instead of having both functions

```
filter.highest_max(series, count)
filter.recent_highest_max( series, count, duration )
```

this PR replaces them with the new definition for `filter.highest_max`:

```
filter.highest_max( series, count [, duration] )
```

which now acts as both versions.

@drcapulet @syamp 