### PR TITLE
Add hard limit on request size

### DIFF
--- a/function/expression.go
+++ b/function/expression.go
@@ -24,6 +24,7 @@ type EvaluationContext struct {
 	SampleMethod          api.SampleMethod         // SampleMethod to use when up/downsampling to match the requested resolution
 	Predicate             api.Predicate            // Predicate to apply to TagSets prior to fetching
 	FetchLimit            FetchCounter             // A limit on the number of fetches which may be performed
+	SlotLimit             int                      // A limit on the number of slots in one fetched metric
 	Cancellable           api.Cancellable
 	Registry              Registry
 	Profiler              *inspect.Profiler // A profiler pointer

--- a/query/command.go
+++ b/query/command.go
@@ -222,6 +222,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 	evaluationContext := function.EvaluationContext{
 		MetricMetadataAPI:     context.MetricMetadataAPI,
 		FetchLimit:            function.NewFetchCounter(context.FetchLimit),
+		SlotLimit:             context.SlotLimit * 10, // 10x buffer for intermediate requests
 		TimeseriesStorageAPI:  context.TimeseriesStorageAPI,
 		Predicate:             cmd.predicate,
 		SampleMethod:          cmd.context.SampleMethod,

--- a/query/expression.go
+++ b/query/expression.go
@@ -37,6 +37,11 @@ func (expr stringExpression) Evaluate(context function.EvaluationContext) (funct
 }
 
 func (expr *metricFetchExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
+	// If there's too many points, reject the query.
+	if context.Timerange.Slots() > context.SlotLimit && context.SlotLimit != 0 {
+		return nil, function.NewLimitError("fetch slot limit exceeded", context.Timerange.Slots(), context.SlotLimit)
+	}
+
 	// Merge predicates appropriately
 	var predicate api.Predicate
 	if context.Predicate == nil && expr.predicate == nil {

--- a/query/expression_test.go
+++ b/query/expression_test.go
@@ -87,6 +87,7 @@ func Test_ScalarExpression(t *testing.T) {
 			Timerange:            test.timerange,
 			SampleMethod:         api.SampleMean,
 			FetchLimit:           function.NewFetchCounter(1000),
+			SlotLimit:            28800,
 			Registry:             registry.Default(),
 		})
 
@@ -110,6 +111,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 		SampleMethod:         api.SampleMean,
 		Predicate:            nil,
 		FetchLimit:           function.NewFetchCounter(1000),
+		SlotLimit:            28800,
 		Cancellable:          api.NewCancellable(),
 	}
 	for _, test := range []struct {

--- a/query/transformation_test.go
+++ b/query/transformation_test.go
@@ -80,6 +80,7 @@ func TestMovingAverage(t *testing.T) {
 			Timerange:            timerange,
 			SampleMethod:         api.SampleMean,
 			FetchLimit:           function.NewFetchCounter(1000),
+			SlotLimit:            28800,
 			Registry:             registry.Default(),
 			Cancellable:          api.NewCancellable(),
 		})


### PR DESCRIPTION
This enforces a limit on the size of a fetchable query.

The slot limit prevents you from writing (for example)

```
select cpu.percent
from -300yr to now
```

but it doesn't prevent you from writing
```
select cpu.percent | transform.moving_average(300yr)
from -1d to now
```

which both perform similar amounts of fetching.

This PR places a hard limit on the length of a single request. In particular, it's 10x whatever the regular slot limit is- so if you're only allowed 2,000 points in a regular query, an intermediate query (moving average or forecast fetch) can only contain up to 20,000 points.

TODO: add tests

TODO: also do this for numbers