### PR TITLE
Scalar Sets for Summary Functions

### DIFF
--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -33,16 +33,16 @@ func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
 }
 
 // ToString is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToString(description string) (string, error) {
-	return "", fmt.Errorf("cannot convert %s (type SeriesList) to type string", description)
+func (list SeriesList) ToString() (string, error) {
+	return "", fmt.Errorf("cannot convert %s (type SeriesList) to type string", "")
 }
 
 // ToScalar is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToScalar(description string) (float64, error) {
-	return 0, fmt.Errorf("cannot convert %s (type SeriesList) to type scalar", description)
+func (list SeriesList) ToScalar() (float64, error) {
+	return 0, fmt.Errorf("cannot convert value of type series list to type scalar")
 }
 
 // ToDuration is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToDuration(description string) (time.Duration, error) {
-	return 0, fmt.Errorf("cannot convert %s (type SeriesList) to type duration", description)
+func (list SeriesList) ToDuration() (time.Duration, error) {
+	return 0, fmt.Errorf("cannot convert value of type series list to type duration")
 }

--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -28,7 +28,7 @@ type SeriesList struct {
 }
 
 // ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.
-func (list SeriesList) ToSeriesList(time Timerange, description string) (SeriesList, error) {
+func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
 	return list, nil
 }
 

--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -14,35 +14,10 @@
 
 package api
 
-import (
-	"fmt"
-	"time"
-)
-
 // SeriesList is a list of time series sharing the same time range.
 // this struct must satisfy the `function.Value` interface. However, a type assertion
 // cannot be held here due to a circular import.
 type SeriesList struct {
 	Series    []Timeseries `json:"series"`
 	Timerange Timerange    `json:"timerange"`
-}
-
-// ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.
-func (list SeriesList) ToSeriesList(time Timerange) (SeriesList, error) {
-	return list, nil
-}
-
-// ToString is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToString() (string, error) {
-	return "", fmt.Errorf("cannot convert %s (type SeriesList) to type string", "")
-}
-
-// ToScalar is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToScalar() (float64, error) {
-	return 0, fmt.Errorf("cannot convert value of type series list to type scalar")
-}
-
-// ToDuration is a conversion function to implement the expression.Value interface.
-func (list SeriesList) ToDuration() (time.Duration, error) {
-	return 0, fmt.Errorf("cannot convert value of type series list to type duration")
 }

--- a/function/expression.go
+++ b/function/expression.go
@@ -190,7 +190,7 @@ func EvaluateToSeriesList(e Expression, context EvaluationContext) (api.SeriesLi
 	if err != nil {
 		return api.SeriesList{}, err
 	}
-	return seriesValue.ToSeriesList(context.Timerange, e.QueryString())
+	return seriesValue.ToSeriesList(context.Timerange)
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a string.

--- a/function/expression.go
+++ b/function/expression.go
@@ -141,6 +141,19 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	return value, nil
 }
 
+// EvaluateToScalarSet is a helper function that takes an Expression and makes it a scalar.
+func EvaluateToScalarSet(e Expression, context EvaluationContext) (ScalarSet, error) {
+	scalarValue, err := e.Evaluate(context)
+	if err != nil {
+		return nil, err
+	}
+	value, convErr := scalarValue.ToScalarSet()
+	if convErr != nil {
+		return nil, convErr.WithContext(e.QueryString())
+	}
+	return value, nil
+}
+
 // EvaluateToDuration is a helper function that takes an Expression and makes it a duration.
 func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration, error) {
 	durationValue, err := e.Evaluate(context)

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,7 +15,6 @@
 package function
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -135,9 +134,9 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	if err != nil {
 		return 0, err
 	}
-	value, err := scalarValue.ToScalar()
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	value, convErr := scalarValue.ToScalar()
+	if convErr != nil {
+		return 0, convErr.WithContext(e.QueryString())
 	}
 	return value, nil
 }
@@ -148,9 +147,9 @@ func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration,
 	if err != nil {
 		return 0, err
 	}
-	value, err := durationValue.ToDuration()
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	value, convErr := durationValue.ToDuration()
+	if convErr != nil {
+		return 0, convErr.WithContext(e.QueryString())
 	}
 	return value, nil
 }
@@ -161,7 +160,11 @@ func EvaluateToSeriesList(e Expression, context EvaluationContext) (api.SeriesLi
 	if err != nil {
 		return api.SeriesList{}, err
 	}
-	return seriesValue.ToSeriesList(context.Timerange)
+	value, convErr := seriesValue.ToSeriesList(context.Timerange)
+	if convErr != nil {
+		return api.SeriesList{}, convErr.WithContext(e.QueryString())
+	}
+	return value, nil
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a string.
@@ -170,9 +173,9 @@ func EvaluateToString(e Expression, context EvaluationContext) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	value, err := stringValue.ToString()
-	if err != nil {
-		return "", fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	value, convErr := stringValue.ToString()
+	if convErr != nil {
+		return "", convErr.WithContext(e.QueryString())
 	}
 	return value, nil
 }

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -134,7 +135,11 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	if err != nil {
 		return 0, err
 	}
-	return scalarValue.ToScalar(e.QueryString())
+	value, err := scalarValue.ToScalar()
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	}
+	return value, nil
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a duration.
@@ -143,7 +148,11 @@ func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration,
 	if err != nil {
 		return 0, err
 	}
-	return durationValue.ToDuration(e.QueryString())
+	value, err := durationValue.ToDuration()
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	}
+	return value, nil
 }
 
 // EvaluateToDuration is a helper function that takes an Expression and makes it a series list.
@@ -161,7 +170,11 @@ func EvaluateToString(e Expression, context EvaluationContext) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return stringValue.ToString(e.QueryString())
+	value, err := stringValue.ToString()
+	if err != nil {
+		return "", fmt.Errorf("failed to convert %s: %s", e.QueryString(), err.Error())
+	}
+	return value, nil
 }
 
 // EvaluateMany evaluates a list of expressions using a single EvaluationContext.

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,7 +15,6 @@
 package function
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -75,53 +74,10 @@ func (notes *EvaluationNotes) Notes() []string {
 	return notes.notes
 }
 
-// The Function interface defines a metric function.
-// It is given several (unevaluated) expressions as input, and evaluates to a Value.
-type Function interface {
-	Run(EvaluationContext, []Expression, Groups) (Value, error)
-}
-
-// The Registry interface defines a mapping from names to Functions
-// and provides a way to get the full list of functions defined.
-type Registry interface {
-	GetFunction(string) (Function, bool) // returns an instance of a Function
-	All() []string                       // all the registered functions
-}
-
-// Groups holds grouping information - which tags to group by (if any), and whether to `collapse` (Collapses = true) or `group` (Collapses = false)
-type Groups struct {
-	List      []string // the tags to group by
-	Collapses bool     // whether to "collapse by" instead of "group by"
-}
-
-// MetricFunction holds a generic function object with information about its parameters.
-type MetricFunction struct {
-	Name          string // Name is the name of the function, used in its registration.
-	MinArguments  int    // MinArguments is the minimum number of arguments the function allows.
-	MaxArguments  int    // MaxArguments is the maximum number of arguments the function allows. -1 indicates an unlimited number.
-	AllowsGroupBy bool   // Whether the function allows a 'group by' clause.
-	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
-}
-
 // WithTimerange duplicates the EvaluationContext but with a new timerange.
 func (e EvaluationContext) WithTimerange(t api.Timerange) EvaluationContext {
 	e.Timerange = t
 	return e
-}
-
-// Run evaluates the given MetricFunction on its arguments.
-// It performs error-checking against the supplies number of arguments and/or group-by clause.
-func (f MetricFunction) Run(context EvaluationContext, arguments []Expression, groups Groups) (Value, error) {
-	// preprocessing
-	length := len(arguments)
-	if length < f.MinArguments || (f.MaxArguments != -1 && f.MaxArguments < length) {
-		return nil, ArgumentLengthError{f.Name, f.MinArguments, f.MaxArguments, length}
-	}
-	if len(groups.List) > 0 && !f.AllowsGroupBy {
-		// TODO(jee) - use typed errors
-		return nil, fmt.Errorf("function %s doesn't allow a group-by clause", f.Name)
-	}
-	return f.Compute(context, arguments, groups)
 }
 
 // FetchCounter is used to count the number of fetches remaining in a thread-safe manner.

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -46,9 +46,9 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err // TODO: add decoration to describe it's coming from the anomaly function
 			}
-			prediction, err := predictionValue.ToSeriesList(context.Timerange)
-			if err != nil {
-				return nil, err
+			prediction, convErr := predictionValue.ToSeriesList(context.Timerange)
+			if convErr != nil {
+				return nil, convErr.WithContext("in anomaly function - model")
 			}
 			period, err := function.EvaluateToDuration(arguments[1], context)
 			if err != nil {
@@ -72,7 +72,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 				}
 			}
 			prediction.Series = result
