### PR TITLE
use MakeFunction in place of explicit MetricFunction everywhere possible

### DIFF
--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -14,34 +14,9 @@
 
 package api
 
-import (
-	"fmt"
-	"time"
-)
-
 // SeriesList is a list of time series sharing the same time range.
 // this struct must satisfy the `function.Value` interface. However, a type assertion
 // cannot be held here due to a circular import.
 type SeriesList struct {
 	Series []Timeseries `json:"series"`
-}
-
-// ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.
-func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
-	return list, nil
-}
-
-// ToString is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToString() (string, error) {
-	return "", fmt.Errorf("cannot convert %s (type SeriesList) to type string", "")
-}
-
-// ToScalar is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToScalar() (float64, error) {
-	return 0, fmt.Errorf("cannot convert value of type series list to type scalar")
-}
-
-// ToDuration is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToDuration() (time.Duration, error) {
-	return 0, fmt.Errorf("cannot convert value of type series list to type duration")
 }

--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -27,7 +27,7 @@ type SeriesList struct {
 }
 
 // ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.
-func (list SeriesList) ToSeriesList(time Timerange, description string) (SeriesList, error) {
+func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
 	return list, nil
 }
 

--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -32,16 +32,16 @@ func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
 }
 
 // ToString is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToString(description string) (string, error) {
-	return "", fmt.Errorf("cannot convert %s (type SeriesList) to type string", description)
+func (list SeriesList) ToString() (string, error) {
+	return "", fmt.Errorf("cannot convert %s (type SeriesList) to type string", "")
 }
 
 // ToScalar is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToScalar(description string) (float64, error) {
-	return 0, fmt.Errorf("cannot convert %s (type SeriesList) to type scalar", description)
+func (list SeriesList) ToScalar() (float64, error) {
+	return 0, fmt.Errorf("cannot convert value of type series list to type scalar")
 }
 
 // ToDuration is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToDuration(description string) (time.Duration, error) {
-	return 0, fmt.Errorf("cannot convert %s (type SeriesList) to type duration", description)
+func (list SeriesList) ToDuration() (time.Duration, error) {
+	return 0, fmt.Errorf("cannot convert value of type series list to type duration")
 }

--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -15,8 +15,6 @@
 package api
 
 // SeriesList is a list of time series sharing the same time range.
-// this struct must satisfy the `function.Value` interface. However, a type assertion
-// cannot be held here due to a circular import.
 type SeriesList struct {
 	Series []Timeseries `json:"series"`
 }

--- a/function/expression.go
+++ b/function/expression.go
@@ -190,7 +190,7 @@ func EvaluateToSeriesList(e Expression, context EvaluationContext) (api.SeriesLi
 	if err != nil {
 		return api.SeriesList{}, err
 	}
-	return seriesValue.ToSeriesList(context.Timerange, e.QueryString())
+	return seriesValue.ToSeriesList(context.Timerange)
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a string.

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,7 +15,6 @@
 package function
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -135,9 +134,9 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	if err != nil {
 		return 0, err
 	}
-	value, err := scalarValue.ToScalar()
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	value, convErr := scalarValue.ToScalar()
+	if convErr != nil {
+		return 0, convErr.WithContext(e.QueryString())
 	}
 	return value, nil
 }
@@ -148,9 +147,9 @@ func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration,
 	if err != nil {
 		return 0, err
 	}
-	value, err := durationValue.ToDuration()
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	value, convErr := durationValue.ToDuration()
+	if convErr != nil {
+		return 0, convErr.WithContext(e.QueryString())
 	}
 	return value, nil
 }
@@ -161,7 +160,11 @@ func EvaluateToSeriesList(e Expression, context EvaluationContext) (api.SeriesLi
 	if err != nil {
 		return api.SeriesList{}, err
 	}
-	return seriesValue.ToSeriesList(context.Timerange)
+	value, convErr := seriesValue.ToSeriesList(context.Timerange)
+	if convErr != nil {
+		return api.SeriesList{}, convErr.WithContext(e.QueryString())
+	}
+	return value, nil
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a string.
@@ -170,9 +173,9 @@ func EvaluateToString(e Expression, context EvaluationContext) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	value, err := stringValue.ToString()
-	if err != nil {
-		return "", fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	value, convErr := stringValue.ToString()
+	if convErr != nil {
+		return "", convErr.WithContext(e.QueryString())
 	}
 	return value, nil
 }

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -134,7 +135,11 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	if err != nil {
 		return 0, err
 	}
-	return scalarValue.ToScalar(e.QueryString())
+	value, err := scalarValue.ToScalar()
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	}
+	return value, nil
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a duration.
@@ -143,7 +148,11 @@ func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration,
 	if err != nil {
 		return 0, err
 	}
-	return durationValue.ToDuration(e.QueryString())
+	value, err := durationValue.ToDuration()
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	}
+	return value, nil
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a series list.
@@ -161,7 +170,11 @@ func EvaluateToString(e Expression, context EvaluationContext) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return stringValue.ToString(e.QueryString())
+	value, err := stringValue.ToString()
+	if err != nil {
+		return "", fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	}
+	return value, nil
 }
 
 // EvaluateMany evaluates a list of expressions using a single EvaluationContext.

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,7 +15,6 @@
 package function
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -75,53 +74,10 @@ func (notes *EvaluationNotes) Notes() []string {
 	return notes.notes
 }
 
-// The Function interface defines a metric function.
-// It is given several (unevaluated) expressions as input, and evaluates to a Value.
-type Function interface {
-	Run(EvaluationContext, []Expression, Groups) (Value, error)
-}
-
-// The Registry interface defines a mapping from names to Functions
-// and provides a way to get the full list of functions defined.
-type Registry interface {
-	GetFunction(string) (Function, bool) // returns an instance of a Function
-	All() []string                       // all the registered functions
-}
-
-// Groups holds grouping information - which tags to group by (if any), and whether to `collapse` (Collapses = true) or `group` (Collapses = false)
-type Groups struct {
-	List      []string // the tags to group by
-	Collapses bool     // whether to "collapse by" instead of "group by"
-}
-
-// MetricFunction holds a generic function object with information about its parameters.
-type MetricFunction struct {
-	Name          string // Name is the name of the function, used in its registration.
-	MinArguments  int    // MinArguments is the minimum number of arguments the function allows.
-	MaxArguments  int    // MaxArguments is the maximum number of arguments the function allows. -1 indicates an unlimited number.
-	AllowsGroupBy bool   // Whether the function allows a 'group by' clause.
-	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
-}
-
 // WithTimerange duplicates the EvaluationContext but with a new timerange.
 func (e EvaluationContext) WithTimerange(t api.Timerange) EvaluationContext {
 	e.Timerange = t
 	return e
-}
-
-// Run evaluates the given MetricFunction on its arguments.
-// It performs error-checking against the supplies number of arguments and/or group-by clause.
-func (f MetricFunction) Run(context EvaluationContext, arguments []Expression, groups Groups) (Value, error) {
-	// preprocessing
-	length := len(arguments)
-	if length < f.MinArguments || (f.MaxArguments != -1 && f.MaxArguments < length) {
-		return nil, ArgumentLengthError{f.Name, f.MinArguments, f.MaxArguments, length}
-	}
-	if len(groups.List) > 0 && !f.AllowsGroupBy {
-		// TODO(jee) - use typed errors
-		return nil, fmt.Errorf("function %s doesn't allow a group-by clause", f.Name)
-	}
-	return f.Compute(context, arguments, groups)
 }
 
 // FetchCounter is used to count the number of fetches remaining in a thread-safe manner.

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -46,9 +46,9 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err // TODO: add decoration to describe it's coming from the anomaly function
 			}
-			prediction, err := predictionValue.ToSeriesList(context.Timerange)
-			if err != nil {
-				return nil, err
+			prediction, convErr := predictionValue.ToSeriesList(context.Timerange)
+			if convErr != nil {
+				return nil, convErr.WithContext("in anomaly function - model")
 			}
 			period, err := function.EvaluateToDuration(arguments[1], context)
 			if err != nil {
@@ -72,7 +72,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 				}
 			}
 			prediction.Series = result
-			return prediction, nil
+			return function.SeriesListValue(prediction), nil
 		},
 	}
 }

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -31,7 +31,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 		panic("FunctionAnomalyMaker requires that the model argument take at least two parameters; series and period.")
 	}
 	return function.MetricFunction{
-		Name:         name,
+		FunctionName: name,
 		MinArguments: model.MinArguments,
 		MaxArguments: model.MaxArguments,
 		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -46,7 +46,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err // TODO: add decoration to describe it's coming from the anomaly function
 			}
-			prediction, err := predictionValue.ToSeriesList(context.Timerange, "prediction series")
+			prediction, err := predictionValue.ToSeriesList(context.Timerange)
 			if err != nil {
 				return nil, err
 			}

--- a/function/forecast/drop_function.go
+++ b/function/forecast/drop_function.go
@@ -16,41 +16,29 @@ package forecast
 
 import (
 	"math"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 )
 
