### PR TITLE
Remove timerange from series list

### DIFF
--- a/api/serieslist.go
+++ b/api/serieslist.go
@@ -23,8 +23,7 @@ import (
 // this struct must satisfy the `function.Value` interface. However, a type assertion
 // cannot be held here due to a circular import.
 type SeriesList struct {
-	Series    []Timeseries `json:"series"`
-	Timerange Timerange    `json:"timerange"`
+	Series []Timeseries `json:"series"`
 }
 
 // ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.

--- a/function/aggregate/aggregate.go
+++ b/function/aggregate/aggregate.go
@@ -211,8 +211,7 @@ func By(list api.SeriesList, aggregator func([]float64) float64, tags []string, 
 	groups := groupBy(list, tags, collapses)
 
 	result := api.SeriesList{
-		Series:    make([]api.Timeseries, len(groups)),
-		Timerange: list.Timerange,
+		Series: make([]api.Timeseries, len(groups)),
 	}
 
 	for i, group := range groups {

--- a/function/aggregate/aggregate_test.go
+++ b/function/aggregate/aggregate_test.go
@@ -69,7 +69,6 @@ func Test_groupBy(t *testing.T) {
 				},
 			},
 		},
-		Timerange: api.Timerange{},
 	}
 
 	var aggregateTestCases = []struct {
@@ -256,12 +255,6 @@ func Test_applyAggregation(t *testing.T) {
 func Test_AggregateBy(t *testing.T) {
 	a := assert.New(t)
 
-	timerange, err := api.NewTimerange(42, 270, 6)
-	if err != nil {
-		t.Fatalf("Timerange for test is invalid")
-		return
-	}
-
 	var testList = api.SeriesList{
 		[]api.Timeseries{
 			{
@@ -329,7 +322,6 @@ func Test_AggregateBy(t *testing.T) {
 				},
 			},
 		},
-		timerange,
 	}
 
 	var aggregatedTests = []struct {
@@ -610,10 +602,6 @@ func Test_AggregateBy(t *testing.T) {
 		aggregated := By(testList, testCase.Aggregator, testCase.Tags, testCase.Combines)
 		// Check that aggregated looks correct.
 		// There should be two series
-		if aggregated.Timerange != testList.Timerange {
-			t.Errorf("Expected aggregate's Timerange to be %+v but is %+v", testList.Timerange, aggregated.Timerange)
-			continue
-		}
 		if len(aggregated.Series) != len(testCase.Results) {
 			t.Errorf("Expected %d series in aggregation result but found %d", len(testCase.Results), len(aggregated.Series))
 			continue

--- a/function/forecast/drop_function.go
+++ b/function/forecast/drop_function.go
@@ -50,8 +50,7 @@ var FunctionDrop = function.MetricFunction{
 		}
 
 		return api.SeriesList{
-			Series:    result,
-			Timerange: original.Timerange,
+			Series: result,
 		}, nil
 	},
 }

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -72,8 +72,7 @@ var FunctionRollingMultiplicativeHoltWinters = function.MetricFunction{
 		}
 
 		result := api.SeriesList{
-			Series:    make([]api.Timeseries, len(seriesList.Series)),
-			Timerange: context.Timerange,
+			Series: make([]api.Timeseries, len(seriesList.Series)),
 		}
 
 		for seriesIndex, series := range seriesList.Series {
@@ -128,8 +127,7 @@ var FunctionRollingSeasonal = function.MetricFunction{
 		}
 
 		result := api.SeriesList{
-			Series:    make([]api.Timeseries, len(seriesList.Series)),
-			Timerange: context.Timerange,
+			Series: make([]api.Timeseries, len(seriesList.Series)),
 		}
 
 		for seriesIndex, series := range seriesList.Series {
@@ -172,8 +170,7 @@ var FunctionForecastLinear = function.MetricFunction{
 		}
 
 		result := api.SeriesList{
-			Series:    make([]api.Timeseries, len(seriesList.Series)),
-			Timerange: context.Timerange,
+			Series: make([]api.Timeseries, len(seriesList.Series)),
 		}
 
 		for seriesIndex, series := range seriesList.Series {

--- a/function/join/join_test.go
+++ b/function/join/join_test.go
@@ -36,12 +36,12 @@ var (
 
 	voidSeries = api.Timeseries{Values: []float64{0, 0, 0}, TagSet: map[string]string{}}
 
-	emptyList = api.SeriesList{[]api.Timeseries{}, api.Timerange{}}
-	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}, api.Timerange{}}
-	dcList    = api.SeriesList{[]api.Timeseries{seriesDC_A, seriesDC_B, seriesDC_C}, api.Timerange{}}
-	envList   = api.SeriesList{[]api.Timeseries{seriesENV_PROD, seriesENV_STAGE}, api.Timerange{}}
+	emptyList = api.SeriesList{[]api.Timeseries{}}
+	basicList = api.SeriesList{[]api.Timeseries{seriesA1, seriesA2, seriesB3, seriesB4, seriesC5}}
+	dcList    = api.SeriesList{[]api.Timeseries{seriesDC_A, seriesDC_B, seriesDC_C}}
+	envList   = api.SeriesList{[]api.Timeseries{seriesENV_PROD, seriesENV_STAGE}}
 
-	voidList = api.SeriesList{[]api.Timeseries{voidSeries}, api.Timerange{}}
+	voidList = api.SeriesList{[]api.Timeseries{voidSeries}}
 )
 
 var testCases = []struct {

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -208,7 +208,7 @@ func NewFilterThreshold(name string, summary func([]float64) float64, below bool
 			if recentDuration < 0 {
 				return nil, fmt.Errorf("expected positive recent duration but got %+v", recentDuration)
 			}
-			result := filter.FilterThresholdByRecent(list, threshold, summary, below, int(recentDuration/context.Timerange.Resolution()))
+			result := filter.FilterThresholdByRecent(list, threshold, summary, below, 1+int(recentDuration/context.Timerange.Resolution()))
 			return result, nil
 		},
 	}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -175,7 +175,7 @@ func NewFilterCount(name string, summary func([]float64) float64, ascending bool
 			if recentDuration < 0 {
 				return nil, fmt.Errorf("expected positive recent duration but got %+v", recentDuration)
 			}
-			result := filter.FilterByRecent(list, count, summary, ascending, int(recentDuration/context.Timerange.Resolution()))
+			result := filter.FilterByRecent(list, count, summary, ascending, 1+int(recentDuration/context.Timerange.Resolution()))
 			return result, nil
 		},
 	}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
@@ -174,7 +175,7 @@ func NewFilterCount(name string, summary func([]float64) float64, ascending bool
 			if recentDuration < 0 {
 				return nil, fmt.Errorf("expected positive recent duration but got %+v", recentDuration)
 			}
-			result := filter.FilterByRecent(list, count, summary, ascending, recentDuration)
+			result := filter.FilterByRecent(list, count, summary, ascending, int(recentDuration/context.Timerange.Resolution()))
 			return result, nil
 		},
 	}
@@ -207,7 +208,7 @@ func NewFilterThreshold(name string, summary func([]float64) float64, below bool
 			if recentDuration < 0 {
 				return nil, fmt.Errorf("expected positive recent duration but got %+v", recentDuration)
 			}
-			result := filter.FilterThresholdByRecent(list, threshold, summary, below, recentDuration)
+			result := filter.FilterThresholdByRecent(list, threshold, summary, below, int(recentDuration/context.Timerange.Resolution()))
 			return result, nil
 		},
 	}
@@ -232,7 +233,7 @@ func NewAggregate(name string, aggregator func([]float64) float64) function.Metr
 }
 
 // NewTransform takes a named transforming function `[float64], [value] => [float64]` and makes it into a MetricFunction.
-func NewTransform(name string, parameterCount int, transformer func(function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error)) function.MetricFunction {
+func NewTransform(name string, parameterCount int, transformer func(function.EvaluationContext, api.Timeseries, []function.Value, time.Duration) ([]float64, error)) function.MetricFunction {
 	return function.MetricFunction{
 		Name:         name,
 		MinArguments: parameterCount + 1,
@@ -249,7 +250,7 @@ func NewTransform(name string, parameterCount int, transformer func(function.Eva
 					return nil, err
 				}
 			}
-			return transform.ApplyTransform(context, list, transformer, parameters)
+			return transform.ApplyTransform(context, list, transformer, parameters, context.Timerange.Resolution())
 		},
 	}
 }
@@ -292,8 +293,7 @@ func NewOperator(op string, operator func(float64, float64) float64) function.Me
 			}
 
 			return api.SeriesList{
-				Series:    result,
-				Timerange: context.Timerange,
+				Series: result,
 			}, nil
 		},
 	}

