### PR TITLE
Fix Yaml Tag for Blueflood Config

### DIFF
--- a/main/web/web.go
+++ b/main/web/web.go
@@ -66,7 +66,7 @@ func main() {
 	config := struct {
 		ConversionRulesPath string           `yaml:"conversion_rules_path"`
 		Cassandra           cassandra.Config `yaml:"cassandra"`
-		Blueflood           blueflood.Config `yaml"blueflood"`
+		Blueflood           blueflood.Config `yaml:"blueflood"`
 		Web                 web.Config       `yaml:"web"`
 	}{}
 


### PR DESCRIPTION
The default behavior for YAML decoding is to use the lowercase field name, so this doesn't actually cause any faulty behavior, but it should be fixed.

@drcapulet 

