### PR TITLE
Reduce Usage of `api.ParseTagSet`

### DIFF
--- a/api/tagset.go
+++ b/api/tagset.go
@@ -112,3 +112,19 @@ func (tagSet TagSet) HasKey(key string) bool {
 	_, hasTag := tagSet[key]
 	return hasTag
 }
+
+type tagSetList []TagSet
+
+func (list tagSetList) Len() int {
+	return len(list)
+}
+func (list tagSetList) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+func (list tagSetList) Less(i, j int) bool {
+	return list[i].Serialize() < list[j].Serialize()
+}
+
+func SortTagSets(list []TagSet) {
+	sort.Sort(tagSetList(list))
+}

--- a/metric_metadata/cassandra/cassandra_db_test.go
+++ b/metric_metadata/cassandra/cassandra_db_test.go
@@ -122,8 +122,8 @@ func Test_GetAllMetrics_DB(t *testing.T) {
 		return
 	}
 	defer cleanDatabase(t, db)
-	a.CheckError(db.AddMetricName("metric.a", api.ParseTagSet("foo=a")))
-	a.CheckError(db.AddMetricName("metric.a", api.ParseTagSet("foo=b")))
+	a.CheckError(db.AddMetricName("metric.a", api.TagSet{"foo": "a"}))
+	a.CheckError(db.AddMetricName("metric.a", api.TagSet{"foo": "b"}))
 	a.CheckError(db.AddMetricNames([]api.TaggedMetric{
 		{
 			"metric.c",
@@ -148,8 +148,8 @@ func Test_GetAllMetrics_DB(t *testing.T) {
 	a.CheckError(err)
 	sort.Sort(api.MetricKeys(keys))
 	a.Eq(keys, []api.MetricKey{"metric.a", "metric.c", "metric.d", "metric.e"})
-	a.CheckError(db.AddMetricName("metric.b", api.ParseTagSet("foo=c")))
-	a.CheckError(db.AddMetricName("metric.b", api.ParseTagSet("foo=c")))
+	a.CheckError(db.AddMetricName("metric.b", api.TagSet{"foo": "c"}))
+	a.CheckError(db.AddMetricName("metric.b", api.TagSet{"foo": "c"}))
 	keys, err = db.GetAllMetrics()
 	a.CheckError(err)
 	sort.Sort(api.MetricKeys(keys))

--- a/query/tests/command_names_test.go
+++ b/query/tests/command_names_test.go
@@ -26,16 +26,16 @@ import (
 
 func TestQueryNaming(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.ParseTagSet("dc=west,env=production")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.ParseTagSet("dc=east,env=staging")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("dc=west,env=production")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("dc=east,env=staging")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series-special#characters", api.ParseTagSet("dc=east,env=staging")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.TagSet{"dc": "west", "env": "production"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.TagSet{"dc": "east", "env": "staging"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.TagSet{"dc": "west", "env": "production"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.TagSet{"dc": "east", "env": "staging"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series-special#characters", api.TagSet{"dc": "east", "env": "staging"}})
 
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"foo.bar.", api.ParseTagSet("qaz=foo1")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{".foo.bar", api.ParseTagSet("qaz=foo1")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"foo.2bar", api.ParseTagSet("qaz=foo1")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"_names423.with_.dots_and_und3rsc0r3s", api.ParseTagSet("qaz=foo1")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"foo.bar.", api.TagSet{"qaz": "foo1"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{".foo.bar", api.TagSet{"qaz": "foo1"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"foo.2bar", api.TagSet{"qaz": "foo1"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"_names423.with_.dots_and_und3rsc0r3s", api.TagSet{"qaz": "foo1"}})
 
 	fakeBackend := mocks.FakeTimeseriesStorageAPI{}
 	tests := []struct {

--- a/query/tests/command_select_test.go
+++ b/query/tests/command_select_test.go
@@ -55,20 +55,20 @@ func TestCommand_Select(t *testing.T) {
 		{"select series_1 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{1, 2, 3, 4, 5},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select series_timeout from 0 to 120 resolution 30ms", true, []api.SeriesList{}},
 		{"select series_1 + 1 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4, 5, 6},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select series_1 * 2 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 4, 6, 8, 10},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select aggregate.max(series_2) from 0 to 120 resolution 30ms", false, []api.SeriesList{{
@@ -86,52 +86,52 @@ func TestCommand_Select(t *testing.T) {
 		{"select series_1 from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{1, 2, 3},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select transform.timeshift(series_1,31ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select transform.timeshift(series_1,62ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{3, 4, 5},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select transform.timeshift(series_1,29ms) from 0 to 60 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select transform.timeshift(series_1,-31ms) from 60 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select transform.timeshift(series_1,-29ms) from 60 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{{
 				Values: []float64{2, 3, 4},
-				TagSet: api.ParseTagSet("dc=west"),
+				TagSet: api.TagSet{"dc": "west"},
 			}},
 		}}},
 		{"select series_3 from 0 to 120 resolution 30ms", false, []api.SeriesList{{
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 			},
 		}}},
@@ -139,15 +139,15 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 			},
 		}}},
@@ -155,11 +155,11 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 			},
 		}}},
@@ -167,7 +167,7 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 			},
 		}}},
