### PR TITLE
Add scalar arithmetic

### DIFF
--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -286,6 +286,10 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 					if errLeftDuration == nil && errRightDuration == nil {
 						return function.ScalarValue(operator(float64(leftDuration), float64(rightDuration))), nil
 					}
+					// Or, the right is a scalar
+					if errLeftDuration == nil && errRightScalar == nil {
+						return function.DurationValue(time.Duration(operator(float64(leftDuration), rightScalar))), nil
+					}
 				}
 			}
 

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
@@ -251,6 +252,43 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 			}
 			leftValue := evaluated[0]
 			rightValue := evaluated[1]
+
+			leftScalar, errLeftScalar := leftValue.ToScalar("left operand scalar")
+			rightScalar, errRightScalar := rightValue.ToScalar("right operand scalar")
+
+			leftDuration, errLeftDuration := leftValue.ToDuration("left operand duration")
+			rightDuration, errRightDuration := rightValue.ToDuration("right operand duration")
+
+			// Handles the two-scalar case.
+			if errLeftScalar == nil && errRightScalar == nil {
+				return function.ScalarValue(operator(leftScalar, rightScalar)), nil
+			}
+
+			if (errLeftScalar == nil || errLeftDuration == nil) && (errRightScalar == nil || errRightDuration == nil) {
+				// both are number-types
+				switch op {
+				case "+", "-":
+					// Input units must match, output has the same units.
+					if errLeftDuration == nil && errRightDuration == nil {
+						// Convert to floats, then convert back.
+						return function.DurationValue(time.Duration(operator(float64(leftDuration), float64(rightDuration)))), nil
+					}
+				case "*":
+					// One of the input units must be a scalar, output has units of the other.
+					if errLeftScalar == nil && errRightDuration == nil {
+						return function.DurationValue(time.Duration(operator(leftScalar, float64(rightDuration)))), nil
+					}
+					if errLeftDuration == nil && errRightScalar == nil {
+						return function.DurationValue(time.Duration(operator(float64(leftDuration), rightScalar))), nil
+					}
+				case "/":
+					// Input units must match, output is scalar.
+					if errLeftDuration == nil && errRightDuration == nil {
+						return function.ScalarValue(operator(float64(leftDuration), float64(rightDuration))), nil
+					}
+				}
+			}
+
 			leftList, err := leftValue.ToSeriesList(context.Timerange, args[0].QueryString())
 			if err != nil {
 				return nil, err

--- a/function/value.go
+++ b/function/value.go
@@ -79,14 +79,7 @@ func (value ScalarValue) ToDuration(description string) (time.Duration, error) {
 	return 0, api.ConversionError{"scalar", "duration", description}
 }
 
-type DurationValue struct {
-	name     string
-	duration time.Duration
-}
-
-func NewDurationValue(name string, duration time.Duration) DurationValue {
-	return DurationValue{name, duration}
-}
+type DurationValue time.Duration
 
 func (value DurationValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
 	return api.SeriesList{}, api.ConversionError{"duration", "SeriesList", description}
@@ -101,7 +94,7 @@ func (value DurationValue) ToScalar(description string) (float64, error) {
 }
 
 func (value DurationValue) ToDuration(description string) (time.Duration, error) {
-	return time.Duration(value.duration), nil
+	return time.Duration(value), nil
 }
 
 var durationRegexp = regexp.MustCompile(`^([+-]?[0-9]+)([smhdwMy]|ms|hr|mo|yr)$`)

--- a/query/expression.go
+++ b/query/expression.go
@@ -25,7 +25,7 @@ import (
 // ===============
 
 func (expr durationExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return function.NewDurationValue(expr.name, expr.duration), nil
+	return function.DurationValue(expr.duration), nil
 }
 
 func (expr scalarExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {


### PR DESCRIPTION
Now you can do (for example):

```
select
cpu.percent | transform.moving_average(2d * 4)
```

TODO: tests

Note: this isn't very useful by itself, but there are some ideas that may be interesting to try in the future for more complicated queries that involve calculating summary values from metrics.