### PR TITLE
Return an empty channel on a nil Timeout

### DIFF
--- a/tasks/canceller.go
+++ b/tasks/canceller.go
@@ -52,6 +52,10 @@ type Timeout struct {
 
 // Done returns a receive-only channel, which will close when the timeout ends.
 func (t *Timeout) Done() <-chan struct{} {
+	if t == nil {
+		return nil
+	}
+
 	return t.done
 }
 


### PR DESCRIPTION
Causing a nil pointer dereference error with an empty `TimeoutOwner`.

R: @Nathan-Fenner 