### PR TITLE
Update interface for background actions in CachedMetricMetadataAPI

### DIFF
--- a/main/ui/ui.go
+++ b/main/ui/ui.go
@@ -87,7 +87,7 @@ func main() {
 	for i := 0; i < 10; i++ {
 		go func() {
 			for {
-				err := optimizedMetadataAPI.PerformBackgroundRequest(api.MetricMetadataAPIContext{})
+				err := optimizedMetadataAPI.GetBackgroundAction()(api.MetricMetadataAPIContext{})
 				if err != nil {
 					log.Errorf("Error performing background cache-update: %s", err.Error())
 				}

--- a/metric_metadata/cached_metadata/cached_test.go
+++ b/metric_metadata/cached_metadata/cached_test.go
@@ -87,7 +87,7 @@ func TestCached(t *testing.T) {
 	a.CheckError(err)
 	a.Eq(tags, []api.TagSet{{"foo": "one"}}) // still read from cache
 
-	cached.PerformBackgroundRequest(api.MetricMetadataAPIContext{}) // updates cache
+	a.CheckError(cached.GetBackgroundAction()(api.MetricMetadataAPIContext{})) // updates cache
 
 	tags, err = cached.GetAllTags("metric_one", api.MetricMetadataAPIContext{})
 	a.CheckError(err)
@@ -95,11 +95,11 @@ func TestCached(t *testing.T) {
 
 	a.EqInt(cached.CurrentLiveRequests(), 2)
 
-	cached.PerformBackgroundRequest(api.MetricMetadataAPIContext{}) // updates cache
+	a.CheckError(cached.GetBackgroundAction()(api.MetricMetadataAPIContext{})) // updates cache
 
 	a.EqInt(cached.CurrentLiveRequests(), 1)
 
-	cached.PerformBackgroundRequest(api.MetricMetadataAPIContext{}) // updates cache
+	a.CheckError(cached.GetBackgroundAction()(api.MetricMetadataAPIContext{})) // updates cache
 
 	a.EqInt(cached.CurrentLiveRequests(), 0)
 
@@ -146,9 +146,9 @@ func TestQueueSize(t *testing.T) {
 		a.EqInt(cached.CurrentLiveRequests(), 3)
 	}
 
-	cached.PerformBackgroundRequest(api.MetricMetadataAPIContext{})
-	cached.PerformBackgroundRequest(api.MetricMetadataAPIContext{})
-	cached.PerformBackgroundRequest(api.MetricMetadataAPIContext{})
+	a.CheckError(cached.GetBackgroundAction()(api.MetricMetadataAPIContext{}))
+	a.CheckError(cached.GetBackgroundAction()(api.MetricMetadataAPIContext{}))
+	a.CheckError(cached.GetBackgroundAction()(api.MetricMetadataAPIContext{}))
 
 	a.EqInt(cached.CurrentLiveRequests(), 0)
 


### PR DESCRIPTION
Replace `.PerformBackgroundRequest(api.MetricMetadataAPIContext) error` with `.GetBackgroundAction() func(api.MetricMetadataAPIContext) error`

@drcapulet 