### PR TITLE
Fix unintentionally creating lots of goroutines with cached metadata

### DIFF
--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -84,6 +84,16 @@ func main() {
 		TimeToLive:   time.Minute * 5, // Cache items invalidated after 5 minutes.
 		RequestLimit: 500,
 	})
+	for i := 0; i < 10; i++ {
+		go func() {
+			for {
+				err := optimizedMetadataAPI.PerformBackgroundRequest(api.MetricMetadataAPIContext{})
+				if err != nil {
+					log.Errorf("Error performing background cache-update: %s", err.Error())
+				}
+			}
+		}()
+	}
 
 	//Defaults
 	userConfig := api.UserSpecifiableConfig{


### PR DESCRIPTION
A huge number of goroutines could be spawned to perform background requests. (They wouldn't actually "leak" because they'd eventually either be handled or dropped, but this is still a waste of resources).

Now the `CachedMetricMetadataAPI` no longer spawns goroutines. Instead, the consumer of the API instance has to invoke the `.PerformBackgroundRequest() error` method explicitly. This is a blocking method, so the caller should do something like this:

```

cachedAPI := cached_metadata.NewCachedMetricMetadataAPI(underlyingAPI, cached_metadata.Config {
    TimeToLive: time.Hour * 2,
    RequestLimit: 500,
})

for i := 0; i < 10; i++ {
    go func() {
        for {
            err := cachedAPI.PerformBackgroundRequest(
                api.MetricMetadataContext{Profile: profiler}
            )
            if err != nil {
                log.Errorf("Error performing background request: %s", err.Error())
            }
        }
    }() 
}
```

Background requests are served on a first-come, first-served basis. If there are too many, then the most recent ones will be dropped (they are stored in a channel). In particular, this won't cause calls to `cached.GetAllTags(metric, context)` to block any longer than normal.

@syamp @drcapulet 