-var FunctionDrop = function.MetricFunction{
-	Name:         "forecast.drop",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		original, err := function.EvaluateToSeriesList(arguments[0], context)
-		if err != nil {
-			return nil, err
-		}
-		dropTime, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
-		result := make([]api.Timeseries, len(original.Series))
-		for i, series := range original.Series {
-			values := make([]float64, len(series.Values))
-			result[i] = series
-			for j := range values {
-				if float64(j) < lastValue {
-					values[j] = series.Values[j]
-				} else {
-					values[j] = math.NaN()
-				}
+var FunctionDrop = function.MakeFunction("forecast.drop", func(context function.EvaluationContext, original api.SeriesList, dropTime time.Duration) function.Value {
+	lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
+	result := make([]api.Timeseries, len(original.Series))
+	for i, series := range original.Series {
+		values := make([]float64, len(series.Values))
+		result[i] = series
+		for j := range values {
+			if float64(j) < lastValue {
+				values[j] = series.Values[j]
+			} else {
+				values[j] = math.NaN()
 			}
-			result[i].Values = values
 		}
+		result[i].Values = values
+	}
 
-		return api.SeriesList{
-			Series: result,
-		}, nil
-	},
-}
+	return api.SeriesList{
+		Series: result,
+	}
+})

--- a/function/forecast/drop_function.go
+++ b/function/forecast/drop_function.go
@@ -22,23 +22,26 @@ import (
 	"github.com/square/metrics/function"
 )
 
-var FunctionDrop = function.MakeFunction("forecast.drop", func(context function.EvaluationContext, original api.SeriesList, dropTime time.Duration) function.Value {
-	lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
-	result := make([]api.Timeseries, len(original.Series))
-	for i, series := range original.Series {
-		values := make([]float64, len(series.Values))
-		result[i] = series
-		for j := range values {
-			if float64(j) < lastValue {
-				values[j] = series.Values[j]
-			} else {
-				values[j] = math.NaN()
+var FunctionDrop = function.MakeFunction(
+	"forecast.drop",
+	func(context function.EvaluationContext, original api.SeriesList, dropTime time.Duration) api.SeriesList {
+		lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
+		result := make([]api.Timeseries, len(original.Series))
+		for i, series := range original.Series {
+			values := make([]float64, len(series.Values))
+			result[i] = series
+			for j := range values {
+				if float64(j) < lastValue {
+					values[j] = series.Values[j]
+				} else {
+					values[j] = math.NaN()
+				}
 			}
+			result[i].Values = values
 		}
-		result[i].Values = values
-	}
 
-	return api.SeriesList{
-		Series: result,
-	}
-})
+		return api.SeriesList{
+			Series: result,
+		}
+	},
+)

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -27,33 +27,12 @@ import (
 // The learning rates are interpreted as being "per period." For example, a value of 0.5 means that values in
 // this period are effectively weighted twice as much as those in the previous. A value of 0.9 means that values in
 // this period are weighted 1.0/(1.0 - 0.9) = 10 times as much as the previous.
-var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
-	Name:         "forecast.rolling_multiplicative_holt_winters",
-	MinArguments: 5, // Series, period, level learning rate,  trend learning rate, seasonal learning rate
-	MaxArguments: 6, // Series, period, level learning rate,  trend learning rate, seasonal learning rate, extra training time
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		period, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		levelLearningRate, err := function.EvaluateToScalar(arguments[2], context)
-		if err != nil {
-			return nil, err
-		}
-		trendLearningRate, err := function.EvaluateToScalar(arguments[3], context)
-		if err != nil {
-			return nil, err
-		}
-		seasonalLearningRate, err := function.EvaluateToScalar(arguments[4], context)
-		if err != nil {
-			return nil, err
-		}
+var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
+	"forecast.rolling_multiplicative_holt_winters",
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, levelLearningRate float64, trendLearningRate float64, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
 		extraTrainingTime := time.Duration(0)
-		if len(arguments) == 6 {
-			extraTrainingTime, err = function.EvaluateToDuration(arguments[5], context)
-			if err != nil {
-				return nil, err
-			}
+		if optionalExtraTrainingTime != nil {
+			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
 			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
@@ -66,7 +45,7 @@ var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
-		seriesList, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -85,30 +64,17 @@ var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
 
 		return result, nil
 	},
-}
+)
 
 // FunctionRollingSeasonal is a forecasting MetricFunction that performs the rolling seasonal estimation.
 // It is designed for data which shows seasonality without trends, although which a high learning rate it can
 // perform tolerably well on data with trends as well.
-var FunctionRollingSeasonal = function.MetricFunction{
-	Name:         "forecast.rolling_seasonal",
-	MinArguments: 3, // Series, period, seasonal learning rate
-	MaxArguments: 4, // Series, period, seasonal learning rate, extra training time
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		period, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		seasonalLearningRate, err := function.EvaluateToScalar(arguments[2], context)
-		if err != nil {
-			return nil, err
-		}
+var FunctionRollingSeasonal = function.MakeFunction(
+	"forecast.rolling_seasonal",
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
 		extraTrainingTime := time.Duration(0)
-		if len(arguments) == 4 {
-			extraTrainingTime, err = function.EvaluateToDuration(arguments[3], context)
-			if err != nil {
-				return nil, err
-			}
+		if optionalExtraTrainingTime != nil {
+			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
 			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
@@ -121,7 +87,7 @@ var FunctionRollingSeasonal = function.MetricFunction{
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
-		seriesList, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -140,23 +106,17 @@ var FunctionRollingSeasonal = function.MetricFunction{
 
 		return result, nil
 	},
-}
+)
 
 // FunctionForecastLinear forecasts with a simple linear regression.
 // For data which is mostly just a linear trend up or down, this will provide a good model of current behavior,
 // as well as a good estimate of near-future behavior.
-var FunctionForecastLinear = function.MetricFunction{
-	Name:         "forecast.linear",
-	MinArguments: 1, // Series
-	MaxArguments: 2, // Series, extra training time
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+var FunctionForecastLinear = function.MakeFunction(
+	"forecast.linear",
+	func(context function.EvaluationContext, seriesExpression function.Expression, optionalTrainingTime *time.Duration) (function.Value, error) {
 		extraTrainingTime := time.Duration(0)
-		if len(arguments) == 2 {
-			var err error
-			extraTrainingTime, err = function.EvaluateToDuration(arguments[1], context)
-			if err != nil {
-				return nil, err
-			}
+		if optionalTrainingTime != nil {
+			extraTrainingTime = *optionalTrainingTime
 		}
 		if extraTrainingTime < 0 {
 			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
@@ -164,7 +124,7 @@ var FunctionForecastLinear = function.MetricFunction{
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
-		seriesList, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -183,4 +143,4 @@ var FunctionForecastLinear = function.MetricFunction{
 
 		return result, nil
 	},
-}
+)

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -29,25 +29,25 @@ import (
 // this period are weighted 1.0/(1.0 - 0.9) = 10 times as much as the previous.
 var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 	"forecast.rolling_multiplicative_holt_winters",
-	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, levelLearningRate float64, trendLearningRate float64, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, levelLearningRate float64, trendLearningRate float64, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (api.SeriesList, error) {
 		extraTrainingTime := time.Duration(0)
 		if optionalExtraTrainingTime != nil {
 			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
-			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
+			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
 		samples := int(period / context.Timerange.Resolution())
 		if samples <= 0 {
-			return nil, fmt.Errorf("forecast.rolling_multiplicative_holt_winters expects the period parameter to mean at least one slot") // TODO: use a structured error
+			return api.SeriesList{}, fmt.Errorf("forecast.rolling_multiplicative_holt_winters expects the period parameter to mean at least one slot") // TODO: use a structured error
 		}
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		result := api.SeriesList{
@@ -71,25 +71,25 @@ var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 // perform tolerably well on data with trends as well.
 var FunctionRollingSeasonal = function.MakeFunction(
 	"forecast.rolling_seasonal",
-	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (api.SeriesList, error) {
 		extraTrainingTime := time.Duration(0)
 		if optionalExtraTrainingTime != nil {
 			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
-			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
+			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
 		samples := int(period / context.Timerange.Resolution())
 		if samples <= 0 {
-			return nil, fmt.Errorf("forecast.rolling_seasonal expects the period parameter to mean at least one slot") // TODO: use a structured error
+			return api.SeriesList{}, fmt.Errorf("forecast.rolling_seasonal expects the period parameter to mean at least one slot") // TODO: use a structured error
 		}
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		result := api.SeriesList{
@@ -113,20 +113,20 @@ var FunctionRollingSeasonal = function.MakeFunction(
 // as well as a good estimate of near-future behavior.
 var FunctionForecastLinear = function.MakeFunction(
 	"forecast.linear",
-	func(context function.EvaluationContext, seriesExpression function.Expression, optionalTrainingTime *time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, seriesExpression function.Expression, optionalTrainingTime *time.Duration) (api.SeriesList, error) {
 		extraTrainingTime := time.Duration(0)
 		if optionalTrainingTime != nil {
 			extraTrainingTime = *optionalTrainingTime
 		}
 		if extraTrainingTime < 0 {
-			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
+			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		result := api.SeriesList{

--- a/function/function.go
+++ b/function/function.go
@@ -1,0 +1,66 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import "fmt"
+
+// The Function interface defines a metric function.
+// It is given several (unevaluated) expressions as input, and evaluates to a Value.
+type Function interface {
+	Run(EvaluationContext, []Expression, Groups) (Value, error)
+	Name() string
+}
+
+// The Registry interface defines a mapping from names to Functions
+// and provides a way to get the full list of functions defined.
+type Registry interface {
+	GetFunction(string) (Function, bool) // returns an instance of a Function
+	All() []string                       // all the registered functions
+}
+
+// Groups holds grouping information - which tags to group by (if any), and whether to `collapse` (Collapses = true) or `group` (Collapses = false)
+type Groups struct {
+	List      []string // the tags to group by
+	Collapses bool     // whether to "collapse by" instead of "group by"
+}
+
+// MetricFunction holds a generic function object with information about its parameters.
+type MetricFunction struct {
+	FunctionName  string // Name is the name of the function, used in its registration.
+	MinArguments  int    // MinArguments is the minimum number of arguments the function allows.
+	MaxArguments  int    // MaxArguments is the maximum number of arguments the function allows. -1 indicates an unlimited number.
+	AllowsGroupBy bool   // Whether the function allows a 'group by' clause.
+	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
+}
+
+// Name returns the MetricFunction's name.
+func (metricFunc MetricFunction) Name() string {
+	return metricFunc.FunctionName
+}
+
+// Run evaluates the given MetricFunction on its arguments.
+// It performs error-checking against the supplies number of arguments and/or group-by clause.
+func (f MetricFunction) Run(context EvaluationContext, arguments []Expression, groups Groups) (Value, error) {
+	// preprocessing
+	length := len(arguments)
+	if length < f.MinArguments || (f.MaxArguments != -1 && f.MaxArguments < length) {
+		return nil, ArgumentLengthError{f.FunctionName, f.MinArguments, f.MaxArguments, length}
+	}
+	if len(groups.List) > 0 && !f.AllowsGroupBy {
+		// TODO(jee) - use typed errors
+		return nil, fmt.Errorf("function %s doesn't allow a group-by clause", f.FunctionName)
+	}
+	return f.Compute(context, arguments, groups)
+}

--- a/function/make.go
+++ b/function/make.go
@@ -209,9 +209,16 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 			if len(output) == 2 && output[1].Interface() != nil {
 				return nil, output[1].Interface().(error)
 			}
-			if funcType.Out(0) == timeseriesType {
+			switch funcType.Out(0) {
+			case stringType:
+				return StringValue(output[0].Interface().(string)), nil
+			case scalarType:
+				return ScalarValue(output[0].Interface().(float64)), nil
+			case durationType:
+				return DurationValue{"", output[0].Interface().(time.Duration)}, nil
+			case timeseriesType:
 				return SeriesListValue(output[0].Interface().(api.SeriesList)), nil
-			} else {
+			default:
 				return output[0].Interface().(Value), nil
 			}
 		},

--- a/function/make.go
+++ b/function/make.go
@@ -123,7 +123,7 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 				case valueType:
 					return expression.Evaluate(context)
 				}
-				panic("Unreachable :: Unknown type to evaluate to")
+				panic(fmt.Sprintf("Unreachable :: Attempting to evaluate to unknown type %+v", resultType))
 			}
 
 			// argumentFuncs holds functions to obtain the Value arguments.
@@ -168,7 +168,7 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 						argumentFuncs[i] = provideZeroValue(argType)
 					} else {
 						argumentFuncs[i] = func() (interface{}, error) {
-							resultI, err := evalTo(arg, argType)
+							resultI, err := evalTo(arg, argType.Elem())
 							if err != nil {
 								return nil, err
 							}

--- a/function/make.go
+++ b/function/make.go
@@ -1,0 +1,179 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/square/metrics/api"
+)
+
+var stringType = reflect.TypeOf("")
+var scalarType = reflect.TypeOf(float64(0.0))
+var durationType = reflect.TypeOf(time.Duration(0))
+var timeseriesType = reflect.TypeOf(api.SeriesList{})
+var valueType = reflect.TypeOf((*Value)(nil)).Elem()
+var expressionType = reflect.TypeOf((*Expression)(nil)).Elem()
+var groupsType = reflect.TypeOf(Groups{})
+var contextType = reflect.TypeOf(EvaluationContext{})
+var timerangeType = reflect.TypeOf(api.Timerange{})
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// MakeFunction is a convenient way to use type-safe functions to
+// construct MetricFunctions without manually checking parameters.
+func MakeFunction(name string, function interface{}) MetricFunction {
+	funcValue := reflect.ValueOf(function)
+	if funcValue.Kind() != reflect.Func {
+		panic("MetricFunction expects a function as input.")
+	}
+	funcType := funcValue.Type()
+	if funcType.NumOut() == 0 {
+		panic("MetricFunction's argument function must return a value.")
+	}
+	if funcType.NumOut() > 2 {
+		panic("MetricFunction's argument function must return at most two values.")
+	}
+	// TODO: allow subtypes
+	if !funcType.Out(0).ConvertibleTo(valueType) {
+		panic("MetricFunction's argument function's first return type must be assignable to `function.Value`")
+	}
+	if funcType.NumOut() == 2 && !funcType.Out(1).ConvertibleTo(errorType) {
+		panic("MetricFunction's argument function's second return type must be `error`.")
+	}
+
+	formalArgumentCount := 0
+	allowsGroupBy := false
+	for i := 0; i < funcType.NumIn(); i++ {
+		argType := funcType.In(i)
+		if argType == contextType || argType == timerangeType {
+			// It asks for context (or part of it).
+			continue
+		}
+		if argType == groupsType {
+			// It asks for groups.
+			allowsGroupBy = true
+			continue
+		}
+		formalArgumentCount++ // The next thing is an actual argument.
+		if argType == stringType || argType == scalarType || argType == durationType || argType == timeseriesType {
+			// Everything is okay
+			continue
+		}
+		if argType == valueType {
+			// It's untyped.
+			continue
+		}
+		if argType == expressionType {
+			// It's lazy.
+			continue
+		}
+		// TODO: handle optional arguments
+		panic(fmt.Sprintf("MetricFunction function argument asks for unsupported type: cannot supply argument %d of type %+v", i, argType))
+	}
+	// We've checked that everything is sound.
+	return MetricFunction{
+		Name:          name,
+		MinArguments:  formalArgumentCount,
+		MaxArguments:  formalArgumentCount,
+		AllowsGroupBy: allowsGroupBy,
+		Compute: func(context EvaluationContext, arguments []Expression, groups Groups) (Value, error) {
+			argValues := make([]reflect.Value, funcType.NumIn())
+			// TODO: evaluate in parallel where possible.
+			formalArgument := 0
+			for i := 0; i < funcType.NumIn(); i++ {
+				argType := funcType.In(i)
+				if argType == contextType {
+					argValues[i] = reflect.ValueOf(context)
+					continue
+				}
+				if argType == timerangeType {
+					argValues[i] = reflect.ValueOf(context.Timerange)
+					continue
+				}
+				if argType == groupsType {
+					argValues[i] = reflect.ValueOf(groups)
+					continue
+				}
+				if argType == stringType {
+					stringArg, err := EvaluateToString(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(stringArg)
+					formalArgument++
+					continue
+				}
+				if argType == scalarType {
+					scalarArg, err := EvaluateToScalar(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(scalarArg)
+					formalArgument++
+					continue
+				}
+				if argType == durationType {
+					durationArg, err := EvaluateToDuration(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(durationArg)
+					formalArgument++
+					continue
+				}
+				if argType == timeseriesType {
+					timeseriesArg, err := EvaluateToSeriesList(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(timeseriesArg)
+					formalArgument++
+					continue
+				}
+				if argType == valueType {
+					valueArg, err := arguments[formalArgument].Evaluate(context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(valueArg)
+					formalArgument++
+					continue
+				}
+				if argType == expressionType {
+					argValues[i] = reflect.ValueOf(arguments[formalArgument])
+					formalArgument++
+					continue
+				}
+				panic(fmt.Sprintf("Argument to MakeFunction requests invalid type %+v", argType))
+			}
+			output := funcValue.Call(argValues)
+			if len(output) == 1 {
+				return output[0].Interface().(Value), nil
+			}
+			if len(output) == 2 {
+				valueI, errI := output[0].Interface(), output[1].Interface()
+				if errI != nil {
+					return nil, errI.(error)
+				}
+				return valueI.(Value), nil
+			}
+			panic("MakeFunction built with function that doesn't return 2 things.")
+		},
+	}
+
+}

--- a/function/make.go
+++ b/function/make.go
@@ -66,7 +66,7 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 		argType := funcType.In(i)
 		switch argType {
 		case contextType, timerangeType:
-		// Asks for part of context.
+			// Asks for part of context.
 		case groupsType:
 			// asks for groups
 			allowsGroupBy = true

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -103,7 +103,7 @@ func Default() StandardRegistry {
 }
 
 // GetFunction returns a function associated with the given name, if it exists.
-func (r StandardRegistry) GetFunction(name string) (function.MetricFunction, bool) {
+func (r StandardRegistry) GetFunction(name string) (function.Function, bool) {
 	fun, ok := r.mapping[name]
 	return fun, ok
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -142,7 +142,7 @@ func MustRegister(fun function.Function) {
 
 // Constructor Functions
 
-// NewFilter creates a new instance of a filtering function.
+// NewFilterCount creates a new instance of a filtering function with count limit.
 func NewFilterCount(name string, summary func([]float64) float64, ascending bool) function.MetricFunction {
 	return function.MakeFunction(
 		name,
@@ -153,10 +153,10 @@ func NewFilterCount(name string, summary func([]float64) float64, ascending bool
 			}
 			duration := timerange.Duration()
 			if optionalDuration != nil {
-				if *optionalDuration < 0 {
-					return api.SeriesList{}, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
-				}
 				duration = *optionalDuration
+			}
+			if duration < 0 {
+				return api.SeriesList{}, fmt.Errorf("expected positive recent duration but got %+v", duration)
 			}
 			return filter.FilterByRecent(list, count, summary, ascending, 1+int(duration/timerange.Resolution())), nil
 		},
@@ -170,9 +170,6 @@ func NewFilterThreshold(name string, summary func([]float64) float64, below bool
 		func(list api.SeriesList, threshold float64, optionalDuration *time.Duration, timerange api.Timerange) (api.SeriesList, error) {
 			duration := timerange.Duration()
 			if optionalDuration != nil {
-				if *optionalDuration < 0 {
-					return api.SeriesList{}, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
-				}
 				duration = *optionalDuration
 			}
 			if duration < 0 {

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -44,15 +44,15 @@ func init() {
 	MustRegister(NewAggregate("aggregate.total", aggregate.Total))
 	MustRegister(NewAggregate("aggregate.count", aggregate.Count))
 	// Transformations
-	MustRegister(NewTransform("transform.integral", 0, transform.Integral))
-	MustRegister(NewTransform("transform.cumulative", 0, transform.Cumulative))
-	MustRegister(NewTransform("transform.nan_fill", 1, transform.Default))
-	MustRegister(NewTransform("transform.abs", 0, transform.MapMaker(math.Abs)))
-	MustRegister(NewTransform("transform.log", 0, transform.MapMaker(math.Log10)))
-	MustRegister(NewTransform("transform.nan_keep_last", 0, transform.NaNKeepLast))
-	MustRegister(NewTransform("transform.bound", 2, transform.Bound))
-	MustRegister(NewTransform("transform.lower_bound", 1, transform.LowerBound))
-	MustRegister(NewTransform("transform.upper_bound", 1, transform.UpperBound))
+	MustRegister(transform.Integral)
+	MustRegister(transform.Cumulative)
+	MustRegister(transform.Default)
+	MustRegister(transform.MapMaker("transform.abs", math.Abs))
+	MustRegister(transform.MapMaker("transform.log", math.Log10))
+	MustRegister(transform.NaNKeepLast)
+	MustRegister(transform.Bound)
+	MustRegister(transform.LowerBound)
+	MustRegister(transform.UpperBound)
 
 	// Filter
 	MustRegister(NewFilterCount("filter.highest_mean", aggregate.Mean, false))
@@ -146,15 +146,15 @@ func MustRegister(fun function.Function) {
 func NewFilterCount(name string, summary func([]float64) float64, ascending bool) function.MetricFunction {
 	return function.MakeFunction(
 		name,
-		func(list api.SeriesList, countFloat float64, optionalDuration *time.Duration, timerange api.Timerange) (function.Value, error) {
+		func(list api.SeriesList, countFloat float64, optionalDuration *time.Duration, timerange api.Timerange) (api.SeriesList, error) {
 			count := int(countFloat + 0.5)
 			if count < 0 {
-				return nil, fmt.Errorf("expected positive count but got %d", count)
+				return api.SeriesList{}, fmt.Errorf("expected positive count but got %d", count)
 			}
 			duration := timerange.Duration()
 			if optionalDuration != nil {
 				if *optionalDuration < 0 {
-					return nil, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
+					return api.SeriesList{}, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
 				}
 				duration = *optionalDuration
 			}
@@ -167,16 +167,16 @@ func NewFilterCount(name string, summary func([]float64) float64, ascending bool
 func NewFilterThreshold(name string, summary func([]float64) float64, below bool) function.MetricFunction {
 	return function.MakeFunction(
 		name,
-		func(list api.SeriesList, threshold float64, optionalDuration *time.Duration, timerange api.Timerange) (function.Value, error) {
+		func(list api.SeriesList, threshold float64, optionalDuration *time.Duration, timerange api.Timerange) (api.SeriesList, error) {
 			duration := timerange.Duration()
 			if optionalDuration != nil {
 				if *optionalDuration < 0 {
-					return nil, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
+					return api.SeriesList{}, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
 				}
 				duration = *optionalDuration
 			}
 			if duration < 0 {
-				return nil, fmt.Errorf("expected positive recent duration but got %+v", duration)
+				return api.SeriesList{}, fmt.Errorf("expected positive recent duration but got %+v", duration)
 			}
 			return filter.FilterThresholdByRecent(list, threshold, summary, below, 1+int(duration/timerange.Resolution())), nil
 		},
@@ -193,35 +193,12 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 	)
 }
 
-// NewTransform takes a named transforming function `[float64], [value] => [float64]` and makes it into a MetricFunction.
-func NewTransform(name string, parameterCount int, transformer func(function.EvaluationContext, api.Timeseries, []function.Value, time.Duration) ([]float64, error)) function.MetricFunction {
-	return function.MetricFunction{
-		FunctionName: name,
-		MinArguments: parameterCount + 1,
-		MaxArguments: parameterCount + 1,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-			list, err := function.EvaluateToSeriesList(arguments[0], context)
-			if err != nil {
-				return nil, err
-			}
-			parameters := make([]function.Value, parameterCount)
-			for i := range parameters {
-				parameters[i], err = arguments[i+1].Evaluate(context)
-				if err != nil {
-					return nil, err
-				}
-			}
-			return transform.ApplyTransform(context, list, transformer, parameters, context.Timerange.Resolution())
-		},
-	}
-}
-
 // NewOperator creates a new binary operator function.
 // the binary operators display a natural join semantic.
 func NewOperator(op string, operator func(float64, float64) float64) function.Function {
 	return function.MakeFunction(
 		op,
-		func(leftList api.SeriesList, rightList api.SeriesList, timerange api.Timerange) (function.Value, error) {
+		func(leftList api.SeriesList, rightList api.SeriesList, timerange api.Timerange) (api.SeriesList, error) {
 			joined := join.Join([]api.SeriesList{leftList, rightList})
 
 			result := make([]api.Timeseries, len(joined.Rows))

--- a/function/registry/registry_test.go
+++ b/function/registry/registry_test.go
@@ -46,7 +46,6 @@ func Test_Registry_Error(t *testing.T) {
 	}{
 		{"empty name", function.MetricFunction{FunctionName: "", Compute: dummyCompute}},
 		{"duplicate name", function.MetricFunction{FunctionName: "existing", Compute: dummyCompute}},
-		{"no compute", function.MetricFunction{FunctionName: "notexisting", Compute: nil}},
 	} {
 		a := assert.New(t).Contextf("%s", suite.Name)
 		// set up the standard registry

--- a/function/registry/registry_test.go
+++ b/function/registry/registry_test.go
@@ -28,12 +28,12 @@ var dummyCompute = func(function.EvaluationContext, []function.Expression, funct
 
 func Test_Registry_Default(t *testing.T) {
 	a := assert.New(t)
-	sr := StandardRegistry{mapping: make(map[string]function.MetricFunction)}
+	sr := StandardRegistry{mapping: make(map[string]function.Function)}
 	a.Eq(sr.All(), []string{})
-	if err := sr.Register(function.MetricFunction{Name: "foo", Compute: dummyCompute}); err != nil {
+	if err := sr.Register(function.MetricFunction{FunctionName: "foo", Compute: dummyCompute}); err != nil {
 		a.CheckError(err)
 	}
-	if err := sr.Register(function.MetricFunction{Name: "bar", Compute: dummyCompute}); err != nil {
+	if err := sr.Register(function.MetricFunction{FunctionName: "bar", Compute: dummyCompute}); err != nil {
 		a.CheckError(err)
 	}
 	a.Eq(sr.All(), []string{"bar", "foo"})
@@ -44,14 +44,14 @@ func Test_Registry_Error(t *testing.T) {
 		Name     string
 		Function function.MetricFunction
 	}{
-		{"empty name", function.MetricFunction{Name: "", Compute: dummyCompute}},
-		{"duplicate name", function.MetricFunction{Name: "existing", Compute: dummyCompute}},
-		{"no compute", function.MetricFunction{Name: "notexisting", Compute: nil}},
+		{"empty name", function.MetricFunction{FunctionName: "", Compute: dummyCompute}},
+		{"duplicate name", function.MetricFunction{FunctionName: "existing", Compute: dummyCompute}},
+		{"no compute", function.MetricFunction{FunctionName: "notexisting", Compute: nil}},
 	} {
 		a := assert.New(t).Contextf("%s", suite.Name)
 		// set up the standard registry
-		sr := StandardRegistry{mapping: make(map[string]function.MetricFunction)}
-		if err := sr.Register(function.MetricFunction{Name: "existing", Compute: dummyCompute}); err != nil {
+		sr := StandardRegistry{mapping: make(map[string]function.Function)}
+		if err := sr.Register(function.MetricFunction{FunctionName: "existing", Compute: dummyCompute}); err != nil {
 			a.CheckError(err)
 			return
 		}

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -64,8 +64,8 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 	}
 }
 
-// DropFunction wraps up DropTag into a MetricFunction called "tag.drop"
+// DropFunction wraps up DropTag into a Function called "tag.drop"
 var DropFunction = function.MakeFunction("tag.drop", DropTag)
 
-// SetFunction wraps up SetTag into a MetricFunction called "tag.set"
+// SetFunction wraps up SetTag into a Function called "tag.set"
 var SetFunction = function.MakeFunction("tag.set", SetTag)

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -65,43 +65,7 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 }
 
 // DropFunction wraps up DropTag into a MetricFunction called "tag.drop"
-var DropFunction = function.MetricFunction{
-	Name:         "tag.drop",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		list, err := function.EvaluateToSeriesList(arguments[0], context)
-		if err != nil {
-			return nil, err
-		}
-		dropTag, err := function.EvaluateToString(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		// Drop the tag from the list.
-		return DropTag(list, dropTag), nil
-	},
-}
+var DropFunction = function.MakeFunction("tag.drop", DropTag)
 
 // SetFunction wraps up SetTag into a MetricFunction called "tag.set"
-var SetFunction = function.MetricFunction{
-	Name:         "tag.set",
-	MinArguments: 3,
-	MaxArguments: 3,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		list, err := function.EvaluateToSeriesList(arguments[0], context)
-		if err != nil {
-			return nil, err
-		}
-		tag, err := function.EvaluateToString(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		set, err := function.EvaluateToString(arguments[2], context)
-		if err != nil {
-			return nil, err
-		}
-		// Set the tag for the list:
-		return SetTag(list, tag, set), nil
-	},
-}
+var SetFunction = function.MakeFunction("tag.set", SetTag)

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -193,11 +193,11 @@ func rate(ctx function.EvaluationContext, series api.Timeseries, parameters []fu
 	return result, nil
 }
 
-// newDerivativeBasedTransform returns a function.MetricFunction that performs
+// newDerivativeBasedTransform returns a function.Function that performs
 // a delta between two data points. The transform parameter is a function of type
 // transform is expected to return an array of values whose length is 1 less
 // than the given series
-func newDerivativeBasedTransform(name string, transformer transform) function.MetricFunction {
+func newDerivativeBasedTransform(name string, transformer transform) function.Function {
 	return function.MakeFunction("transform."+name, func(context function.EvaluationContext, listExpression function.Expression) (function.Value, error) {
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
 

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -105,7 +105,7 @@ func MapMaker(fun func(float64) float64) func(function.EvaluationContext, api.Ti
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
 func Default(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
-	defaultValue, err := parameters[0].ToScalar("default value")
+	defaultValue, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}
@@ -150,11 +150,11 @@ func (b boundError) TokenName() string {
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
 func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
-	lowerBound, err := parameters[0].ToScalar("lower bound")
+	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}
-	upperBound, err := parameters[1].ToScalar("upper bound")
+	upperBound, err := parameters[1].ToScalar()
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []f
 // LowerBound replaces values that fall below the given bound with the lower bound.
 func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
-	lowerBound, err := parameters[0].ToScalar("lower bound")
+	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameter
 // UpperBound replaces values that fall below the given bound with the lower bound.
 func UpperBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
-	upperBound, err := parameters[0].ToScalar("upper bound")
+	upperBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -19,119 +19,129 @@ package transform
 import (
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 )
 
-// A transform takes the list of values, other parameters, and the resolution of the query.
-type transform func(function.EvaluationContext, api.Timeseries, []function.Value, time.Duration) ([]float64, error)
-
-// ApplyTransform applies the given transform to the entire list of series.
-func ApplyTransform(ctx function.EvaluationContext, list api.SeriesList, transformFunc transform, parameters []function.Value, resolution time.Duration) (api.SeriesList, error) {
-	result := api.SeriesList{
+func transformEach(list api.SeriesList, transformation func([]float64) []float64) api.SeriesList {
+	resultList := api.SeriesList{
 		Series: make([]api.Timeseries, len(list.Series)),
 	}
-	var numResult []float64
-	var err error
-	for i, series := range list.Series {
-		//TODO(cchandler): Modify the last parameter of this type to be an actual Resolution
-		numResult, err = transformFunc(ctx, series, parameters, resolution)
-		if err != nil {
-			return api.SeriesList{}, err
-		}
-		result.Series[i] = api.Timeseries{
-			Values: numResult,
-			TagSet: series.TagSet,
+	for seriesIndex, series := range list.Series {
+		resultList.Series[seriesIndex] = api.Timeseries{
+			Values: transformation(series.Values),
+			TagSet: series.TagSet, // TODO: verify that these are immutable
 		}
 	}
-	return result, nil
+	return resultList
+}
+
+func mapper(list api.SeriesList, mapFunc func(float64) float64) api.SeriesList {
+	return transformEach(list, func(values []float64) []float64 {
+		result := make([]float64, len(values))
+		for i := range result {
+			result[i] = mapFunc(values[i])
+		}
+		return result
+	})
 }
 
 // Integral integrates a series whose values are "X per millisecond" to estimate "total X so far"
 // if the series represents "X in this sampling interval" instead, then you should use transformCumulative.
-func Integral(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	result := make([]float64, len(values))
-	integral := 0.0
-	for i := range values {
-		// Skip the 0th element since thats not technically part of our timerange
-		if i == 0 {
-			continue
-		}
+var Integral = function.MakeFunction(
+	"transform.integral",
+	func(list api.SeriesList, timerange api.Timerange) api.SeriesList {
+		return transformEach(list, func(values []float64) []float64 {
+			result := make([]float64, len(values))
+			integral := 0.0
+			for i := range values {
+				// Skip the 0th element since thats not technically part of our timerange
+				if i == 0 {
+					continue
+				}
 
-		if !math.IsNaN(values[i]) {
-			integral += values[i]
-		}
-		result[i] = integral * resolution.Seconds()
-	}
-	return result, nil
-}
+				if !math.IsNaN(values[i]) {
+					integral += values[i]
+				}
+				result[i] = integral * timerange.Resolution().Seconds()
+			}
+			return result
+		})
+	},
+)
 
 // Cumulative computes the cumulative sum of the given values.
-func Cumulative(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	result := make([]float64, len(values))
-	sum := 0.0
-	for i := range values {
-		// Skip the 0th element since thats not technically part of our timerange
-		if i == 0 {
-			continue
-		}
+var Cumulative = function.MakeFunction(
+	"transform.cumulative",
+	func(list api.SeriesList, timerange api.Timerange) api.SeriesList {
+		return transformEach(list, func(values []float64) []float64 {
+			result := make([]float64, len(values))
+			sum := 0.0
+			for i := range values {
+				// Skip the 0th element since thats not technically part of our timerange
+				if i == 0 {
+					continue
+				}
 
-		if !math.IsNaN(values[i]) {
-			sum += values[i]
-		}
-		result[i] = sum
-	}
-	return result, nil
-}
+				if !math.IsNaN(values[i]) {
+					sum += values[i]
+				}
+				result[i] = sum
+			}
+			return result
+		})
+	},
+)
 
 // MapMaker can be used to use a function as a transform, such as 'math.Abs' (or similar):
 //  `MapMaker(math.Abs)` is a transform function which can be used, e.g. with ApplyTransform
 // The name is used for error-checking purposes.
-func MapMaker(fun func(float64) float64) func(function.EvaluationContext, api.Timeseries, []function.Value, time.Duration) ([]float64, error) {
-	return func(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-		values := series.Values
-		result := make([]float64, len(values))
-		for i := range values {
-			result[i] = fun(values[i])
-		}
-		return result, nil
-	}
+
+func MapMaker(name string, fun func(float64) float64) function.Function {
+	return function.MakeFunction(
+		name,
+		func(list api.SeriesList, timerange api.Timerange) api.SeriesList {
+			return transformEach(list, func(values []float64) []float64 {
+				result := make([]float64, len(values))
+				for i := range values {
+					result[i] = fun(values[i])
+				}
+				return result
+			})
+		},
+	)
 }
 
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
-func Default(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	defaultValue, err := parameters[0].ToScalar()
-	if err != nil {
-		return nil, err
-	}
-	result := make([]float64, len(values))
-	for i := range values {
-		if math.IsNaN(values[i]) {
-			result[i] = defaultValue
-		} else {
-			result[i] = values[i]
-		}
-	}
-	return result, nil
-}
+var Default = function.MakeFunction(
+	"transform.default",
+	func(list api.SeriesList, defaultValue float64) api.SeriesList {
+		return mapper(list, func(value float64) float64 {
+			if math.IsNaN(value) {
+				return defaultValue
+			}
+			return value
+		})
+	},
+)
 
 // NaNKeepLast will replace missing NaN data with the data before it
-func NaNKeepLast(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	result := make([]float64, len(values))
-	for i := range result {
-		result[i] = values[i]
-		if math.IsNaN(result[i]) && i > 0 {
-			result[i] = result[i-1]
-		}
-	}
-	return result, nil
-}
+var NaNKeepLast = function.MakeFunction(
+	"transform.nan_keep_last",
+	func(list api.SeriesList) api.SeriesList {
+		return transformEach(list, func(values []float64) []float64 {
+			result := make([]float64, len(values))
+			for i := range result {
+				result[i] = values[i]
+				if math.IsNaN(values[i]) && i > 0 {
+					result[i] = result[i-1]
+				}
+			}
+			return result
+		})
+	},
+)
 
 // boundError represents an error in bounds, when (lower > upper) so the interval is empty.
 type boundError struct {
@@ -148,62 +158,46 @@ func (b boundError) TokenName() string {
 }
 
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
-func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	lowerBound, err := parameters[0].ToScalar()
-	if err != nil {
-		return nil, err
-	}
-	upperBound, err := parameters[1].ToScalar()
-	if err != nil {
-		return nil, err
-	}
-	if lowerBound > upperBound {
-		return nil, boundError{lowerBound, upperBound}
-	}
-	result := make([]float64, len(values))
-	for i := range result {
-		result[i] = values[i]
-		if result[i] < lowerBound {
-			result[i] = lowerBound
+var Bound = function.MakeFunction(
+	"transform.bound",
+	func(list api.SeriesList, lowerBound float64, upperBound float64) (api.SeriesList, error) {
+		if lowerBound > upperBound {
+			return api.SeriesList{}, boundError{lowerBound, upperBound}
 		}
-		if result[i] > upperBound {
-			result[i] = upperBound
-		}
-	}
-	return result, nil
-}
+		return mapper(list, func(value float64) float64 {
+			if value < lowerBound {
+				return lowerBound
+			}
+			if value > upperBound {
+				return upperBound
+			}
+			return value
+		}), nil
+	},
+)
 
 // LowerBound replaces values that fall below the given bound with the lower bound.
-func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	lowerBound, err := parameters[0].ToScalar()
-	if err != nil {
-		return nil, err
-	}
-	result := make([]float64, len(values))
-	for i := range result {
-		result[i] = values[i]
-		if result[i] < lowerBound {
-			result[i] = lowerBound
-		}
-	}
-	return result, nil
-}
+var LowerBound = function.MakeFunction(
+	"transform.lower_bound",
+	func(list api.SeriesList, lowerBound float64) (api.SeriesList, error) {
+		return mapper(list, func(value float64) float64 {
+			if value < lowerBound {
+				return lowerBound
+			}
+			return value
+		}), nil
+	},
+)
 
 // UpperBound replaces values that fall below the given bound with the lower bound.
-func UpperBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
-	values := series.Values
-	upperBound, err := parameters[0].ToScalar()
-	if err != nil {
-		return nil, err
-	}
-	result := make([]float64, len(values))
-	for i := range result {
-		result[i] = values[i]
-		if result[i] > upperBound {
-			result[i] = upperBound
-		}
-	}
-	return result, nil
-}
+var UpperBound = function.MakeFunction(
+	"transform.upper_bound",
+	func(list api.SeriesList, upperBound float64) (api.SeriesList, error) {
+		return mapper(list, func(value float64) float64 {
+			if value > upperBound {
+				return upperBound
+			}
+			return value
+		}), nil
+	},
+)

--- a/function/transform/transformation_test.go
+++ b/function/transform/transformation_test.go
@@ -39,6 +39,10 @@ func (lit literal) Evaluate(context function.EvaluationContext) (function.Value,
 }
 
 func TestTransformTimeseries(t *testing.T) {
+	timerange, err := api.NewSnappedTimerange(0, 4*30000, 30000)
+	if err != nil {
+		t.Fatalf("Error creating test timerange: %s", err.Error())
+	}
 	testCases := []struct {
 		series     api.Timeseries
 		values     []float64
@@ -91,7 +95,7 @@ func TestTransformTimeseries(t *testing.T) {
 			TagSet: test.tagSet,
 		}
 		for _, transform := range test.tests {
-			ctx := function.EvaluationContext{}
+			ctx := function.EvaluationContext{Timerange: timerange}
 			seriesList := api.SeriesList{
 				Series: []api.Timeseries{series},
 			}
@@ -126,6 +130,10 @@ func TestTransformTimeseries(t *testing.T) {
 }
 
 func TestApplyTransform(t *testing.T) {
+	timerange, err := api.NewSnappedTimerange(0, 5*30000, 30000)
+	if err != nil {
+		t.Fatalf("Error creating timerange: %s", err.Error())
+	}
 	epsilon := 1e-10
 	list := api.SeriesList{
 		Series: []api.Timeseries{
@@ -189,7 +197,7 @@ func TestApplyTransform(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		ctx := function.EvaluationContext{}
+		ctx := function.EvaluationContext{Timerange: timerange}
 		resultValue, err := test.transform.Run(ctx, []function.Expression{listExpression}, function.Groups{})
 		if err != nil {
 			t.Error(err)
@@ -230,6 +238,10 @@ func TestApplyTransform(t *testing.T) {
 }
 
 func TestApplyNotes(t *testing.T) {
+	timerange, err := api.NewSnappedTimerange(0, 5*30000, 30000)
+	if err != nil {
+		t.Fatalf("Error creating timerange for test case: %s", err.Error())
+	}
 	list := api.SeriesList{
 		Series: []api.Timeseries{
 			{
@@ -257,7 +269,7 @@ func TestApplyNotes(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ctx := function.EvaluationContext{EvaluationNotes: new(function.EvaluationNotes)}
+		ctx := function.EvaluationContext{EvaluationNotes: new(function.EvaluationNotes), Timerange: timerange}
 		_, err := test.transform.Run(ctx, test.parameters, function.Groups{})
 		if err != nil {
 			t.Error(err)
@@ -414,6 +426,11 @@ func TestApplyBound(t *testing.T) {
 }
 
 func TestApplyTransformNaN(t *testing.T) {
+	timerange, err := api.NewSnappedTimerange(0, 5*30000, 30000)
+	if err != nil {
+		t.Fatalf("Error constructing timerange for testcase; %s", err.Error())
+	}
+
 	nan := math.NaN()
 	list := api.SeriesList{
 		Series: []api.Timeseries{
@@ -499,7 +516,7 @@ func TestApplyTransformNaN(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		ctx := function.EvaluationContext{}
+		ctx := function.EvaluationContext{Timerange: timerange}
 		resultValue, err := test.transform.Run(ctx, test.parameters, function.Groups{})
 		if err != nil {
 			t.Fatalf(fmt.Sprintf("error applying transformation %s", err))
@@ -534,6 +551,10 @@ func TestApplyTransformNaN(t *testing.T) {
 func TestTransformIdentity(t *testing.T) {
 	//This is to make sure that the scale of all the data
 	//is interpreted as 30 seconds (30000 milliseconds)
+	timerange, err := api.NewSnappedTimerange(0, 5*30000, 30000)
+	if err != nil {
+		t.Fatalf("Error constructing timerange for testcase: %s", err.Error())
+	}
 
 	testCases := []struct {
 		values []float64
@@ -591,7 +612,6 @@ func TestTransformIdentity(t *testing.T) {
 		},
 	}
 	epsilon := 1e-10
-	var err error
 	for _, test := range testCases {
 		series := api.Timeseries{
 			Values: test.values,
@@ -600,7 +620,7 @@ func TestTransformIdentity(t *testing.T) {
 		for _, transform := range test.tests {
 			result := series
 			for _, fun := range transform.transforms {
-				ctx := function.EvaluationContext{}
+				ctx := function.EvaluationContext{Timerange: timerange}
 
 				seriesList := api.SeriesList{
 					Series: []api.Timeseries{result},

--- a/function/value.go
+++ b/function/value.go
@@ -27,9 +27,9 @@ import (
 // They can be floating point values, strings, or series lists.
 type Value interface {
 	ToSeriesList(api.Timerange) (api.SeriesList, error)
-	ToString(string) (string, error)          // takes a description of the object's expression
-	ToScalar(string) (float64, error)         // takes a description of the object's expression
-	ToDuration(string) (time.Duration, error) // takes a description of the object's expression
+	ToString() (string, error)
+	ToScalar() (float64, error)
+	ToDuration() (time.Duration, error)
 }
 
 // ConversionError represents an error converting between two items of different types.
@@ -58,18 +58,18 @@ func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error
 }
 
 // ToString is a conversion function.
-func (value StringValue) ToString(description string) (string, error) {
+func (value StringValue) ToString() (string, error) {
 	return string(value), nil
 }
 
 // ToScalar is a conversion function.
-func (value StringValue) ToScalar(description string) (float64, error) {
-	return 0, ConversionError{"string", "scalar", description}
+func (value StringValue) ToScalar() (float64, error) {
+	return 0, ConversionError{"string", "scalar", ""}
 }
 
 // ToDuration is a conversion function.
-func (value StringValue) ToDuration(description string) (time.Duration, error) {
-	return 0, ConversionError{"string", "duration", description}
+func (value StringValue) ToDuration() (time.Duration, error) {
+	return 0, ConversionError{"string", "duration", ""}
 }
 
 // A ScalarValue holds a float and can be converted to a serieslist
@@ -89,19 +89,19 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 }
 
 // ToString is a conversion function. Numbers become formatted.
-func (value ScalarValue) ToString(description string) (string, error) {
+func (value ScalarValue) ToString() (string, error) {
 	return "", ConversionError{"scalar", "string", fmt.Sprintf("%f", value)}
 }
 
 // ToScalar is a conversion function.
-func (value ScalarValue) ToScalar(description string) (float64, error) {
+func (value ScalarValue) ToScalar() (float64, error) {
 	return float64(value), nil
 }
 
 // ToDuration is a conversion function.
 // Scalars cannot be converted to durations.
-func (value ScalarValue) ToDuration(description string) (time.Duration, error) {
-	return 0, ConversionError{"scalar", "duration", description}
+func (value ScalarValue) ToDuration() (time.Duration, error) {
+	return 0, ConversionError{"scalar", "duration", ""}
 }
 
 // DurationValue is a duration with a (usually) human-written name.
@@ -121,17 +121,17 @@ func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList
 }
 
 // ToString is a conversion function.
-func (value DurationValue) ToString(description string) (string, error) {
-	return "", ConversionError{"duration", "string", description}
+func (value DurationValue) ToString() (string, error) {
+	return "", ConversionError{"duration", "string", ""}
 }
 
 // ToScalar is a conversion function.
-func (value DurationValue) ToScalar(description string) (float64, error) {
-	return 0, ConversionError{"duration", "scalar", description}
+func (value DurationValue) ToScalar() (float64, error) {
+	return 0, ConversionError{"duration", "scalar", ""}
 }
 
 // ToDuration is a conversion function.
-func (value DurationValue) ToDuration(description string) (time.Duration, error) {
+func (value DurationValue) ToDuration() (time.Duration, error) {
 	return time.Duration(value.duration), nil
 }
 

--- a/function/value.go
+++ b/function/value.go
@@ -26,7 +26,7 @@ import (
 // Value is the result of evaluating an expression.
 // They can be floating point values, strings, or series lists.
 type Value interface {
-	ToSeriesList(api.Timerange, string) (api.SeriesList, error)
+	ToSeriesList(api.Timerange) (api.SeriesList, error)
 	ToString(string) (string, error)          // takes a description of the object's expression
 	ToScalar(string) (float64, error)         // takes a description of the object's expression
 	ToDuration(string) (time.Duration, error) // takes a description of the object's expression
@@ -53,8 +53,8 @@ func (e ConversionError) TokenName() string {
 type StringValue string
 
 // ToSeriesList is a conversion function.
-func (value StringValue) ToSeriesList(time api.Timerange, description string) (api.SeriesList, error) {
-	return api.SeriesList{}, ConversionError{"string", "SeriesList", description}
+func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
+	return api.SeriesList{}, ConversionError{"string", "SeriesList", "// TODO //"}
 }
 
 // ToString is a conversion function.
@@ -77,7 +77,7 @@ type ScalarValue float64
 
 // ToSeriesList is a conversion function.
 // The scalar becomes a constant value for the timerange.
-func (value ScalarValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
+func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
 	series := make([]float64, timerange.Slots())
 	for i := range series {
 		series[i] = float64(value)
@@ -116,8 +116,8 @@ func NewDurationValue(name string, duration time.Duration) DurationValue {
 }
 
 // ToSeriesList is a conversion function.
-func (value DurationValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
-	return api.SeriesList{}, ConversionError{"duration", "SeriesList", description}
+func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
+	return api.SeriesList{}, ConversionError{"duration", "SeriesList", "// TODO //"}
 }
 
 // ToString is a conversion function.

--- a/function/value.go
+++ b/function/value.go
@@ -26,50 +26,82 @@ import (
 // Value is the result of evaluating an expression.
 // They can be floating point values, strings, or series lists.
 type Value interface {
-	ToSeriesList(api.Timerange) (api.SeriesList, error)
-	ToString() (string, error)
-	ToScalar() (float64, error)
-	ToDuration() (time.Duration, error)
+	ToSeriesList(api.Timerange) (api.SeriesList, *ConversionFailure)
+	ToString() (string, *ConversionFailure)
+	ToScalar() (float64, *ConversionFailure)
+	ToDuration() (time.Duration, *ConversionFailure)
+}
+
+type ConversionFailure struct {
+	From string // the original data type
+	To   string // the type that it attempted to convert to
+}
+
+// WithContext adds enough context to make the ConversionFailure into an error.
+func (c *ConversionFailure) WithContext(context string) ConversionError {
+	return ConversionError{
+		From:    c.From,
+		To:      c.To,
+		Context: context,
+	}
 }
 
 // ConversionError represents an error converting between two items of different types.
 type ConversionError struct {
-	From  string // the original data type
-	To    string // the type that attempted to convert to
-	Value string // a short string representation of the value
+	From    string // the original data type
+	To      string // the type that attempted to convert to
+	Context string // a short string representation of the value
 }
 
 // Error gives a readable description of the error.
 func (e ConversionError) Error() string {
-	return fmt.Sprintf("cannot convert %s (type %s) to type %s", e.Value, e.From, e.To)
+	return fmt.Sprintf("cannot convert %s (type %s) to type %s", e.Context, e.From, e.To)
 }
 
-// TokenName gives the token name where the error occurred.
-func (e ConversionError) TokenName() string {
-	return fmt.Sprintf("%+v (type %s)", e.Value, e.From)
+// A SeriesListValue holds a SeriesList.
+type SeriesListValue api.SeriesList
+
+// ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.
+func (list SeriesListValue) ToSeriesList(time api.Timerange) (api.SeriesList, *ConversionFailure) {
+	return api.SeriesList(list), nil
+}
+
+// ToString is a conversion function to implement the expression.Value interface.
+func (list SeriesListValue) ToString() (string, *ConversionFailure) {
+	return "", &ConversionFailure{"series list", "string"}
+}
+
+// ToScalar is a conversion function to implement the expression.Value interface.
+func (list SeriesListValue) ToScalar() (float64, *ConversionFailure) {
+	return 0, &ConversionFailure{"series list", "scalar"}
+}
+
+// ToDuration is a conversion function to implement the expression.Value interface.
+func (list SeriesListValue) ToDuration() (time.Duration, *ConversionFailure) {
+	return 0, &ConversionFailure{"series list", "duration"}
 }
 
 // A StringValue holds a string
 type StringValue string
 
 // ToSeriesList is a conversion function.
-func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, ConversionError{"string", "SeriesList", "// TODO //"}
+func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, *ConversionFailure) {
+	return api.SeriesList{}, &ConversionFailure{"string", "SeriesList"}
 }
 
 // ToString is a conversion function.
-func (value StringValue) ToString() (string, error) {
+func (value StringValue) ToString() (string, *ConversionFailure) {
 	return string(value), nil
 }
 
 // ToScalar is a conversion function.
-func (value StringValue) ToScalar() (float64, error) {
-	return 0, ConversionError{"string", "scalar", ""}
+func (value StringValue) ToScalar() (float64, *ConversionFailure) {
+	return 0, &ConversionFailure{"string", "scalar"}
 }
 
 // ToDuration is a conversion function.
-func (value StringValue) ToDuration() (time.Duration, error) {
-	return 0, ConversionError{"string", "duration", ""}
+func (value StringValue) ToDuration() (time.Duration, *ConversionFailure) {
+	return 0, &ConversionFailure{"string", "duration"}
 }
 
 // A ScalarValue holds a float and can be converted to a serieslist
@@ -77,7 +109,7 @@ type ScalarValue float64
 
 // ToSeriesList is a conversion function.
 // The scalar becomes a constant value for the timerange.
-func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
+func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, *ConversionFailure) {
 	series := make([]float64, timerange.Slots())
 	for i := range series {
 		series[i] = float64(value)
@@ -89,19 +121,19 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 }
 
 // ToString is a conversion function. Numbers become formatted.
-func (value ScalarValue) ToString() (string, error) {
-	return "", ConversionError{"scalar", "string", fmt.Sprintf("%f", value)}
+func (value ScalarValue) ToString() (string, *ConversionFailure) {
+	return "", &ConversionFailure{"scalar", "string"}
 }
 
 // ToScalar is a conversion function.
-func (value ScalarValue) ToScalar() (float64, error) {
+func (value ScalarValue) ToScalar() (float64, *ConversionFailure) {
 	return float64(value), nil
 }
 
 // ToDuration is a conversion function.
 // Scalars cannot be converted to durations.
-func (value ScalarValue) ToDuration() (time.Duration, error) {
-	return 0, ConversionError{"scalar", "duration", ""}
+func (value ScalarValue) ToDuration() (time.Duration, *ConversionFailure) {
+	return 0, &ConversionFailure{"scalar", "duration"}
 }
 
 // DurationValue is a duration with a (usually) human-written name.
@@ -116,22 +148,22 @@ func NewDurationValue(name string, duration time.Duration) DurationValue {
 }
 
 // ToSeriesList is a conversion function.
-func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
-	return api.SeriesList{}, ConversionError{"duration", "SeriesList", "// TODO //"}
+func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, *ConversionFailure) {
+	return api.SeriesList{}, &ConversionFailure{"duration", "SeriesList"}
 }
 
 // ToString is a conversion function.
-func (value DurationValue) ToString() (string, error) {
-	return "", ConversionError{"duration", "string", ""}
+func (value DurationValue) ToString() (string, *ConversionFailure) {
+	return "", &ConversionFailure{"duration", "string"}
 }
 
 // ToScalar is a conversion function.
-func (value DurationValue) ToScalar() (float64, error) {
-	return 0, ConversionError{"duration", "scalar", ""}
+func (value DurationValue) ToScalar() (float64, *ConversionFailure) {
+	return 0, &ConversionFailure{"duration", "scalar"}
 }
 
 // ToDuration is a conversion function.
-func (value DurationValue) ToDuration() (time.Duration, error) {
+func (value DurationValue) ToDuration() (time.Duration, *ConversionFailure) {
 	return time.Duration(value.duration), nil
 }
 

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -273,9 +273,10 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 	case result := <-results:
 		lists := make([]api.SeriesList, len(result))
 		for i := range result {
-			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange)
-			if err != nil {
-				return CommandResult{}, err
+			var convErr *function.ConversionFailure
+			lists[i], convErr = result[i].ToSeriesList(evaluationContext.Timerange)
+			if convErr != nil {
+				return CommandResult{}, convErr.WithContext(cmd.Expressions[i].QueryString())
 			}
 		}
 		description := map[string][]string{}

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -273,7 +273,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 	case result := <-results:
 		lists := make([]api.SeriesList, len(result))
 		for i := range result {
-			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange, cmd.Expressions[i].QueryString())
+			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange)
 			if err != nil {
 				return CommandResult{}, err
 			}

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -142,7 +142,7 @@ func (expr *FunctionExpression) Evaluate(context function.EvaluationContext) (fu
 		return nil, SyntaxError{fmt.Sprintf("no such function %s", expr.FunctionName)}
 	}
 
-	return fun.Evaluate(context, expr.Arguments, expr.GroupBy, expr.GroupByCollapses)
+	return fun.Run(context, expr.Arguments, function.Groups{expr.GroupBy, expr.GroupByCollapses})
 }
 
 func functionFormatString(argumentStrings []string, f FunctionExpression) string {

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -105,7 +105,7 @@ func (expr *MetricFetchExpression) Evaluate(context function.EvaluationContext) 
 		metrics[i] = api.TaggedMetric{api.MetricKey(expr.MetricName), filtered[i]}
 	}
 
-	return context.TimeseriesStorageAPI.FetchMultipleTimeseries(
+	seriesList, err := context.TimeseriesStorageAPI.FetchMultipleTimeseries(
 		timeseries.FetchMultipleRequest{
 			metrics,
 			timeseries.RequestDetails{
@@ -117,6 +117,10 @@ func (expr *MetricFetchExpression) Evaluate(context function.EvaluationContext) 
 			},
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	return function.SeriesListValue(seriesList), nil
 }
 
 func (expr *MetricFetchExpression) QueryString() string {

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -41,9 +41,9 @@ func (le LiteralExpression) Name() string {
 }
 
 func (expr *LiteralExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return api.SeriesList{
+	return function.SeriesListValue(api.SeriesList{
 		Series: []api.Timeseries{{Values: expr.Values, TagSet: api.NewTagSet()}},
-	}, nil
+	}), nil
 }
 
 type LiteralSeriesExpression struct {

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -318,7 +318,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			continue
 		}
 
-		result, err := value.ToSeriesList(test.context.Timerange, "-test-")
+		result, err := value.ToSeriesList(test.context.Timerange)
 		if err != nil {
 			a.EqBool(err == nil, test.expectSuccess)
 			continue

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -57,7 +57,7 @@ func (lse LiteralSeriesExpression) Name() string {
 	return "<literal series expression>"
 }
 func (expr *LiteralSeriesExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return expr.list, nil
+	return function.SeriesListValue(expr.list), nil
 }
 
 func Test_ScalarExpression(t *testing.T) {
@@ -318,9 +318,9 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			continue
 		}
 
-		result, err := value.ToSeriesList(test.context.Timerange)
-		if err != nil {
-			a.EqBool(err == nil, test.expectSuccess)
+		result, convErr := value.ToSeriesList(test.context.Timerange)
+		if convErr != nil {
+			a.EqBool(convErr == nil, test.expectSuccess)
 			continue
 		}
 

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -312,7 +312,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 
 		metricFun := registry.NewOperator(test.functionName, test.evalFunction)
 
-		value, err := metricFun.Evaluate(test.context, []function.Expression{&LiteralSeriesExpression{test.left}, &LiteralSeriesExpression{test.right}}, []string{}, false)
+		value, err := metricFun.Run(test.context, []function.Expression{&LiteralSeriesExpression{test.left}, &LiteralSeriesExpression{test.right}}, function.Groups{})
 		if err != nil {
 			a.EqBool(err == nil, test.expectSuccess)
 			continue


### PR DESCRIPTION
To try to make it easier to define `MetricFunction`s without having to write repetitive evaluations and casts everywhere, a new function `function.MakeFunction` (possible rename to just `Make`) has been added.

It asks for an `interface{}` which is a function that acts like a metric function. It can take any of:

- `string`
- `float64`
- `time.Duration`
- `api.SeriesList`
- `function.Value`
- `function.Expression`

In addition, it can have optional arguments by requesting pointers to any of these:

- `*string`
- `*float`
- `*time.Duration`
- `*api.SeriesList`
- `*function.Value`
- `*function.Expression`

Non-optional formal arguments cannot follow optional ones. (So, for example, `(float, *string, float)` would be illegal).

For all of these, the parameters will be evaluated before they are passed to the function except for `function.Expression` and `*function.Expression`, where it is up to the given function to evaluate them.

All evaluations are done **in parallel automatically**, so the function itself does not have to do any extra work here.

The argument function can also ask for an `function.EvaluationContext` to get the current context (or an `api.Timerange` to get just the current timerange).

If it wants to allow `group by` or `collapse by` clauses, it can ask for a `function.Groups` object. 

The argument function can return either `(function.Value, error)` or just a `function.Value` (which means it never errors). Either of these can be replaced by any subtype implementing these interfaces (e.g. `api.SeriesList` or `SyntaxError` respectively).

If an input function violates any of these constraints, `MakeFunction` panics.

TODO: test optional arguments, cleaning up reflection in `MakeFunction`.

TODO: variadic functions for `MakeFunction` (for variadic functions in MQE)

TODO: float, string, duration returns?

# Example

Consider the following toy metric function:

## Old Way

```
// adder takes one or two numbers.
// when given only one parameter, the second defaults to "1.0".
function.MetricFunction {
    Name: "adder",
    MinArguments: 1,
    MaxArguments: 2,
    Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
         left, err := function.EvaluateToDuration(arguments[0], context)
         if err != nil {
             return nil, err
         }
         right := float64(1.0)
         if len(arguments) == 2 {
             right, err = function.EvaluateToDuration(arguments[1], context)
         }
         return expression.Scalar(left + right), nil
    },
}
```

## New Way

```
// adder takes one or two numbers.
// when given only one parameter, the second defaults to "1.0".
function.MakeFunction(
    "adder",
    func(left float64, optionalRight *float64) float64 {
         right := float64(1.0)
         if optionalRight != nil {
             right = *optionalRight
         }
         return left + right
    },
)
```
in addition, the arguments will be evaluated in parallel here (there are library functions to evaluate them in parallel using the old way, but it will add several more lines for error-checking).

