### PR TITLE
Add CheckHealthy methods for metadata.MetricAPI and timeseries.StorageAPI

### DIFF
--- a/metric_metadata/api.go
+++ b/metric_metadata/api.go
@@ -39,4 +39,6 @@ type MetricAPI interface {
 	// GetMetricsForTag takes a tag key-value pair and returnsthe list of all the
 	// MetricKeys associated with them.
 	GetMetricsForTag(tagKey, tagValue string, context Context) ([]api.MetricKey, error)
+	// CheckHealthy checks if this MetricAPI is healthy, returning a possible error
+	CheckHealthy() error
 }

--- a/metric_metadata/cached/cached.go
+++ b/metric_metadata/cached/cached.go
@@ -106,6 +106,11 @@ func (c *CachedMetricMetadataAPI) GetMetricsForTag(tagKey, tagValue string, cont
 	return c.metricMetadataAPI.GetMetricsForTag(tagKey, tagValue, context)
 }
 
+// CheckHealthy checks if the underlying MetricAPI is healthy
+func (c *CachedMetricMetadataAPI) CheckHealthy() error {
+	return c.metricMetadataAPI.CheckHealthy()
+}
+
 // getCachedTagSet is a thread-safe way to get the cached data for a metric (protected by a mutex)
 func (c *CachedMetricMetadataAPI) getCachedTagSet(metricKey api.MetricKey) CachedTagSetList {
 	c.mutex.Lock()

--- a/metric_metadata/cached/cached_test.go
+++ b/metric_metadata/cached/cached_test.go
@@ -49,6 +49,11 @@ func (c *testAPI) GetMetricsForTag(tagKey, tagValue string, context metadata.Con
 	panic("unimplemented")
 }
 
+// CheckHealthy checks if the underlying MetricMetadataAPI is healthy
+func (c *testAPI) CheckHealthy() error {
+	panic("unimplemented")
+}
+
 func (c *testAPI) GetAllTags(metricKey api.MetricKey, context metadata.Context) ([]api.TagSet, error) {
 	defer func() { c.finished <- string(metricKey) }()
 

--- a/metric_metadata/cassandra/cassandra.go
+++ b/metric_metadata/cassandra/cassandra.go
@@ -93,6 +93,11 @@ func (a *MetricMetadataAPI) GetAllMetrics(context metadata.Context) ([]api.Metri
 	return a.db.GetAllMetrics()
 }
 
+// CheckHealthy checks if the underlying connection to Cassandra is healthy
+func (a *MetricMetadataAPI) CheckHealthy() error {
+	return a.db.CheckHealthy()
+}
+
 type cassandraDatabase struct {
 	session *gocql.Session
 }
@@ -220,4 +225,9 @@ func (db *cassandraDatabase) RemoveFromTagIndex(tagKey string, tagValue string, 
 		tagKey,
 		tagValue,
 	).Exec()
+}
+
+// CheckHealthy checks if the connection to Cassandra is healthy
+func (db *cassandraDatabase) CheckHealthy() error {
+	return db.session.Query("SELECT now() FROM system.local").Exec()
 }

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -110,6 +110,11 @@ MetricLoop:
 	return list, nil
 }
 
+// CheckHealthy checks if the FakeMetricMetadataAPI is healthy
+func (fa *FakeMetricMetadataAPI) CheckHealthy() error {
+	return nil
+}
+
 type FakeGraphiteConverter struct {
 	MetricMap map[util.GraphiteMetric]api.TaggedMetric
 }
@@ -184,4 +189,8 @@ func (f FakeTimeseriesStorageAPI) FetchMultipleTimeseries(request timeseries.Fet
 		Series:    timeseries,
 		Timerange: request.Timerange,
 	}, nil
+}
+
+func (f FakeTimeseriesStorageAPI) CheckHealthy() error {
+	return nil
 }

--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -288,7 +288,26 @@ func (b *Blueflood) FetchSingleTimeseries(request timeseries.FetchRequest) (api.
 			TagSet: request.Metric.TagSet,
 		}, nil
 	}
+}
 
+// CheckHealthy checks if the blueflood server is available by querying /v2.0
+func (b *Blueflood) CheckHealthy() error {
+	resp, err := b.client.Get(fmt.Sprintf("%s/v2.0", b.config.BaseURL))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Blueflood returned an unhealthy status of %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
 }
 
 // Helper functions

--- a/timeseries/interface.go
+++ b/timeseries/interface.go
@@ -27,6 +27,8 @@ type StorageAPI interface {
 	ChooseResolution(requested api.Timerange, smallestResolution time.Duration) time.Duration
 	FetchSingleTimeseries(request FetchRequest) (api.Timeseries, error)
 	FetchMultipleTimeseries(request FetchMultipleRequest) (api.SeriesList, error)
+	// CheckHealthy checks if this StorageAPI is healthy, returning a possible error
+	CheckHealthy() error
 }
 
 type RequestDetails struct {


### PR DESCRIPTION
Although the server won't boot up without being able to talk to Cassandra, if if goes away it'd be nice to be able to check the status of the underlying connections in the MetricMetadataAPI.

R: @Nathan-Fenner || @syamp