-			return prediction, nil
+			return function.SeriesListValue(prediction), nil
 		},
 	}
 }

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -31,7 +31,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 		panic("FunctionAnomalyMaker requires that the model argument take at least two parameters; series and period.")
 	}
 	return function.MetricFunction{
-		Name:         name,
+		FunctionName: name,
 		MinArguments: model.MinArguments,
 		MaxArguments: model.MaxArguments,
 		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {

--- a/function/forecast/anomaly_function.go
+++ b/function/forecast/anomaly_function.go
@@ -46,7 +46,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err // TODO: add decoration to describe it's coming from the anomaly function
 			}
-			prediction, err := predictionValue.ToSeriesList(context.Timerange, "prediction series")
+			prediction, err := predictionValue.ToSeriesList(context.Timerange)
 			if err != nil {
 				return nil, err
 			}

--- a/function/forecast/drop_function.go
+++ b/function/forecast/drop_function.go
@@ -16,42 +16,30 @@ package forecast
 
 import (
 	"math"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 )
 
-var FunctionDrop = function.MetricFunction{
-	Name:         "forecast.drop",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		original, err := function.EvaluateToSeriesList(arguments[0], context)
-		if err != nil {
-			return nil, err
-		}
-		dropTime, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
-		result := make([]api.Timeseries, len(original.Series))
-		for i, series := range original.Series {
-			values := make([]float64, len(series.Values))
-			result[i] = series
-			for j := range values {
-				if float64(j) < lastValue {
-					values[j] = series.Values[j]
-				} else {
-					values[j] = math.NaN()
-				}
+var FunctionDrop = function.MakeFunction("forecast.drop", func(context function.EvaluationContext, original api.SeriesList, dropTime time.Duration) function.Value {
+	lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
+	result := make([]api.Timeseries, len(original.Series))
+	for i, series := range original.Series {
+		values := make([]float64, len(series.Values))
+		result[i] = series
+		for j := range values {
+			if float64(j) < lastValue {
+				values[j] = series.Values[j]
+			} else {
+				values[j] = math.NaN()
 			}
-			result[i].Values = values
 		}
+		result[i].Values = values
+	}
 
-		return api.SeriesList{
-			Series:    result,
-			Timerange: original.Timerange,
-		}, nil
-	},
-}
+	return api.SeriesList{
+		Series:    result,
+		Timerange: original.Timerange,
+	}
+})

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -29,25 +29,25 @@ import (
 // this period are weighted 1.0/(1.0 - 0.9) = 10 times as much as the previous.
 var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 	"forecast.rolling_multiplicative_holt_winters",
-	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, levelLearningRate float64, trendLearningRate float64, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, levelLearningRate float64, trendLearningRate float64, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (api.SeriesList, error) {
 		extraTrainingTime := time.Duration(0)
 		if optionalExtraTrainingTime != nil {
 			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
-			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
+			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
 		samples := int(period / context.Timerange.Resolution())
 		if samples <= 0 {
-			return nil, fmt.Errorf("forecast.rolling_multiplicative_holt_winters expects the period parameter to mean at least one slot") // TODO: use a structured error
+			return api.SeriesList{}, fmt.Errorf("forecast.rolling_multiplicative_holt_winters expects the period parameter to mean at least one slot") // TODO: use a structured error
 		}
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		result := api.SeriesList{
@@ -72,25 +72,25 @@ var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 // perform tolerably well on data with trends as well.
 var FunctionRollingSeasonal = function.MakeFunction(
 	"forecast.rolling_seasonal",
-	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (api.SeriesList, error) {
 		extraTrainingTime := time.Duration(0)
 		if optionalExtraTrainingTime != nil {
 			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
-			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
+			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
 		samples := int(period / context.Timerange.Resolution())
 		if samples <= 0 {
-			return nil, fmt.Errorf("forecast.rolling_seasonal expects the period parameter to mean at least one slot") // TODO: use a structured error
+			return api.SeriesList{}, fmt.Errorf("forecast.rolling_seasonal expects the period parameter to mean at least one slot") // TODO: use a structured error
 		}
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		result := api.SeriesList{
@@ -115,20 +115,20 @@ var FunctionRollingSeasonal = function.MakeFunction(
 // as well as a good estimate of near-future behavior.
 var FunctionForecastLinear = function.MakeFunction(
 	"forecast.linear",
-	func(context function.EvaluationContext, seriesExpression function.Expression, optionalTrainingTime *time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, seriesExpression function.Expression, optionalTrainingTime *time.Duration) (api.SeriesList, error) {
 		extraTrainingTime := time.Duration(0)
 		if optionalTrainingTime != nil {
 			extraTrainingTime = *optionalTrainingTime
 		}
 		if extraTrainingTime < 0 {
-			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
+			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		result := api.SeriesList{

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -27,33 +27,12 @@ import (
 // The learning rates are interpreted as being "per period." For example, a value of 0.5 means that values in
 // this period are effectively weighted twice as much as those in the previous. A value of 0.9 means that values in
 // this period are weighted 1.0/(1.0 - 0.9) = 10 times as much as the previous.
-var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
-	Name:         "forecast.rolling_multiplicative_holt_winters",
-	MinArguments: 5, // Series, period, level learning rate,  trend learning rate, seasonal learning rate
-	MaxArguments: 6, // Series, period, level learning rate,  trend learning rate, seasonal learning rate, extra training time
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		period, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		levelLearningRate, err := function.EvaluateToScalar(arguments[2], context)
-		if err != nil {
-			return nil, err
-		}
-		trendLearningRate, err := function.EvaluateToScalar(arguments[3], context)
-		if err != nil {
-			return nil, err
-		}
-		seasonalLearningRate, err := function.EvaluateToScalar(arguments[4], context)
-		if err != nil {
-			return nil, err
-		}
+var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
+	"forecast.rolling_multiplicative_holt_winters",
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, levelLearningRate float64, trendLearningRate float64, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
 		extraTrainingTime := time.Duration(0)
-		if len(arguments) == 6 {
-			extraTrainingTime, err = function.EvaluateToDuration(arguments[5], context)
-			if err != nil {
-				return nil, err
-			}
+		if optionalExtraTrainingTime != nil {
+			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
 			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
@@ -66,7 +45,7 @@ var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
-		seriesList, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -86,30 +65,17 @@ var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
 
 		return result, nil
 	},
-}
+)
 
 // FunctionRollingSeasonal is a forecasting MetricFunction that performs the rolling seasonal estimation.
 // It is designed for data which shows seasonality without trends, although which a high learning rate it can
 // perform tolerably well on data with trends as well.
-var FunctionRollingSeasonal = function.MetricFunction{
-	Name:         "forecast.rolling_seasonal",
-	MinArguments: 3, // Series, period, seasonal learning rate
-	MaxArguments: 4, // Series, period, seasonal learning rate, extra training time
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		period, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		seasonalLearningRate, err := function.EvaluateToScalar(arguments[2], context)
-		if err != nil {
-			return nil, err
-		}
+var FunctionRollingSeasonal = function.MakeFunction(
+	"forecast.rolling_seasonal",
+	func(context function.EvaluationContext, seriesExpression function.Expression, period time.Duration, seasonalLearningRate float64, optionalExtraTrainingTime *time.Duration) (function.Value, error) {
 		extraTrainingTime := time.Duration(0)
-		if len(arguments) == 4 {
-			extraTrainingTime, err = function.EvaluateToDuration(arguments[3], context)
-			if err != nil {
-				return nil, err
-			}
+		if optionalExtraTrainingTime != nil {
+			extraTrainingTime = *optionalExtraTrainingTime
 		}
 		if extraTrainingTime < 0 {
 			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
@@ -122,7 +88,7 @@ var FunctionRollingSeasonal = function.MetricFunction{
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
-		seriesList, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -142,23 +108,17 @@ var FunctionRollingSeasonal = function.MetricFunction{
 
 		return result, nil
 	},
-}
+)
 
 // FunctionForecastLinear forecasts with a simple linear regression.
 // For data which is mostly just a linear trend up or down, this will provide a good model of current behavior,
 // as well as a good estimate of near-future behavior.
-var FunctionForecastLinear = function.MetricFunction{
-	Name:         "forecast.linear",
-	MinArguments: 1, // Series
-	MaxArguments: 2, // Series, extra training time
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+var FunctionForecastLinear = function.MakeFunction(
+	"forecast.linear",
+	func(context function.EvaluationContext, seriesExpression function.Expression, optionalTrainingTime *time.Duration) (function.Value, error) {
 		extraTrainingTime := time.Duration(0)
-		if len(arguments) == 2 {
-			var err error
-			extraTrainingTime, err = function.EvaluateToDuration(arguments[1], context)
-			if err != nil {
-				return nil, err
-			}
+		if optionalTrainingTime != nil {
+			extraTrainingTime = *optionalTrainingTime
 		}
 		if extraTrainingTime < 0 {
 			return nil, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
@@ -166,7 +126,7 @@ var FunctionForecastLinear = function.MetricFunction{
 
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
 		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
-		seriesList, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -186,4 +146,4 @@ var FunctionForecastLinear = function.MetricFunction{
 
 		return result, nil
 	},
-}
+)

--- a/function/function.go
+++ b/function/function.go
@@ -1,0 +1,66 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import "fmt"
+
+// The Function interface defines a metric function.
+// It is given several (unevaluated) expressions as input, and evaluates to a Value.
+type Function interface {
+	Run(EvaluationContext, []Expression, Groups) (Value, error)
+	Name() string
+}
+
+// The Registry interface defines a mapping from names to Functions
+// and provides a way to get the full list of functions defined.
+type Registry interface {
+	GetFunction(string) (Function, bool) // returns an instance of a Function
+	All() []string                       // all the registered functions
+}
+
+// Groups holds grouping information - which tags to group by (if any), and whether to `collapse` (Collapses = true) or `group` (Collapses = false)
+type Groups struct {
+	List      []string // the tags to group by
+	Collapses bool     // whether to "collapse by" instead of "group by"
+}
+
+// MetricFunction holds a generic function object with information about its parameters.
+type MetricFunction struct {
+	FunctionName  string // Name is the name of the function, used in its registration.
+	MinArguments  int    // MinArguments is the minimum number of arguments the function allows.
+	MaxArguments  int    // MaxArguments is the maximum number of arguments the function allows. -1 indicates an unlimited number.
+	AllowsGroupBy bool   // Whether the function allows a 'group by' clause.
+	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
+}
+
+// Name returns the MetricFunction's name.
+func (metricFunc MetricFunction) Name() string {
+	return metricFunc.FunctionName
+}
+
+// Run evaluates the given MetricFunction on its arguments.
+// It performs error-checking against the supplies number of arguments and/or group-by clause.
+func (f MetricFunction) Run(context EvaluationContext, arguments []Expression, groups Groups) (Value, error) {
+	// preprocessing
+	length := len(arguments)
+	if length < f.MinArguments || (f.MaxArguments != -1 && f.MaxArguments < length) {
+		return nil, ArgumentLengthError{f.FunctionName, f.MinArguments, f.MaxArguments, length}
+	}
+	if len(groups.List) > 0 && !f.AllowsGroupBy {
+		// TODO(jee) - use typed errors
+		return nil, fmt.Errorf("function %s doesn't allow a group-by clause", f.FunctionName)
+	}
+	return f.Compute(context, arguments, groups)
+}

--- a/function/make.go
+++ b/function/make.go
@@ -75,7 +75,6 @@ func makePointerTo(x interface{}) interface{} {
 	pointer := reflect.New(reflect.TypeOf(x))
 	pointer.Elem().Set(reflect.ValueOf(x))
 	return pointer.Interface()
-
 }
 
 // MakeFunction is a convenient way to use type-safe functions to

--- a/function/make.go
+++ b/function/make.go
@@ -123,7 +123,7 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 				case valueType:
 					return expression.Evaluate(context)
 				}
-				panic("Unreachable :: Unknown type to evaluate to")
+				panic(fmt.Sprintf("Unreachable :: Attempting to evaluate to unknown type %+v", resultType))
 			}
 
 			// argumentFuncs holds functions to obtain the Value arguments.
@@ -168,7 +168,7 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 						argumentFuncs[i] = provideZeroValue(argType)
 					} else {
 						argumentFuncs[i] = func() (interface{}, error) {
-							resultI, err := evalTo(arg, argType)
+							resultI, err := evalTo(arg, argType.Elem())
 							if err != nil {
 								return nil, err
 							}

--- a/function/make.go
+++ b/function/make.go
@@ -1,0 +1,179 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/square/metrics/api"
+)
+
+var stringType = reflect.TypeOf("")
+var scalarType = reflect.TypeOf(float64(0.0))
+var durationType = reflect.TypeOf(time.Duration(0))
+var timeseriesType = reflect.TypeOf(api.SeriesList{})
+var valueType = reflect.TypeOf((*Value)(nil)).Elem()
+var expressionType = reflect.TypeOf((*Expression)(nil)).Elem()
+var groupsType = reflect.TypeOf(Groups{})
+var contextType = reflect.TypeOf(EvaluationContext{})
+var timerangeType = reflect.TypeOf(api.Timerange{})
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// MakeFunction is a convenient way to use type-safe functions to
+// construct MetricFunctions without manually checking parameters.
+func MakeFunction(name string, function interface{}) MetricFunction {
+	funcValue := reflect.ValueOf(function)
+	if funcValue.Kind() != reflect.Func {
+		panic("MetricFunction expects a function as input.")
+	}
+	funcType := funcValue.Type()
+	if funcType.NumOut() == 0 {
+		panic("MetricFunction's argument function must return a value.")
+	}
+	if funcType.NumOut() > 2 {
+		panic("MetricFunction's argument function must return at most two values.")
+	}
+	// TODO: allow subtypes
+	if !funcType.Out(0).ConvertibleTo(valueType) {
+		panic("MetricFunction's argument function's first return type must be assignable to `function.Value`")
+	}
+	if funcType.NumOut() == 2 && !funcType.Out(1).ConvertibleTo(errorType) {
+		panic("MetricFunction's argument function's second return type must be `error`.")
+	}
+
+	formalArgumentCount := 0
+	allowsGroupBy := false
+	for i := 0; i < funcType.NumIn(); i++ {
+		argType := funcType.In(i)
+		if argType == contextType || argType == timerangeType {
+			// It asks for context (or part of it).
+			continue
+		}
+		if argType == groupsType {
+			// It asks for groups.
+			allowsGroupBy = true
+			continue
+		}
+		formalArgumentCount++ // The next thing is an actual argument.
+		if argType == stringType || argType == scalarType || argType == durationType || argType == timeseriesType {
+			// Everything is okay
+			continue
+		}
+		if argType == valueType {
+			// It's untyped.
+			continue
+		}
+		if argType == expressionType {
+			// It's lazy.
+			continue
+		}
+		// TODO: handle optional arguments
+		panic(fmt.Sprintf("MetricFunction function argument asks for unsupported type: cannot supply argument %d of type %+v", i, argType))
+	}
+	// We've checked that everything is sound.
+	return MetricFunction{
+		Name:          name,
+		MinArguments:  formalArgumentCount,
+		MaxArguments:  formalArgumentCount,
+		AllowsGroupBy: allowsGroupBy,
+		Compute: func(context EvaluationContext, arguments []Expression, groups Groups) (Value, error) {
+			argValues := make([]reflect.Value, funcType.NumIn())
+			// TODO: evaluate in parallel where possible.
+			formalArgument := 0
+			for i := 0; i < funcType.NumIn(); i++ {
+				argType := funcType.In(i)
+				if argType == contextType {
+					argValues[i] = reflect.ValueOf(context)
+					continue
+				}
+				if argType == timerangeType {
+					argValues[i] = reflect.ValueOf(context.Timerange)
+					continue
+				}
+				if argType == groupsType {
+					argValues[i] = reflect.ValueOf(groups)
+					continue
+				}
+				if argType == stringType {
+					stringArg, err := EvaluateToString(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(stringArg)
+					formalArgument++
+					continue
+				}
+				if argType == scalarType {
+					scalarArg, err := EvaluateToScalar(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(scalarArg)
+					formalArgument++
+					continue
+				}
+				if argType == durationType {
+					durationArg, err := EvaluateToDuration(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(durationArg)
+					formalArgument++
+					continue
+				}
+				if argType == timeseriesType {
+					timeseriesArg, err := EvaluateToSeriesList(arguments[formalArgument], context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(timeseriesArg)
+					formalArgument++
+					continue
+				}
+				if argType == valueType {
+					valueArg, err := arguments[formalArgument].Evaluate(context)
+					if err != nil {
+						return nil, err
+					}
+					argValues[i] = reflect.ValueOf(valueArg)
+					formalArgument++
+					continue
+				}
+				if argType == expressionType {
+					argValues[i] = reflect.ValueOf(arguments[formalArgument])
+					formalArgument++
+					continue
+				}
+				panic(fmt.Sprintf("Argument to MakeFunction requests invalid type %+v", argType))
+			}
+			output := funcValue.Call(argValues)
+			if len(output) == 1 {
+				return output[0].Interface().(Value), nil
+			}
+			if len(output) == 2 {
+				valueI, errI := output[0].Interface(), output[1].Interface()
+				if errI != nil {
+					return nil, errI.(error)
+				}
+				return valueI.(Value), nil
+			}
+			panic("MakeFunction built with function that doesn't return 2 things.")
+		},
+	}
+
+}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -103,7 +103,7 @@ func Default() StandardRegistry {
 }
 
 // GetFunction returns a function associated with the given name, if it exists.
-func (r StandardRegistry) GetFunction(name string) (function.MetricFunction, bool) {
+func (r StandardRegistry) GetFunction(name string) (function.Function, bool) {
 	fun, ok := r.mapping[name]
 	return fun, ok
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
@@ -144,91 +145,49 @@ func MustRegister(fun function.MetricFunction) {
 
 // Constructor Functions
 
-// NewFilterCount creates a new instance of a count filtering function.
+// NewFilter creates a new instance of a filtering function.
 func NewFilterCount(name string, summary func([]float64) float64, ascending bool) function.MetricFunction {
-	return function.MetricFunction{
-		Name:         name,
-		MinArguments: 2,
-		MaxArguments: 3,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-			list, err := function.EvaluateToSeriesList(arguments[0], context)
-			if err != nil {
-				return nil, err
-			}
-			countFloat, err := function.EvaluateToScalar(arguments[1], context)
-			if err != nil {
-				return nil, err
-			}
-			recentDuration := context.Timerange.Duration()
-			if len(arguments) == 3 {
-				recentDuration, err = function.EvaluateToDuration(arguments[2], context)
-				if err != nil {
-					return nil, err
-				}
-			}
-			// Round to the nearest integer.
+	return function.MakeFunction(
+		name,
+		func(list api.SeriesList, countFloat float64, optionalDuration *time.Duration, timerange api.Timerange) (function.Value, error) {
 			count := int(countFloat + 0.5)
 			if count < 0 {
 				return nil, fmt.Errorf("expected positive count but got %d", count)
 			}
-			if recentDuration < 0 {
-				return nil, fmt.Errorf("expected positive recent duration but got %+v", recentDuration)
+			duration := timerange.Duration()
+			if optionalDuration != nil {
+				if *optionalDuration < 0 {
+					return nil, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
+				}
+				duration = *optionalDuration
 			}
-			result := filter.FilterByRecent(list, count, summary, ascending, recentDuration)
-			return result, nil
+			return filter.FilterByRecent(list, count, summary, ascending, duration), nil
 		},
-	}
+	)
 }
 
-// NewFilterThreshold creates a new instance of a threshold filtering function.
-func NewFilterThreshold(name string, summary func([]float64) float64, below bool) function.MetricFunction {
-	return function.MetricFunction{
-		Name:         name,
-		MinArguments: 2,
-		MaxArguments: 3,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-			list, err := function.EvaluateToSeriesList(arguments[0], context)
-			if err != nil {
-				return nil, err
-			}
-			threshold, err := function.EvaluateToScalar(arguments[1], context)
-			if err != nil {
-				return nil, err
-			}
-			recentDuration := context.Timerange.Duration()
-			if len(arguments) == 3 {
-				// Set the duration to the third argument.
-				recentDuration, err = function.EvaluateToDuration(arguments[2], context)
-				if err != nil {
-					return nil, err
+// NewFilterThreshold creates a new instance of a filtering function.
+func NewFilterThreshold(name string, summary func([]float64) float64, ascending bool) function.MetricFunction {
+	return function.MakeFunction(
+		name,
+		func(list api.SeriesList, threshold float64, optionalDuration *time.Duration, timerange api.Timerange) (function.Value, error) {
+			duration := timerange.Duration()
+			if optionalDuration != nil {
+				if *optionalDuration < 0 {
+					return nil, fmt.Errorf("expected a positive duration but got %+v", *optionalDuration)
 				}
+				duration = *optionalDuration
 			}
-
-			if recentDuration < 0 {
-				return nil, fmt.Errorf("expected positive recent duration but got %+v", recentDuration)
-			}
-			result := filter.FilterThresholdByRecent(list, threshold, summary, below, recentDuration)
-			return result, nil
+			return filter.FilterThresholdByRecent(list, threshold, summary, ascending, duration), nil
 		},
-	}
+	)
 }
 
 // NewAggregate takes a named aggregating function `[float64] => float64` and makes it into a MetricFunction.
 func NewAggregate(name string, aggregator func([]float64) float64) function.MetricFunction {
-	return function.MetricFunction{
-		Name:          name,
-		MinArguments:  1,
-		MaxArguments:  1,
-		AllowsGroupBy: true,
-		Compute: func(context function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
-			argument := args[0]
-			seriesList, err := function.EvaluateToSeriesList(argument, context)
-			if err != nil {
-				return nil, err
-			}
-			return aggregate.By(seriesList, aggregator, groups.List, groups.Collapses), nil
-		},
-	}
+	return function.MakeFunction(name, func(seriesList api.SeriesList, groups function.Groups) api.SeriesList {
+		return aggregate.By(seriesList, aggregator, groups.List, groups.Collapses)
+	})
 }
 
 // NewTransform takes a named transforming function `[float64], [value] => [float64]` and makes it into a MetricFunction.
@@ -257,22 +216,15 @@ func NewTransform(name string, parameterCount int, transformer func(function.Eva
 // NewOperator creates a new binary operator function.
 // the binary operators display a natural join semantic.
 func NewOperator(op string, operator func(float64, float64) float64) function.MetricFunction {
-	return function.MetricFunction{
-		Name:         op,
-		MinArguments: 2,
-		MaxArguments: 2,
-		Compute: func(context function.EvaluationContext, args []function.Expression, groups function.Groups) (function.Value, error) {
-			evaluated, err := function.EvaluateMany(context, args)
+	return function.MakeFunction(
+		op,
+		func(leftValue function.Value, rightValue function.Value, timerange api.Timerange) (function.Value, error) {
+			// TODO: rewrite MakeFunction to evaluate these in parallel.
+			leftList, err := leftValue.ToSeriesList(timerange)
 			if err != nil {
 				return nil, err
 			}
-			leftValue := evaluated[0]
-			rightValue := evaluated[1]
-			leftList, err := leftValue.ToSeriesList(context.Timerange, args[0].QueryString())
-			if err != nil {
-				return nil, err
-			}
-			rightList, err := rightValue.ToSeriesList(context.Timerange, args[1].QueryString())
+			rightList, err := rightValue.ToSeriesList(timerange)
 			if err != nil {
 				return nil, err
 			}
@@ -293,8 +245,8 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 
 			return api.SeriesList{
 				Series:    result,
-				Timerange: context.Timerange,
+				Timerange: timerange,
 			}, nil
 		},
-	}
+	)
 }

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -93,10 +93,10 @@ func init() {
 
 // StandardRegistry of a functions available in MQE.
 type StandardRegistry struct {
-	mapping map[string]function.MetricFunction
+	mapping map[string]function.Function
 }
 
-var defaultRegistry = StandardRegistry{mapping: make(map[string]function.MetricFunction)}
+var defaultRegistry = StandardRegistry{mapping: make(map[string]function.Function)}
 
 func Default() StandardRegistry {
 	return defaultRegistry
@@ -120,23 +120,20 @@ func (r StandardRegistry) All() []string {
 }
 
 // Register a new function into the registry.
-func (r StandardRegistry) Register(fun function.MetricFunction) error {
-	_, ok := r.mapping[fun.Name]
+func (r StandardRegistry) Register(fun function.Function) error {
+	_, ok := r.mapping[fun.Name()]
 	if ok {
 		return fmt.Errorf("function %s has already been registered", fun.Name)
 	}
-	if fun.Compute == nil {
-		return fmt.Errorf("function %s has no Compute() field", fun.Name)
-	}
-	if fun.Name == "" {
+	if fun.Name() == "" {
 		return fmt.Errorf("empty function name")
 	}
-	r.mapping[fun.Name] = fun
+	r.mapping[fun.Name()] = fun
 	return nil
 }
 
 // MustRegister adds a new metric function to the global function registry.
-func MustRegister(fun function.MetricFunction) {
+func MustRegister(fun function.Function) {
 	err := defaultRegistry.Register(fun)
 	if err != nil {
 		panic(fmt.Sprintf("function %s has failed to register", fun.Name))
@@ -185,15 +182,18 @@ func NewFilterThreshold(name string, summary func([]float64) float64, ascending 
 
 // NewAggregate takes a named aggregating function `[float64] => float64` and makes it into a MetricFunction.
 func NewAggregate(name string, aggregator func([]float64) float64) function.MetricFunction {
-	return function.MakeFunction(name, func(seriesList api.SeriesList, groups function.Groups) api.SeriesList {
-		return aggregate.By(seriesList, aggregator, groups.List, groups.Collapses)
-	})
+	return function.MakeFunction(
+		name,
+		func(seriesList api.SeriesList, groups function.Groups) api.SeriesList {
+			return aggregate.By(seriesList, aggregator, groups.List, groups.Collapses)
+		},
+	)
 }
 
 // NewTransform takes a named transforming function `[float64], [value] => [float64]` and makes it into a MetricFunction.
 func NewTransform(name string, parameterCount int, transformer func(function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error)) function.MetricFunction {
 	return function.MetricFunction{
-		Name:         name,
+		FunctionName: name,
 		MinArguments: parameterCount + 1,
 		MaxArguments: parameterCount + 1,
 		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
@@ -215,20 +215,10 @@ func NewTransform(name string, parameterCount int, transformer func(function.Eva
 
 // NewOperator creates a new binary operator function.
 // the binary operators display a natural join semantic.
-func NewOperator(op string, operator func(float64, float64) float64) function.MetricFunction {
+func NewOperator(op string, operator func(float64, float64) float64) function.Function {
 	return function.MakeFunction(
 		op,
-		func(leftValue function.Value, rightValue function.Value, timerange api.Timerange) (function.Value, error) {
-			// TODO: rewrite MakeFunction to evaluate these in parallel.
-			leftList, err := leftValue.ToSeriesList(timerange)
-			if err != nil {
-				return nil, err
-			}
-			rightList, err := rightValue.ToSeriesList(timerange)
-			if err != nil {
-				return nil, err
-			}
-
+		func(leftList api.SeriesList, rightList api.SeriesList, timerange api.Timerange) (function.Value, error) {
 			joined := join.Join([]api.SeriesList{leftList, rightList})
 
 			result := make([]api.Timeseries, len(joined.Rows))

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/square/metrics/function/filter"
 	"github.com/square/metrics/function/forecast"
 	"github.com/square/metrics/function/join"
+	"github.com/square/metrics/function/summary"
 	"github.com/square/metrics/function/tag"
 	"github.com/square/metrics/function/transform"
 )
@@ -89,6 +90,14 @@ func init() {
 	MustRegister(forecast.FunctionForecastLinear)
 
 	MustRegister(forecast.FunctionDrop)
+
+	// Summary
+	MustRegister(summary.Mean)
+	MustRegister(summary.Min)
+	MustRegister(summary.Max)
+	MustRegister(summary.Current)
+	MustRegister(summary.LastNotNaN)
+
 }
 
 // StandardRegistry of a functions available in MQE.

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -132,7 +132,7 @@ func (r StandardRegistry) All() []string {
 func (r StandardRegistry) Register(fun function.Function) error {
 	_, ok := r.mapping[fun.Name()]
 	if ok {
-		return fmt.Errorf("function %s has already been registered", fun.Name)
+		return fmt.Errorf("function %s has already been registered", fun.Name())
 	}
 	if fun.Name() == "" {
 		return fmt.Errorf("empty function name")
@@ -145,7 +145,7 @@ func (r StandardRegistry) Register(fun function.Function) error {
 func MustRegister(fun function.Function) {
 	err := defaultRegistry.Register(fun)
 	if err != nil {
-		panic(fmt.Sprintf("function %s has failed to register", fun.Name))
+		panic(fmt.Sprintf("function %s has failed to register: %s", fun.Name(), err.Error()))
 	}
 }
 

--- a/function/registry/registry_test.go
+++ b/function/registry/registry_test.go
@@ -46,7 +46,6 @@ func Test_Registry_Error(t *testing.T) {
 	}{
 		{"empty name", function.MetricFunction{FunctionName: "", Compute: dummyCompute}},
 		{"duplicate name", function.MetricFunction{FunctionName: "existing", Compute: dummyCompute}},
-		{"no compute", function.MetricFunction{FunctionName: "notexisting", Compute: nil}},
 	} {
 		a := assert.New(t).Contextf("%s", suite.Name)
 		// set up the standard registry

--- a/function/registry/registry_test.go
+++ b/function/registry/registry_test.go
@@ -28,12 +28,12 @@ var dummyCompute = func(function.EvaluationContext, []function.Expression, funct
 
 func Test_Registry_Default(t *testing.T) {
 	a := assert.New(t)
-	sr := StandardRegistry{mapping: make(map[string]function.MetricFunction)}
+	sr := StandardRegistry{mapping: make(map[string]function.Function)}
 	a.Eq(sr.All(), []string{})
-	if err := sr.Register(function.MetricFunction{Name: "foo", Compute: dummyCompute}); err != nil {
+	if err := sr.Register(function.MetricFunction{FunctionName: "foo", Compute: dummyCompute}); err != nil {
 		a.CheckError(err)
 	}
-	if err := sr.Register(function.MetricFunction{Name: "bar", Compute: dummyCompute}); err != nil {
+	if err := sr.Register(function.MetricFunction{FunctionName: "bar", Compute: dummyCompute}); err != nil {
 		a.CheckError(err)
 	}
 	a.Eq(sr.All(), []string{"bar", "foo"})
@@ -44,14 +44,14 @@ func Test_Registry_Error(t *testing.T) {
 		Name     string
 		Function function.MetricFunction
 	}{
-		{"empty name", function.MetricFunction{Name: "", Compute: dummyCompute}},
-		{"duplicate name", function.MetricFunction{Name: "existing", Compute: dummyCompute}},
-		{"no compute", function.MetricFunction{Name: "notexisting", Compute: nil}},
+		{"empty name", function.MetricFunction{FunctionName: "", Compute: dummyCompute}},
+		{"duplicate name", function.MetricFunction{FunctionName: "existing", Compute: dummyCompute}},
+		{"no compute", function.MetricFunction{FunctionName: "notexisting", Compute: nil}},
 	} {
 		a := assert.New(t).Contextf("%s", suite.Name)
 		// set up the standard registry
-		sr := StandardRegistry{mapping: make(map[string]function.MetricFunction)}
-		if err := sr.Register(function.MetricFunction{Name: "existing", Compute: dummyCompute}); err != nil {
+		sr := StandardRegistry{mapping: make(map[string]function.Function)}
+		if err := sr.Register(function.MetricFunction{FunctionName: "existing", Compute: dummyCompute}); err != nil {
 			a.CheckError(err)
 			return
 		}

--- a/function/summary/summary.go
+++ b/function/summary/summary.go
@@ -1,0 +1,112 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"math"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/function"
+)
+
+// This file culminates in the definition of `aggregateBy`, which takes a SeriesList and an Aggregator and a list of tags,
+// and produces an aggregated SeriesList with one list per group, each group having been aggregated into it.
+
+var recent = func(name string, summarizer func([]float64) float64) function.MetricFunction {
+	return function.MakeFunction(
+		"summarize.mean",
+		func(list api.SeriesList, optionalDuration *time.Duration) function.ScalarSet {
+			duration := list.Timerange.Duration()
+			if optionalDuration != nil {
+				duration = *optionalDuration
+			}
+			start := list.Timerange.Slots() - 1 - int(duration/list.Timerange.Resolution())
+			if start < 0 {
+				start = 0
+				// TODO: warn or error?
+			}
+			result := function.ScalarSet{}
+			for i := range list.Series {
+				slice := list.Series[i].Values[start:]
+				result = append(result, function.TaggedScalar{
+					TagSet: list.Series[i].TagSet,
+					Value:  summarizer(slice),
+				})
+			}
+			return result
+		},
+	)
+}
+
+var Mean = recent(
+	"summarize.mean",
+	func(slice []float64) float64 {
+		sum := 0.0
+		for i := range slice {
+			sum += slice[i]
+		}
+		return sum / float64(len(slice))
+	},
+)
+
+var Min = recent(
+	"summarize.min",
+	func(slice []float64) float64 {
+		min := math.Inf(1)
+		for i := range slice {
+			min = math.Min(min, slice[i])
+		}
+		return min
+	},
+)
+
+var Max = recent(
+	"summarize.max",
+	func(slice []float64) float64 {
+		max := math.Inf(-1)
+		for i := range slice {
+			max = math.Max(max, slice[i])
+		}
+		return max
+	},
+)
+
+var LastNotNaN = recent(
+	"summarize.last_not_nan",
+	func(slice []float64) float64 {
+		for i := range slice {
+			if !math.IsNaN(slice[len(slice)-1-i]) {
+				return slice[len(slice)-1-i]
+			}
+		}
+		return math.NaN()
+	},
+)
+
+var Current = function.MakeFunction(
+	"summarize.current",
+	func(list api.SeriesList) function.ScalarSet {
+		result := function.ScalarSet{}
+		for i := range list.Series {
+			values := list.Series[i].Values
+			result = append(result, function.TaggedScalar{
+				TagSet: list.Series[i].TagSet,
+				Value:  values[len(values)-1],
+			})
+		}
+		return result
+	},
+)

--- a/function/summary/summary.go
+++ b/function/summary/summary.go
@@ -27,7 +27,7 @@ import (
 
 var recent = func(name string, summarizer func([]float64) float64) function.MetricFunction {
 	return function.MakeFunction(
-		"summarize.mean",
+		name,
 		func(list api.SeriesList, optionalDuration *time.Duration) function.ScalarSet {
 			duration := list.Timerange.Duration()
 			if optionalDuration != nil {

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -66,8 +66,8 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 	}
 }
 
-// DropFunction wraps up DropTag into a MetricFunction called "tag.drop"
+// DropFunction wraps up DropTag into a Function called "tag.drop"
 var DropFunction = function.MakeFunction("tag.drop", DropTag)
 
-// SetFunction wraps up SetTag into a MetricFunction called "tag.set"
+// SetFunction wraps up SetTag into a Function called "tag.set"
 var SetFunction = function.MakeFunction("tag.set", SetTag)

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -67,43 +67,7 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 }
 
 // DropFunction wraps up DropTag into a MetricFunction called "tag.drop"
-var DropFunction = function.MetricFunction{
-	Name:         "tag.drop",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		list, err := function.EvaluateToSeriesList(arguments[0], context)
-		if err != nil {
-			return nil, err
-		}
-		dropTag, err := function.EvaluateToString(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		// Drop the tag from the list.
-		return DropTag(list, dropTag), nil
-	},
-}
+var DropFunction = function.MakeFunction("tag.drop", DropTag)
 
 // SetFunction wraps up SetTag into a MetricFunction called "tag.set"
-var SetFunction = function.MetricFunction{
-	Name:         "tag.set",
-	MinArguments: 3,
-	MaxArguments: 3,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		list, err := function.EvaluateToSeriesList(arguments[0], context)
-		if err != nil {
-			return nil, err
-		}
-		tag, err := function.EvaluateToString(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-		set, err := function.EvaluateToString(arguments[2], context)
-		if err != nil {
-			return nil, err
-		}
-		// Set the tag for the list:
-		return SetTag(list, tag, set), nil
-	},
-}
+var SetFunction = function.MakeFunction("tag.set", SetTag)

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -33,7 +33,7 @@ var Timeshift = function.MakeFunction(
 
 var MovingAverage = function.MakeFunction(
 	"transform.moving_average",
-	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (api.SeriesList, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
 		limit := int(float64(size)/float64(context.Timerange.Resolution()) + 0.5) // Limit is the number of items to include in the average
 		if limit < 1 {
@@ -44,13 +44,13 @@ var MovingAverage = function.MakeFunction(
 		timerange := context.Timerange
 		newTimerange, err := api.NewSnappedTimerange(timerange.StartMillis()-int64(limit-1)*timerange.ResolutionMillis(), timerange.EndMillis(), timerange.ResolutionMillis())
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 		newContext := context.WithTimerange(newTimerange)
 		// The new context has a timerange which is extended beyond the query's.
 		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		// The timerange must be reverted.
@@ -91,7 +91,7 @@ var MovingAverage = function.MakeFunction(
 
 var ExponentialMovingAverage = function.MakeFunction(
 	"transform.exponential_moving_average",
-	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (function.Value, error) {
+	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (api.SeriesList, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
 		limit := int(float64(size)/float64(context.Timerange.Resolution()) + 0.5) // Limit is the number of items to include in the average
 		if limit < 1 {
@@ -102,7 +102,7 @@ var ExponentialMovingAverage = function.MakeFunction(
 		timerange := context.Timerange
 		newTimerange, err := api.NewSnappedTimerange(timerange.StartMillis()-int64(limit-1)*timerange.ResolutionMillis(), timerange.EndMillis(), timerange.ResolutionMillis())
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		newContext := context.WithTimerange(newTimerange)
@@ -110,7 +110,7 @@ var ExponentialMovingAverage = function.MakeFunction(
 		// The new context has a timerange which is extended beyond the query's.
 		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
 
 		// How many "ticks" are there in "size"?
@@ -152,83 +152,79 @@ var Alias = function.MakeFunction("transform.alias", func(context function.Evalu
 
 // Derivative is special because it needs to get one extra data point to the left
 // This transform estimates the "change per second" between the two samples (scaled consecutive difference)
-var Derivative = newDerivativeBasedTransform("derivative", derivative)
-
-func derivative(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
-	values := series.Values
-	result := make([]float64, len(values)-1)
-	for i := range values {
-		if i == 0 {
-			continue
+var Derivative = function.MakeFunction(
+	"transform.derivative",
+	func(listExpression function.Expression, context function.EvaluationContext) (api.SeriesList, error) {
+		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
+		list, err := function.EvaluateToSeriesList(listExpression, newContext)
+		if err != nil {
+			return api.SeriesList{}, err
 		}
-		// Scaled difference
-		result[i-1] = (values[i] - values[i-1]) / scale
-	}
-	return result, nil
-}
+		resultList := api.SeriesList{
+			Series:    make([]api.Timeseries, len(list.Series)),
+			Timerange: list.Timerange,
+		}
+		for seriesIndex, series := range list.Series {
+			newValues := make([]float64, len(series.Values)-1)
+			for i := range series.Values {
+				if i == 0 {
+					continue
+				}
+				// Scaled difference
+				newValues[i-1] = (series.Values[i] - series.Values[i-1]) / context.Timerange.Resolution().Seconds()
+			}
+			resultList.Series[seriesIndex] = api.Timeseries{
+				Values: newValues,
+				TagSet: series.TagSet, // TODO: verify that these are immutable
+			}
+		}
+		return resultList, nil
+	},
+)
 
 // Rate is special because it needs to get one extra data point to the left.
 // This transform functions mostly like Derivative but bounds the result to be positive.
 // Specifically this function is designed for strictly increasing counters that
 // only decrease when reset to zero. That is, thie function returns consecutive
 // differences which are at least 0, or math.Max of the newly reported value and 0
-var Rate = newDerivativeBasedTransform("rate", rate)
-
-func rate(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
-	values := series.Values
-	result := make([]float64, len(values)-1)
-	for i := range values {
-		if i == 0 {
-			continue
-		}
-		// Scaled difference
-		result[i-1] = (values[i] - values[i-1]) / scale
-		if result[i-1] < 0 {
-			result[i-1] = 0
-		}
-		if i+1 < len(values) && values[i-1] > values[i] && values[i] <= values[i+1] {
-			// Downsampling may cause a drop from 1000 to 0 to look like [1000, 500, 0] instead of [1000, 1001, 0].
-			// So we check the next, in addition to the previous.
-			ctx.EvaluationNotes.AddNote(fmt.Sprintf("Rate(%v): The underlying counter reset between %f, %f\n", series.TagSet, values[i-1], values[i]))
-			// values[i] is our best approximatation of the delta between i-1 and i
-			// Why? This should only be used on counters, so if v[i] - v[i-1] < 0 then
-			// the counter has reset, and we know *at least* v[i] increments have happened
-			result[i-1] = math.Max(values[i], 0) / scale
-		}
-	}
-	return result, nil
-}
-
-// newDerivativeBasedTransform returns a function.Function that performs
-// a delta between two data points. The transform parameter is a function of type
-// transform is expected to return an array of values whose length is 1 less
-// than the given series
-func newDerivativeBasedTransform(name string, transformer transform) function.Function {
-	return function.MakeFunction("transform."+name, func(context function.EvaluationContext, listExpression function.Expression) (function.Value, error) {
+var Rate = function.MakeFunction(
+	"transform.rate",
+	func(listExpression function.Expression, context function.EvaluationContext) (api.SeriesList, error) {
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
-
-		// The new context has a timerange which is extended beyond the query's.
 		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
-			return nil, err
+			return api.SeriesList{}, err
 		}
-
-		// Reset the timerange
-		list.Timerange = context.Timerange
-
-		//Apply the original context to the transform even though the list
-		//will include one additional data point.
-		result, err := ApplyTransform(context, list, transformer, []function.Value{})
-		if err != nil {
-			return nil, err
+		resultList := api.SeriesList{
+			Series:    make([]api.Timeseries, len(list.Series)),
+			Timerange: list.Timerange,
 		}
-
-		// Validate our series are the correct length
-		for i := range result.Series {
-			if len(result.Series[i].Values) != len(list.Series[i].Values)-1 {
-				panic(fmt.Sprintf("Expected transform to return %d values, received %d", len(list.Series[i].Values)-1, len(result.Series[i].Values)))
+		for seriesIndex, series := range list.Series {
+			newValues := make([]float64, len(series.Values)-1)
+			for i := range series.Values {
+				if i == 0 {
+					continue
+				}
+				// Scaled difference
+				newValues[i-1] = (series.Values[i] - series.Values[i-1]) / context.Timerange.Resolution().Seconds()
+				if newValues[i-1] < 0 {
+					newValues[i-1] = 0
+				}
+				if i+1 < len(series.Values) && series.Values[i-1] > series.Values[i] && series.Values[i] <= series.Values[i+1] {
+					// Downsampling may cause a drop from 1000 to 0 to look like [1000, 500, 0] instead of [1000, 1001, 0].
+					// So we check the next, in addition to the previous.
+					context.EvaluationNotes.AddNote(fmt.Sprintf("Rate(%v): The underlying counter reset between %f, %f\n", series.TagSet, series.Values[i-1], series.Values[i]))
+					// values[i] is our best approximatation of the delta between i-1 and i
+					// Why? This should only be used on counters, so if v[i] - v[i-1] < 0 then
+					// the counter has reset, and we know *at least* v[i] increments have happened
+					newValues[i-1] = math.Max(series.Values[i], 0) / context.Timerange.Resolution().Seconds()
+				}
+			}
+			resultList.Series[seriesIndex] = api.Timeseries{
+				Values: newValues,
+				TagSet: series.TagSet, // TODO: verify that these are immutable
 			}
 		}
-		return result, nil
-	})
-}
+		return resultList, nil
+	},
+)

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -199,11 +199,11 @@ func rate(ctx function.EvaluationContext, series api.Timeseries, parameters []fu
 	return result, nil
 }
 
-// newDerivativeBasedTransform returns a function.MetricFunction that performs
+// newDerivativeBasedTransform returns a function.Function that performs
 // a delta between two data points. The transform parameter is a function of type
 // transform is expected to return an array of values whose length is 1 less
 // than the given series
-func newDerivativeBasedTransform(name string, transformer transform) function.MetricFunction {
+func newDerivativeBasedTransform(name string, transformer transform) function.Function {
 	return function.MakeFunction("transform."+name, func(context function.EvaluationContext, listExpression function.Expression) (function.Value, error) {
 		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
 

--- a/function/transform/special.go
+++ b/function/transform/special.go
@@ -17,37 +17,24 @@ package transform
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 )
 
-var Timeshift = function.MetricFunction{
-	Name:         "transform.timeshift",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		duration, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
-
+var Timeshift = function.MakeFunction(
+	"transform.timeshift",
+	func(expression function.Expression, duration time.Duration, context function.EvaluationContext) (function.Value, error) {
 		newContext := context.WithTimerange(context.Timerange.Shift(duration))
-		return arguments[0].Evaluate(newContext)
+		return expression.Evaluate(newContext)
 	},
-}
+)
 
-var MovingAverage = function.MetricFunction{
-	Name:         "transform.moving_average",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+var MovingAverage = function.MakeFunction(
+	"transform.moving_average",
+	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (function.Value, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
-
-		size, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
 		limit := int(float64(size)/float64(context.Timerange.Resolution()) + 0.5) // Limit is the number of items to include in the average
 		if limit < 1 {
 			// At least one value must be included at all times
@@ -61,7 +48,7 @@ var MovingAverage = function.MetricFunction{
 		}
 		newContext := context.WithTimerange(newTimerange)
 		// The new context has a timerange which is extended beyond the query's.
-		list, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -100,19 +87,12 @@ var MovingAverage = function.MetricFunction{
 		}
 		return list, nil
 	},
-}
+)
 
-var ExponentialMovingAverage = function.MetricFunction{
-	Name:         "transform.exponential_moving_average",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+var ExponentialMovingAverage = function.MakeFunction(
+	"transform.exponential_moving_average",
+	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (function.Value, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
-
-		size, err := function.EvaluateToDuration(arguments[1], context)
-		if err != nil {
-			return nil, err
-		}
 		limit := int(float64(size)/float64(context.Timerange.Resolution()) + 0.5) // Limit is the number of items to include in the average
 		if limit < 1 {
 			// At least one value must be included at all times
@@ -128,7 +108,7 @@ var ExponentialMovingAverage = function.MetricFunction{
 		newContext := context.WithTimerange(newTimerange)
 
 		// The new context has a timerange which is extended beyond the query's.
-		list, err := function.EvaluateToSeriesList(arguments[0], newContext)
+		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
 			return nil, err
 		}
@@ -162,18 +142,13 @@ var ExponentialMovingAverage = function.MetricFunction{
 		}
 		return list, nil
 	},
-}
+)
 
-var Alias = function.MetricFunction{
-	Name:         "transform.alias",
-	MinArguments: 2,
-	MaxArguments: 2,
-	Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
-		// TODO: delete this function
-		context.EvaluationNotes.AddNote("transform.alias is deprecated")
-		return arguments[0].Evaluate(context)
-	},
-}
+// TODO: delete this function
+var Alias = function.MakeFunction("transform.alias", func(context function.EvaluationContext, value function.Value) function.Value {
+	context.EvaluationNotes.AddNote("transform.alias is deprecated")
+	return value
+})
 
 // Derivative is special because it needs to get one extra data point to the left
 // This transform estimates the "change per second" between the two samples (scaled consecutive difference)
@@ -229,38 +204,31 @@ func rate(ctx function.EvaluationContext, series api.Timeseries, parameters []fu
 // transform is expected to return an array of values whose length is 1 less
 // than the given series
 func newDerivativeBasedTransform(name string, transformer transform) function.MetricFunction {
-	return function.MetricFunction{
-		Name:         "transform." + name,
-		MinArguments: 1,
-		MaxArguments: 1,
-		Compute: func(context function.EvaluationContext, arguments []function.Expression, groups function.Groups) (function.Value, error) {
+	return function.MakeFunction("transform."+name, func(context function.EvaluationContext, listExpression function.Expression) (function.Value, error) {
+		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
 
-			// Calcuate the new timerange to include one extra point to the left.
-			newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
+		// The new context has a timerange which is extended beyond the query's.
+		list, err := function.EvaluateToSeriesList(listExpression, newContext)
+		if err != nil {
+			return nil, err
+		}
 
-			// The new context has a timerange which is extended beyond the query's.
-			list, err := function.EvaluateToSeriesList(arguments[0], newContext)
-			if err != nil {
-				return nil, err
+		// Reset the timerange
+		list.Timerange = context.Timerange
+
+		//Apply the original context to the transform even though the list
+		//will include one additional data point.
+		result, err := ApplyTransform(context, list, transformer, []function.Value{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Validate our series are the correct length
+		for i := range result.Series {
+			if len(result.Series[i].Values) != len(list.Series[i].Values)-1 {
+				panic(fmt.Sprintf("Expected transform to return %d values, received %d", len(list.Series[i].Values)-1, len(result.Series[i].Values)))
 			}
-
-			// Reset the timerange
-			list.Timerange = context.Timerange
-
-			//Apply the original context to the transform even though the list
-			//will include one additional data point.
-			result, err := ApplyTransform(context, list, transformer, []function.Value{})
-			if err != nil {
-				return nil, err
-			}
-
-			// Validate our series are the correct length
-			for i := range result.Series {
-				if len(result.Series[i].Values) != len(list.Series[i].Values)-1 {
-					panic(fmt.Sprintf("Expected transform to return %d values, received %d", len(list.Series[i].Values)-1, len(result.Series[i].Values)))
-				}
-			}
-			return result, nil
-		},
-	}
+		}
+		return result, nil
+	})
 }

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -109,7 +109,7 @@ func MapMaker(fun func(float64) float64) func(function.EvaluationContext, api.Ti
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
 func Default(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	defaultValue, err := parameters[0].ToScalar("default value")
+	defaultValue, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}
@@ -154,11 +154,11 @@ func (b boundError) TokenName() string {
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
 func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	lowerBound, err := parameters[0].ToScalar("lower bound")
+	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}
-	upperBound, err := parameters[1].ToScalar("upper bound")
+	upperBound, err := parameters[1].ToScalar()
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []f
 // LowerBound replaces values that fall below the given bound with the lower bound.
 func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	lowerBound, err := parameters[0].ToScalar("lower bound")
+	lowerBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameter
 // UpperBound replaces values that fall below the given bound with the lower bound.
 func UpperBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
 	values := series.Values
-	upperBound, err := parameters[0].ToScalar("upper bound")
+	upperBound, err := parameters[0].ToScalar()
 	if err != nil {
 		return nil, err
 	}

--- a/function/value.go
+++ b/function/value.go
@@ -26,7 +26,7 @@ import (
 // Value is the result of evaluating an expression.
 // They can be floating point values, strings, or series lists.
 type Value interface {
-	ToSeriesList(api.Timerange, string) (api.SeriesList, error)
+	ToSeriesList(api.Timerange) (api.SeriesList, error)
 	ToString(string) (string, error)          // takes a description of the object's expression
 	ToScalar(string) (float64, error)         // takes a description of the object's expression
 	ToDuration(string) (time.Duration, error) // takes a description of the object's expression
@@ -53,8 +53,8 @@ func (e ConversionError) TokenName() string {
 type StringValue string
 
 // ToSeriesList is a conversion function.
-func (value StringValue) ToSeriesList(time api.Timerange, description string) (api.SeriesList, error) {
-	return api.SeriesList{}, ConversionError{"string", "SeriesList", description}
+func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error) {
+	return api.SeriesList{}, ConversionError{"string", "SeriesList", "// TODO //"}
 }
 
 // ToString is a conversion function.
@@ -77,7 +77,7 @@ type ScalarValue float64
 
 // ToSeriesList is a conversion function.
 // The scalar becomes a constant value for the timerange.
-func (value ScalarValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
+func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
 	series := make([]float64, timerange.Slots())
 	for i := range series {
 		series[i] = float64(value)
@@ -117,8 +117,8 @@ func NewDurationValue(name string, duration time.Duration) DurationValue {
 }
 
 // ToSeriesList is a conversion function.
-func (value DurationValue) ToSeriesList(timerange api.Timerange, description string) (api.SeriesList, error) {
-	return api.SeriesList{}, ConversionError{"duration", "SeriesList", description}
+func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, error) {
+	return api.SeriesList{}, ConversionError{"duration", "SeriesList", "// TODO //"}
 }
 
 // ToString is a conversion function.

--- a/function/value.go
+++ b/function/value.go
@@ -27,9 +27,9 @@ import (
 // They can be floating point values, strings, or series lists.
 type Value interface {
 	ToSeriesList(api.Timerange) (api.SeriesList, error)
-	ToString(string) (string, error)          // takes a description of the object's expression
-	ToScalar(string) (float64, error)         // takes a description of the object's expression
-	ToDuration(string) (time.Duration, error) // takes a description of the object's expression
+	ToString() (string, error)
+	ToScalar() (float64, error)
+	ToDuration() (time.Duration, error)
 }
 
 // ConversionError represents an error converting between two items of different types.
@@ -58,18 +58,18 @@ func (value StringValue) ToSeriesList(time api.Timerange) (api.SeriesList, error
 }
 
 // ToString is a conversion function.
-func (value StringValue) ToString(description string) (string, error) {
+func (value StringValue) ToString() (string, error) {
 	return string(value), nil
 }
 
 // ToScalar is a conversion function.
-func (value StringValue) ToScalar(description string) (float64, error) {
-	return 0, ConversionError{"string", "scalar", description}
+func (value StringValue) ToScalar() (float64, error) {
+	return 0, ConversionError{"string", "scalar", ""}
 }
 
 // ToDuration is a conversion function.
-func (value StringValue) ToDuration(description string) (time.Duration, error) {
-	return 0, ConversionError{"string", "duration", description}
+func (value StringValue) ToDuration() (time.Duration, error) {
+	return 0, ConversionError{"string", "duration", ""}
 }
 
 // A ScalarValue holds a float and can be converted to a serieslist
@@ -90,19 +90,19 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange) (api.SeriesList, 
 }
 
 // ToString is a conversion function. Numbers become formatted.
-func (value ScalarValue) ToString(description string) (string, error) {
+func (value ScalarValue) ToString() (string, error) {
 	return "", ConversionError{"scalar", "string", fmt.Sprintf("%f", value)}
 }
 
 // ToScalar is a conversion function.
-func (value ScalarValue) ToScalar(description string) (float64, error) {
+func (value ScalarValue) ToScalar() (float64, error) {
 	return float64(value), nil
 }
 
 // ToDuration is a conversion function.
 // Scalars cannot be converted to durations.
-func (value ScalarValue) ToDuration(description string) (time.Duration, error) {
-	return 0, ConversionError{"scalar", "duration", description}
+func (value ScalarValue) ToDuration() (time.Duration, error) {
+	return 0, ConversionError{"scalar", "duration", ""}
 }
 
 // DurationValue is a duration with a (usually) human-written name.
@@ -122,17 +122,17 @@ func (value DurationValue) ToSeriesList(timerange api.Timerange) (api.SeriesList
 }
 
 // ToString is a conversion function.
-func (value DurationValue) ToString(description string) (string, error) {
-	return "", ConversionError{"duration", "string", description}
+func (value DurationValue) ToString() (string, error) {
+	return "", ConversionError{"duration", "string", ""}
 }
 
 // ToScalar is a conversion function.
-func (value DurationValue) ToScalar(description string) (float64, error) {
-	return 0, ConversionError{"duration", "scalar", description}
+func (value DurationValue) ToScalar() (float64, error) {
+	return 0, ConversionError{"duration", "scalar", ""}
 }
 
 // ToDuration is a conversion function.
-func (value DurationValue) ToDuration(description string) (time.Duration, error) {
+func (value DurationValue) ToDuration() (time.Duration, error) {
 	return time.Duration(value.duration), nil
 }
 

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -272,7 +272,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 	case result := <-results:
 		lists := make([]api.SeriesList, len(result))
 		for i := range result {
-			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange, cmd.Expressions[i].QueryString())
+			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange)
 			if err != nil {
 				return CommandResult{}, err
 			}

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -272,9 +272,10 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 	case result := <-results:
 		lists := make([]api.SeriesList, len(result))
 		for i := range result {
-			lists[i], err = result[i].ToSeriesList(evaluationContext.Timerange)
-			if err != nil {
-				return CommandResult{}, err
+			var convErr *function.ConversionFailure
+			lists[i], convErr = result[i].ToSeriesList(evaluationContext.Timerange)
+			if convErr != nil {
+				return CommandResult{}, convErr.WithContext(cmd.Expressions[i].QueryString())
 			}
 		}
 		description := map[string][]string{}

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -142,7 +142,7 @@ func (expr *FunctionExpression) Evaluate(context function.EvaluationContext) (fu
 		return nil, SyntaxError{fmt.Sprintf("no such function %s", expr.FunctionName)}
 	}
 
-	return fun.Evaluate(context, expr.Arguments, expr.GroupBy, expr.GroupByCollapses)
+	return fun.Run(context, expr.Arguments, function.Groups{expr.GroupBy, expr.GroupByCollapses})
 }
 
 func functionFormatString(argumentStrings []string, f FunctionExpression) string {

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -36,7 +36,7 @@ type Duration struct {
 }
 
 func (expr Duration) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return function.NewDurationValue(expr.Literal, expr.Duration), nil
+	return function.DurationValue(expr.Duration), nil
 }
 
 func (expr Duration) Name() string {

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -105,7 +105,7 @@ func (expr *MetricFetchExpression) Evaluate(context function.EvaluationContext) 
 		metrics[i] = api.TaggedMetric{api.MetricKey(expr.MetricName), filtered[i]}
 	}
 
-	return context.TimeseriesStorageAPI.FetchMultipleTimeseries(
+	seriesList, err := context.TimeseriesStorageAPI.FetchMultipleTimeseries(
 		timeseries.FetchMultipleRequest{
 			metrics,
 			timeseries.RequestDetails{
@@ -117,6 +117,10 @@ func (expr *MetricFetchExpression) Evaluate(context function.EvaluationContext) 
 			},
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	return function.SeriesListValue(seriesList), nil
 }
 
 func (expr *MetricFetchExpression) QueryString() string {

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -325,7 +325,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 
 		metricFun := registry.NewOperator(test.functionName, test.evalFunction)
 
-		value, err := metricFun.Evaluate(test.context, []function.Expression{&LiteralSeriesExpression{test.left}, &LiteralSeriesExpression{test.right}}, []string{}, false)
+		value, err := metricFun.Run(test.context, []function.Expression{&LiteralSeriesExpression{test.left}, &LiteralSeriesExpression{test.right}}, function.Groups{})
 		if err != nil {
 			a.EqBool(err == nil, test.expectSuccess)
 			continue

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -331,7 +331,7 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			continue
 		}
 
-		result, err := value.ToSeriesList(test.context.Timerange, "-test-")
+		result, err := value.ToSeriesList(test.context.Timerange)
 		if err != nil {
 			a.EqBool(err == nil, test.expectSuccess)
 			continue

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -41,10 +41,10 @@ func (le LiteralExpression) Name() string {
 }
 
 func (expr *LiteralExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return api.SeriesList{
+	return function.SeriesListValue(api.SeriesList{
 		Series:    []api.Timeseries{{Values: expr.Values, TagSet: api.NewTagSet()}},
 		Timerange: api.Timerange{},
-	}, nil
+	}), nil
 }
 
 type LiteralSeriesExpression struct {
@@ -58,7 +58,7 @@ func (lse LiteralSeriesExpression) Name() string {
 	return "<literal series expression>"
 }
 func (expr *LiteralSeriesExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
-	return expr.list, nil
+	return function.SeriesListValue(expr.list), nil
 }
 
 func Test_ScalarExpression(t *testing.T) {
@@ -331,9 +331,9 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 			continue
 		}
 
-		result, err := value.ToSeriesList(test.context.Timerange)
-		if err != nil {
-			a.EqBool(err == nil, test.expectSuccess)
+		result, convErr := value.ToSeriesList(test.context.Timerange)
+		if convErr != nil {
+			a.EqBool(convErr == nil, test.expectSuccess)
 			continue
 		}
 


### PR DESCRIPTION
This builds off of #276 and adds support for "scalar sets," or tagged-scalar-values. Make sure to merge it (and rebase this change) first.

These are used to be able to get summary numbers out of MQE, or use them in calculations. For example,

```
select
http.requests | aggregate.sum(group by app) | summarize.mean
from -2hr to now
```
to see a per-app total request count over the past 2 hours.

TODO: tests

TODO: add UI for scalar results (pie chart? polar area chart? bar chart? stacked bar chart? table?)