--- a/function/tag/tag.go
+++ b/function/tag/tag.go
@@ -39,7 +39,6 @@ func DropTag(list api.SeriesList, tag string) api.SeriesList {
 	}
 	return api.SeriesList{
 		series,
-		list.Timerange,
 	}
 }
 
@@ -62,7 +61,6 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 	}
 	return api.SeriesList{
 		series,
-		list.Timerange,
 	}
 }
 

--- a/function/tag/tag_test.go
+++ b/function/tag/tag_test.go
@@ -105,12 +105,7 @@ func TestDropSeries(t *testing.T) {
 }
 
 func TestDrop(t *testing.T) {
-	timerange, err := api.NewTimerange(1300, 1600, 100)
-	if err != nil {
-		t.Fatal("invalid timerange used in testcase")
-	}
 	list := api.SeriesList{
-		Timerange: timerange,
 		Series: []api.Timeseries{
 			{
 				Values: []float64{1, 2, 3, 4},
@@ -148,7 +143,6 @@ func TestDrop(t *testing.T) {
 	}
 	result := DropTag(list, "host")
 	expect := api.SeriesList{
-		Timerange: timerange,
 		Series: []api.Timeseries{
 			{
 				Values: []float64{1, 2, 3, 4},
@@ -182,7 +176,6 @@ func TestDrop(t *testing.T) {
 	}
 	// Verify that result == expect
 	a := assert.New(t)
-	a.Eq(result.Timerange, expect.Timerange)
 	a.EqInt(len(result.Series), len(expect.Series))
 	for i := range result.Series {
 		// Verify that the two are equal
@@ -295,13 +288,8 @@ func TestSetSeries(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	timerange, err := api.NewTimerange(1300, 1600, 100)
-	if err != nil {
-		t.Fatal("invalid timerange used in testcase")
-	}
 	newValue := "east"
 	list := api.SeriesList{
-		Timerange: timerange,
 		Series: []api.Timeseries{
 			{
 				Values: []float64{1, 2, 3, 4},
@@ -337,7 +325,6 @@ func TestSet(t *testing.T) {
 	}
 	result := SetTag(list, "dc", newValue)
 	expect := api.SeriesList{
-		Timerange: timerange,
 		Series: []api.Timeseries{
 			{
 				Values: []float64{1, 2, 3, 4},
@@ -375,7 +362,6 @@ func TestSet(t *testing.T) {
 	}
 	// Verify that result == expect
 	a := assert.New(t)
-	a.Eq(result.Timerange, expect.Timerange)
 	a.EqInt(len(result.Series), len(expect.Series))
 	for i := range result.Series {
 		// Verify that the two are equal

--- a/function/transform/transformation.go
+++ b/function/transform/transformation.go
@@ -19,29 +19,25 @@ package transform
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 )
 
-// A transform takes the list of values, other parameters, and the resolution (as a float64) of the query.
-type transform func(function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error)
+// A transform takes the list of values, other parameters, and the resolution of the query.
+type transform func(function.EvaluationContext, api.Timeseries, []function.Value, time.Duration) ([]float64, error)
 
 // ApplyTransform applies the given transform to the entire list of series.
-func ApplyTransform(ctx function.EvaluationContext, list api.SeriesList, transformFunc transform, parameters []function.Value) (api.SeriesList, error) {
+func ApplyTransform(ctx function.EvaluationContext, list api.SeriesList, transformFunc transform, parameters []function.Value, resolution time.Duration) (api.SeriesList, error) {
 	result := api.SeriesList{
-		Series:    make([]api.Timeseries, len(list.Series)),
-		Timerange: list.Timerange,
+		Series: make([]api.Timeseries, len(list.Series)),
 	}
 	var numResult []float64
 	var err error
 	for i, series := range list.Series {
 		//TODO(cchandler): Modify the last parameter of this type to be an actual Resolution
-		if (list.Timerange == api.Timerange{}) {
-			fmt.Printf("Current time range %+v\n", list.Timerange)
-			panic("The series list we have doesn't provide an indexed Timerange")
-		}
-		numResult, err = transformFunc(ctx, series, parameters, float64(list.Timerange.ResolutionMillis())/1000)
+		numResult, err = transformFunc(ctx, series, parameters, resolution)
 		if err != nil {
 			return api.SeriesList{}, err
 		}
@@ -55,7 +51,7 @@ func ApplyTransform(ctx function.EvaluationContext, list api.SeriesList, transfo
 
 // Integral integrates a series whose values are "X per millisecond" to estimate "total X so far"
 // if the series represents "X in this sampling interval" instead, then you should use transformCumulative.
-func Integral(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func Integral(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	result := make([]float64, len(values))
 	integral := 0.0
@@ -68,13 +64,13 @@ func Integral(ctx function.EvaluationContext, series api.Timeseries, parameters 
 		if !math.IsNaN(values[i]) {
 			integral += values[i]
 		}
-		result[i] = integral * scale
+		result[i] = integral * resolution.Seconds()
 	}
 	return result, nil
 }
 
 // Cumulative computes the cumulative sum of the given values.
-func Cumulative(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func Cumulative(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	result := make([]float64, len(values))
 	sum := 0.0
@@ -95,8 +91,8 @@ func Cumulative(ctx function.EvaluationContext, series api.Timeseries, parameter
 // MapMaker can be used to use a function as a transform, such as 'math.Abs' (or similar):
 //  `MapMaker(math.Abs)` is a transform function which can be used, e.g. with ApplyTransform
 // The name is used for error-checking purposes.
-func MapMaker(fun func(float64) float64) func(function.EvaluationContext, api.Timeseries, []function.Value, float64) ([]float64, error) {
-	return func(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func MapMaker(fun func(float64) float64) func(function.EvaluationContext, api.Timeseries, []function.Value, time.Duration) ([]float64, error) {
+	return func(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 		values := series.Values
 		result := make([]float64, len(values))
 		for i := range values {
@@ -107,7 +103,7 @@ func MapMaker(fun func(float64) float64) func(function.EvaluationContext, api.Ti
 }
 
 // Default will replacing missing data (NaN) with the `default` value supplied as a parameter.
-func Default(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func Default(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	defaultValue, err := parameters[0].ToScalar("default value")
 	if err != nil {
@@ -125,7 +121,7 @@ func Default(ctx function.EvaluationContext, series api.Timeseries, parameters [
 }
 
 // NaNKeepLast will replace missing NaN data with the data before it
-func NaNKeepLast(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func NaNKeepLast(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	result := make([]float64, len(values))
 	for i := range result {
@@ -152,7 +148,7 @@ func (b boundError) TokenName() string {
 }
 
 // Bound replaces values which fall outside the given limits with the limits themselves. If the lowest bound exceeds the upper bound, an error is returned.
-func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	lowerBound, err := parameters[0].ToScalar("lower bound")
 	if err != nil {
@@ -179,7 +175,7 @@ func Bound(ctx function.EvaluationContext, series api.Timeseries, parameters []f
 }
 
 // LowerBound replaces values that fall below the given bound with the lower bound.
-func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	lowerBound, err := parameters[0].ToScalar("lower bound")
 	if err != nil {
@@ -196,7 +192,7 @@ func LowerBound(ctx function.EvaluationContext, series api.Timeseries, parameter
 }
 
 // UpperBound replaces values that fall below the given bound with the lower bound.
-func UpperBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, scale float64) ([]float64, error) {
+func UpperBound(ctx function.EvaluationContext, series api.Timeseries, parameters []function.Value, resolution time.Duration) ([]float64, error) {
 	values := series.Values
 	upperBound, err := parameters[0].ToScalar("upper bound")
 	if err != nil {

--- a/function/value.go
+++ b/function/value.go
@@ -84,8 +84,7 @@ func (value ScalarValue) ToSeriesList(timerange api.Timerange, description strin
 	}
 
 	return api.SeriesList{
-		Series:    []api.Timeseries{{Values: series, TagSet: api.NewTagSet()}},
-		Timerange: timerange,
+		Series: []api.Timeseries{{Values: series, TagSet: api.NewTagSet()}},
 	}, nil
 }
 

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -183,8 +183,9 @@ func (cmd *DescribeMetricsCommand) Name() string {
 
 type QuerySeriesList struct {
 	api.SeriesList
-	Query string `json:"query"`
-	Name  string `json:"name"`
+	Timerange api.Timerange `json:"timerange"`
+	Query     string        `json:"query"`
+	Name      string        `json:"name"`
 }
 
 // Execute performs the query represented by the given query string, and returs the result.
@@ -303,6 +304,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (CommandResult, erro
 		for i := range body {
 			body[i] = QuerySeriesList{
 				SeriesList: lists[i],
+				Timerange:  chosenTimerange,
 				Query:      cmd.Expressions[i].QueryString(),
 				Name:       cmd.Expressions[i].Name(),
 			}

--- a/query/tests/command_select_test.go
+++ b/query/tests/command_select_test.go
@@ -37,7 +37,8 @@ func TestCommand_Select(t *testing.T) {
 	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_3", api.ParseTagSet("dc=north")})
 	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_timeout", api.ParseTagSet("dc=west")})
 	var fakeBackend mocks.FakeTimeseriesStorageAPI
-	testTimerange, err := api.NewTimerange(0, 120, 30)
+	// TODO: remove this commented stuff
+	/*testTimerange, err := api.NewTimerange(0, 120, 30)
 	if err != nil {
 		t.Errorf("Invalid test timerange")
 		return
@@ -49,7 +50,7 @@ func TestCommand_Select(t *testing.T) {
 	lateTimerange, err := api.NewTimerange(60, 120, 30)
 	if err != nil {
 		t.Errorf("Invalid test timerange")
-	}
+	}*/
 	for _, test := range []struct {
 		query       string
 		expectError bool
@@ -61,7 +62,6 @@ func TestCommand_Select(t *testing.T) {
 				Values: []float64{1, 2, 3, 4, 5},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: testTimerange,
 		}}},
 		{"select series_timeout from 0 to 120 resolution 30ms", true, []api.SeriesList{}},
 		{"select series_1 + 1 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
@@ -69,70 +69,60 @@ func TestCommand_Select(t *testing.T) {
 				Values: []float64{2, 3, 4, 5, 6},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: testTimerange,
 		}}},
 		{"select series_1 * 2 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 4, 6, 8, 10},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: testTimerange,
 		}}},
 		{"select aggregate.max(series_2) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{3, 2, 3, 6, 5},
 				TagSet: api.NewTagSet(),
 			}},
-			Timerange: testTimerange,
 		}}},
 		{"select (1 + series_2) | aggregate.max from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{4, 3, 4, 7, 6},
 				TagSet: api.NewTagSet(),
 			}},
-			Timerange: testTimerange,
 		}}},
 		{"select series_1 from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{1, 2, 3},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: earlyTimerange,
 		}}},
 		{"select transform.timeshift(series_1,31ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: earlyTimerange,
 		}}},
 		{"select transform.timeshift(series_1,62ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{3, 4, 5},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: earlyTimerange,
 		}}},
 		{"select transform.timeshift(series_1,29ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: earlyTimerange,
 		}}},
 		{"select transform.timeshift(series_1,-31ms) from 60 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: lateTimerange,
 		}}},
 		{"select transform.timeshift(series_1,-29ms) from 60 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
 				TagSet: api.ParseTagSet("dc=west"),
 			}},
-			Timerange: lateTimerange,
 		}}},
 		{"select series_3 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -42,8 +42,7 @@ func (le LiteralExpression) Name() string {
 
 func (expr *LiteralExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
 	return api.SeriesList{
-		Series:    []api.Timeseries{{Values: expr.Values, TagSet: api.NewTagSet()}},
-		Timerange: api.Timerange{},
+		Series: []api.Timeseries{{Values: expr.Values, TagSet: api.NewTagSet()}},
 	}, nil
 }
 
@@ -132,7 +131,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						TagSet: api.TagSet{},
 					},
 				},
-				api.Timerange{},
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -141,7 +139,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						TagSet: api.TagSet{},
 					},
 				},
-				api.Timerange{},
 			},
 			func(left, right float64) float64 { return left + right },
 			true,
@@ -156,7 +153,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						Values: []float64{1, 2, 3},
 					},
 				},
-				api.Timerange{},
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -164,7 +160,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						Values: []float64{4, 5, 1},
 					},
 				},
-				api.Timerange{},
 			},
 			func(left, right float64) float64 { return left - right },
 			true,
@@ -197,7 +192,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -214,7 +208,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
 			},
 			func(left, right float64) float64 { return left + right },
 			true,
@@ -247,7 +240,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -264,7 +256,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
 			},
 			func(left, right float64) float64 { return left * right },
 			true,
@@ -297,7 +288,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
 			},
 			api.SeriesList{
 				[]api.Timeseries{
@@ -314,7 +304,6 @@ func Test_evaluateBinaryOperation(t *testing.T) {
 						},
 					},
 				},
-				api.Timerange{},
 			},
 			func(left, right float64) float64 { return left - right },
 			true,

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -68,12 +68,10 @@ func Test_ScalarExpression(t *testing.T) {
 	}
 	for _, test := range []struct {
 		expr           expression.Scalar
-		timerange      api.Timerange
 		expectedSeries []api.Timeseries
 	}{
 		{
 			expression.Scalar{5},
-			timerangeA,
 			[]api.Timeseries{
 				{
 					Values: []float64{5.0, 5.0, 5.0, 5.0, 5.0, 5.0},
@@ -85,7 +83,7 @@ func Test_ScalarExpression(t *testing.T) {
 		a := assert.New(t).Contextf("%+v", test)
 		result, err := function.EvaluateToSeriesList(test.expr, function.EvaluationContext{
 			TimeseriesStorageAPI: FakeBackend{},
-			Timerange:            test.timerange,
+			Timerange:            timerangeA,
 			SampleMethod:         timeseries.SampleMean,
 			FetchLimit:           function.NewFetchCounter(1000),
 			Registry:             registry.Default(),

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -166,8 +166,7 @@ func (f FakeTimeseriesStorageAPI) FetchMultipleTimeseries(request timeseries.Fet
 	}
 
 	return api.SeriesList{
-		Series:    timeseries,
-		Timerange: request.Timerange,
+		Series: timeseries,
 	}, nil
 }
 

--- a/testing_support/mocks/combo_api.go
+++ b/testing_support/mocks/combo_api.go
@@ -103,8 +103,7 @@ func (fapi FakeComboAPI) FetchSingleTimeseries(request timeseries.FetchRequest) 
 func (fapi FakeComboAPI) FetchMultipleTimeseries(multiRequest timeseries.FetchMultipleRequest) (api.SeriesList, error) {
 	requests := multiRequest.ToSingle()
 	seriesList := api.SeriesList{
-		Series:    make([]api.Timeseries, len(requests)),
-		Timerange: multiRequest.Timerange,
+		Series: make([]api.Timeseries, len(requests)),
 	}
 	for i, request := range requests {
 		timeseries, err := fapi.FetchSingleTimeseries(request)

--- a/testing_support/mocks/combo_api.go
+++ b/testing_support/mocks/combo_api.go
@@ -69,10 +69,10 @@ func (fapi FakeComboAPI) CheckHealthy() error {
 var _ metadata.MetricAPI = FakeComboAPI{}
 
 func (fapi FakeComboAPI) ChooseResolution(requested api.Timerange, smallestResolution time.Duration) time.Duration {
-	if fapi.timerange.Resolution() < smallestResolution {
-		panic("ChooseResolution is too coarse for FakeComboAPI instance.")
+	if requested.Resolution() != fapi.timerange.Resolution() {
+		panic(fmt.Sprintf("FakeComboAPI has internal resolution %+v but user requested %+v", fapi.timerange.Resolution(), requested.Resolution()))
 	}
-	return fapi.timerange.Resolution()
+	return requested.Resolution()
 }
 
 func (fapi FakeComboAPI) FetchSingleTimeseries(request timeseries.FetchRequest) (api.Timeseries, error) {

--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -200,8 +200,7 @@ func (b *Blueflood) FetchMultipleTimeseries(request timeseries.FetchMultipleRequ
 	}
 
 	return api.SeriesList{
-		Series:    resultSeries,
-		Timerange: request.Timerange,
+		Series: resultSeries,
 	}, nil
 }
 


### PR DESCRIPTION
There is almost no benefit to storing the timerange of a series list in the list itself, since it will always be recorded in the associated `EvaluationContext` anyway.

Removing the `Timerange` field from `SeriesList` makes it easier to handle `SeriesList`s.

Only a few places were actually seriously effects:

* `ApplyTransformation` now has to ask for the resolution instead of finding it itself. This required only minor changes.
* `select_command_test.go` used a backend which needs `SeriesList`s to have timeranges in order to accurately query them. It's been replaced with `ComboAPI` (which has been modified slightly to support this).
* the JSON output is identical, but `QuerySeriesList` needed to be modified to report the timerange too.

@drcapulet 