@@ -175,15 +175,15 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 			},
 		}}},
@@ -191,15 +191,15 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 			},
 		}}},
@@ -207,15 +207,15 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 			},
 		}}},
@@ -223,11 +223,11 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 			},
 		}}},
@@ -235,7 +235,7 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 			},
 		}}},
@@ -243,15 +243,15 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 			},
 		}}},
@@ -259,11 +259,11 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 			},
 		}}},
@@ -271,7 +271,7 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 			},
 		}}},
@@ -279,15 +279,15 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 				{
 					Values: []float64{5, 5, 5, 2, 2},
-					TagSet: api.ParseTagSet("dc=east"),
+					TagSet: api.TagSet{"dc": "east"},
 				},
 			},
 		}}},
@@ -295,11 +295,11 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 				{
 					Values: []float64{1, 1, 1, 4, 4},
-					TagSet: api.ParseTagSet("dc=west"),
+					TagSet: api.TagSet{"dc": "west"},
 				},
 			},
 		}}},
@@ -307,7 +307,7 @@ func TestCommand_Select(t *testing.T) {
 			Series: []api.Timeseries{
 				{
 					Values: []float64{3, 3, 3, 3, 3},
-					TagSet: api.ParseTagSet("dc=north"),
+					TagSet: api.TagSet{"dc": "north"},
 				},
 			},
 		}}},
@@ -404,10 +404,10 @@ func TestCommand_Select(t *testing.T) {
 
 func TestTag(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.ParseTagSet("dc=west,env=production")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.ParseTagSet("dc=east,env=staging")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("dc=west,env=production")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("dc=east,env=staging")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.TagSet{"dc": "west", "env": "production"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.TagSet{"dc": "east", "env": "staging"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.TagSet{"dc": "west", "env": "production"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.TagSet{"dc": "east", "env": "staging"}})
 
 	fakeBackend := mocks.FakeTimeseriesStorageAPI{}
 	tests := []struct {

--- a/query/tests/command_test.go
+++ b/query/tests/command_test.go
@@ -33,10 +33,10 @@ var emptyGraphiteName = util.GraphiteMetric("")
 
 func TestCommand_Describe(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=production,host=a")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=west,env=staging,host=b")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=production,host=c")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("dc=east,env=staging,host=d")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.TagSet{"dc": "west", "env": "production", "host": "a"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.TagSet{"dc": "west", "env": "staging", "host": "b"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.TagSet{"dc": "east", "env": "production", "host": "c"}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.TagSet{"dc": "east", "env": "staging", "host": "d"}})
 
 	for _, test := range []struct {
 		query          string
@@ -87,10 +87,10 @@ func TestCommand_Describe(t *testing.T) {
 
 func TestCommand_DescribeAll(t *testing.T) {
 	fakeAPI := mocks.NewFakeMetricMetadataAPI()
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.ParseTagSet("")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.ParseTagSet("")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.ParseTagSet("")})
-	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_3", api.ParseTagSet("")})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_0", api.TagSet{}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_1", api.TagSet{}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_2", api.TagSet{}})
+	fakeAPI.AddPairWithoutGraphite(api.TaggedMetric{"series_3", api.TagSet{}})
 
 	for _, test := range []struct {
 		query          string

--- a/query/tests/inspect_test.go
+++ b/query/tests/inspect_test.go
@@ -49,19 +49,19 @@ func TestProfilerIntegration(t *testing.T) {
 	// 	},
 	// }
 
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=1,y=2")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=2,y=2")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.ParseTagSet("x=3,y=1")})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.TagSet{"x": "1", "y": "2"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.TagSet{"x": "2", "y": "2"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"A", api.TagSet{"x": "3", "y": "1"}})
 
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.ParseTagSet("q=foo")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.ParseTagSet("q=bar")})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.TagSet{"q": "foo"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"B", api.TagSet{"q": "bar"}})
 
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=1")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=2")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=3")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=4")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=5")})
-	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.ParseTagSet("c=6")})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.TagSet{"c": "1"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.TagSet{"c": "2"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.TagSet{"c": "3"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.TagSet{"c": "4"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.TagSet{"c": "5"}})
+	myAPI.AddPairWithoutGraphite(api.TaggedMetric{"C", api.TagSet{"c": "6"}})
 
 	testCases := []struct {
 		query    string

--- a/testing_support/mocks/api.go
+++ b/testing_support/mocks/api.go
@@ -128,9 +128,9 @@ func (f FakeTimeseriesStorageAPI) ChooseResolution(requested api.Timerange, smal
 func (f FakeTimeseriesStorageAPI) FetchSingleTimeseries(request timeseries.FetchRequest) (api.Timeseries, error) {
 	defer request.Profiler.Record("Mock FetchSingleTimeseries")()
 	metricMap := map[api.MetricKey][]api.Timeseries{
-		"series_1": {{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.ParseTagSet("dc=west")}},
-		"series_2": {{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.ParseTagSet("dc=west")}, {Values: []float64{3, 0, 3, 6, 2}, TagSet: api.ParseTagSet("dc=east")}},
-		"series_3": {{Values: []float64{1, 1, 1, 4, 4}, TagSet: api.ParseTagSet("dc=west")}, {Values: []float64{5, 5, 5, 2, 2}, TagSet: api.ParseTagSet("dc=east")}, {Values: []float64{3, 3, 3, 3, 3}, TagSet: api.ParseTagSet("dc=north")}},
+		"series_1": {{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.TagSet{"dc": "west"}}},
+		"series_2": {{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.TagSet{"dc": "west"}}, {Values: []float64{3, 0, 3, 6, 2}, TagSet: api.TagSet{"dc": "east"}}},
+		"series_3": {{Values: []float64{1, 1, 1, 4, 4}, TagSet: api.TagSet{"dc": "west"}}, {Values: []float64{5, 5, 5, 2, 2}, TagSet: api.TagSet{"dc": "east"}}, {Values: []float64{3, 3, 3, 3, 3}, TagSet: api.TagSet{"dc": "north"}}},
 	}
 	if string(request.Metric.MetricKey) == "series_timeout" {
 		<-make(chan struct{}) // block forever

--- a/timeseries/blueflood/blueflood_test.go
+++ b/timeseries/blueflood/blueflood_test.go
@@ -38,7 +38,7 @@ func Test_Blueflood(t *testing.T) {
 		MetricMap: map[util.GraphiteMetric]api.TaggedMetric{
 			util.GraphiteMetric("some.key.graphite"): {
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 		},
 	}
@@ -72,7 +72,7 @@ func Test_Blueflood(t *testing.T) {
 			name: "Success case",
 			queryMetric: api.TaggedMetric{
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 			sampleMethod: timeseries.SampleMean,
 			timerange:    timerange,
@@ -101,14 +101,14 @@ func Test_Blueflood(t *testing.T) {
       }`,
 			expectedSeriesList: api.Timeseries{
 				Values: []float64{5, 3},
-				TagSet: api.ParseTagSet("tag=value"),
+				TagSet: api.TagSet{"tag": "value"},
 			},
 		},
 		{
 			name: "Failure case - invalid JSON",
 			queryMetric: api.TaggedMetric{
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 			sampleMethod:      timeseries.SampleMean,
 			timerange:         timerange,
@@ -121,7 +121,7 @@ func Test_Blueflood(t *testing.T) {
 			name: "Failure case - HTTP error",
 			queryMetric: api.TaggedMetric{
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 			sampleMethod:      timeseries.SampleMean,
 			timerange:         timerange,
@@ -135,7 +135,7 @@ func Test_Blueflood(t *testing.T) {
 			name: "Failure case - timeout",
 			queryMetric: api.TaggedMetric{
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 			sampleMethod:      timeseries.SampleMean,
 			timerange:         timerange,
@@ -193,7 +193,7 @@ func TestIncludeRawPayload(t *testing.T) {
 		MetricMap: map[util.GraphiteMetric]api.TaggedMetric{
 			util.GraphiteMetric("some.key.value"): {
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 		},
 	}
@@ -281,7 +281,7 @@ func TestIncludeRawPayload(t *testing.T) {
 	timeSeries, err := b.FetchSingleTimeseries(timeseries.FetchRequest{
 		Metric: api.TaggedMetric{
 			MetricKey: api.MetricKey("some.key"),
-			TagSet:    api.ParseTagSet("tag=value"),
+			TagSet:    api.TagSet{"tag": "value"},
 		},
 		RequestDetails: timeseries.RequestDetails{
 			SampleMethod:          timeseries.SampleMean,
@@ -355,7 +355,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 		MetricMap: map[util.GraphiteMetric]api.TaggedMetric{
 			util.GraphiteMetric("some.key.value"): {
 				MetricKey: api.MetricKey("some.key"),
-				TagSet:    api.ParseTagSet("tag=value"),
+				TagSet:    api.TagSet{"tag": "value"},
 			},
 		},
 	}
@@ -482,7 +482,7 @@ func TestFullResolutionDataFilling(t *testing.T) {
 	seriesList, err := b.FetchSingleTimeseries(timeseries.FetchRequest{
 		Metric: api.TaggedMetric{
 			MetricKey: api.MetricKey("some.key"),
-			TagSet:    api.ParseTagSet("tag=value"),
+			TagSet:    api.TagSet{"tag": "value"},
 		},
 		RequestDetails: timeseries.RequestDetails{
 			SampleMethod: timeseries.SampleMean,

--- a/util/rules_test.go
+++ b/util/rules_test.go
@@ -182,7 +182,7 @@ func TestToGraphiteName(t *testing.T) {
 	a.CheckError(err)
 	tm := api.TaggedMetric{
 		MetricKey: "test-metric",
-		TagSet:    api.ParseTagSet("foo=fooValue"),
+		TagSet:    api.TagSet{"foo": "fooValue"},
 	}
 	reversed, err := rule.ToGraphiteName(tm)
 	a.CheckError(err)
@@ -198,14 +198,14 @@ func TestToGraphiteName_Error(t *testing.T) {
 	a.CheckError(err)
 	reversed, err := rule.ToGraphiteName(api.TaggedMetric{
 		MetricKey: "test-metric",
-		TagSet:    api.ParseTagSet(""),
+		TagSet:    api.TagSet{},
 	})
 	checkConversionErrorCode(t, err, MissingTag)
 	a.EqString(string(reversed), "")
 
 	reversed, err = rule.ToGraphiteName(api.TaggedMetric{
 		MetricKey: "test-metric-foo",
-		TagSet:    api.ParseTagSet("foo=fooValue"),
+		TagSet:    api.TagSet{"foo": "fooValue"},
 	})
 	checkConversionErrorCode(t, err, CannotInterpolate)
 	a.EqString(string(reversed), "")


### PR DESCRIPTION
Tag sets are unserialized in a lot of cases where they could just be literals.

@drcapulet 