### PR TITLE
Scalar Sets for Summary Functions

### DIFF
--- a/api/timeseries.go
+++ b/api/timeseries.go
@@ -48,5 +48,5 @@ func (ts Timeseries) MarshalJSON() ([]byte, error) {
 		buffer.WriteString(strconv.FormatFloat(y, 'g', -1, 64))
 	}
 	buffer.WriteString("]}")
-	return buffer.Bytes(), err
+	return buffer.Bytes(), nil
 }

--- a/api/timeseries.go
+++ b/api/timeseries.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"math"
 	"strconv"
@@ -24,66 +23,30 @@ import (
 
 // Timeseries is a single time series, identified with the associated tagset.
 type Timeseries struct {
-	Values []float64
-	TagSet TagSet
-	Raw    [][]byte
+	Values []float64 `json:"values"`
+	TagSet TagSet    `json:"tagset"`
 }
 
 // MarshalJSON exists to manually encode floats.
 func (ts Timeseries) MarshalJSON() ([]byte, error) {
 	var buffer bytes.Buffer
-	var scratch [64]byte
-	buffer.WriteByte('{')
-	buffer.WriteString("\"tagset\":")
+	buffer.WriteString(`{"tagset":`)
 	tagset, err := json.Marshal(ts.TagSet)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 	buffer.Write(tagset)
-	buffer.WriteByte(',')
-
-	if ts.Raw != nil {
-		buffer.WriteString("\"raw\":")
-		buffer.WriteByte('[')
-		first := true
-		for _, raw := range ts.Raw {
-			if !first {
-				buffer.WriteByte(',')
-			}
-			buffer.WriteByte('[')
-			buffer.WriteByte('"')
-			base64Wrapped := base64.StdEncoding.EncodeToString(raw)
-			buffer.WriteString(base64Wrapped)
-			buffer.WriteByte('"')
-			buffer.WriteByte(']')
-			first = false
-		}
-		// raw, _ := json.Marshal(ts.Raw)
-		buffer.WriteByte(']')
-		buffer.WriteByte(',')
-	}
-
-	// buffer.WriteByte(',')
-	buffer.WriteString("\"values\":")
-	buffer.WriteByte('[')
-	n := len(ts.Values)
-	for i := 0; i < n; i++ {
+	buffer.WriteString(`,"values":[`)
+	for i, y := range ts.Values {
 		if i > 0 {
 			buffer.WriteByte(',')
 		}
-		f := ts.Values[i]
-		if math.IsInf(f, 1) {
-			buffer.WriteString("null") // TODO - positive infinity
-		} else if math.IsInf(f, -1) {
-			buffer.WriteString("null") // TODO - negative infinity
-		} else if math.IsNaN(f) {
-			buffer.WriteString("null")
-		} else {
-			b := strconv.AppendFloat(scratch[:0], f, 'g', -1, 64)
-			buffer.Write(b)
+		if math.IsInf(y, 0) || math.IsNaN(y) {
+			buffer.WriteString(`null`)
+			continue
 		}
+		buffer.WriteString(strconv.FormatFloat(y, 'g', -1, 64))
 	}
-	buffer.WriteByte(']')
-	buffer.WriteByte('}')
+	buffer.WriteString("]}")
 	return buffer.Bytes(), err
 }

--- a/demo/example-config.yaml
+++ b/demo/example-config.yaml
@@ -14,7 +14,7 @@ blueflood:
 
 cassandra:
   hosts:
-    - localhost:9042                            # the IP addresses/hostnames for the Cassandra nodes (9160 is the default port, and can be omitted)
+    - localhost:9042                            # the IP addresses/hostnames for the Cassandra nodes
   keyspace: metrics_indexer                     # the keyspace for MQE indexing
 
 web:

--- a/demo/example-config.yaml
+++ b/demo/example-config.yaml
@@ -14,7 +14,7 @@ blueflood:
 
 cassandra:
   hosts:
-    - localhost:9160                            # the IP addresses/hostnames for the Cassandra nodes (9160 is the default port, and can be omitted)
+    - localhost:9042                            # the IP addresses/hostnames for the Cassandra nodes (9160 is the default port, and can be omitted)
   keyspace: metrics_indexer                     # the keyspace for MQE indexing
 
 web:

--- a/function/expression.go
+++ b/function/expression.go
@@ -141,6 +141,19 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	return value, nil
 }
 
+// EvaluateToScalarSet is a helper function that takes an Expression and makes it a scalar set.
+func EvaluateToScalarSet(e Expression, context EvaluationContext) (ScalarSet, error) {
+	scalarValue, err := e.Evaluate(context)
+	if err != nil {
+		return nil, err
+	}
+	value, convErr := scalarValue.ToScalarSet()
+	if convErr != nil {
+		return nil, convErr.WithContext(e.QueryString())
+	}
+	return value, nil
+}
+
 // EvaluateToDuration is a helper function that takes an Expression and makes it a duration.
 func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration, error) {
 	durationValue, err := e.Evaluate(context)

--- a/function/forecast/rolling_function.go
+++ b/function/forecast/rolling_function.go
@@ -57,7 +57,6 @@ var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 		for seriesIndex, series := range seriesList.Series {
 			result.Series[seriesIndex] = api.Timeseries{
 				TagSet: series.TagSet,
-				Raw:    series.Raw,
 				Values: RollingMultiplicativeHoltWinters(series.Values, samples, levelLearningRate, trendLearningRate, seasonalLearningRate)[extraSlots:], // Slice to drop the first few extra slots from the result
 			}
 		}
@@ -99,7 +98,6 @@ var FunctionRollingSeasonal = function.MakeFunction(
 		for seriesIndex, series := range seriesList.Series {
 			result.Series[seriesIndex] = api.Timeseries{
 				TagSet: series.TagSet,
-				Raw:    series.Raw,
 				Values: RollingSeasonal(series.Values, samples, seasonalLearningRate)[extraSlots:], // Slice to drop the first few extra slots from the result
 			}
 		}
@@ -136,7 +134,6 @@ var FunctionForecastLinear = function.MakeFunction(
 		for seriesIndex, series := range seriesList.Series {
 			result.Series[seriesIndex] = api.Timeseries{
 				TagSet: series.TagSet,
-				Raw:    series.Raw,
 				Values: ForecastLinear(series.Values)[extraSlots:], // Slice to drop the first few extra slots from the result
 			}
 		}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/square/metrics/function/filter"
 	"github.com/square/metrics/function/forecast"
 	"github.com/square/metrics/function/join"
+	"github.com/square/metrics/function/summary"
 	"github.com/square/metrics/function/tag"
 	"github.com/square/metrics/function/transform"
 )
@@ -78,9 +79,11 @@ func init() {
 	MustRegister(transform.ExponentialMovingAverage)
 	MustRegister(transform.Rate)
 	MustRegister(transform.Timeshift)
+
 	// Tags
 	MustRegister(tag.DropFunction)
 	MustRegister(tag.SetFunction)
+
 	// Forecasting
 	MustRegister(forecast.FunctionRollingMultiplicativeHoltWinters)
 	MustRegister(forecast.FunctionAnomalyRollingMultiplicativeHoltWinters)
@@ -89,6 +92,13 @@ func init() {
 	MustRegister(forecast.FunctionForecastLinear)
 
 	MustRegister(forecast.FunctionDrop)
+
+	// Summary
+	MustRegister(summary.Current)
+	MustRegister(summary.Mean)
+	MustRegister(summary.Min)
+	MustRegister(summary.Max)
+	MustRegister(summary.LastNotNaN)
 }
 
 // StandardRegistry of a functions available in MQE.

--- a/function/scalarset.go
+++ b/function/scalarset.go
@@ -1,3 +1,17 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package function
 
 import (

--- a/function/scalarset.go
+++ b/function/scalarset.go
@@ -1,0 +1,54 @@
+package function
+
+import (
+	"time"
+
+	"github.com/square/metrics/api"
+)
+
+type TaggedScalar struct {
+	TagSet api.TagSet
+	Value  float64
+}
+
+type ScalarSet []TaggedScalar
+
+func (set ScalarSet) ToSeriesList(timerange api.Timerange) (api.SeriesList, *ConversionFailure) {
+	list := api.SeriesList{
+		Series: make([]api.Timeseries, len(set)),
+	}
+	for i := range list.Series {
+		list.Series[i] = api.Timeseries{
+			TagSet: set[i].TagSet,
+			Values: make([]float64, timerange.Slots()),
+		}
+		for j := range list.Series[i].Values {
+			list.Series[i].Values[j] = set[i].Value
+		}
+	}
+	return list, nil
+}
+func (set ScalarSet) ToString() (string, *ConversionFailure) {
+	return "", &ConversionFailure{
+		From: "scalar set",
+		To:   "string",
+	}
+}
+func (set ScalarSet) ToScalar() (float64, *ConversionFailure) {
+	if len(set) == 1 && set[0].TagSet.Equals(api.TagSet{}) {
+		return set[0].Value, nil
+	}
+	return 0, &ConversionFailure{
+		From: "scalar set",
+		To:   "scalar",
+	}
+}
+func (set ScalarSet) ToScalarSet() (ScalarSet, *ConversionFailure) {
+	return set, nil
+}
+func (set ScalarSet) ToDuration() (time.Duration, *ConversionFailure) {
+	return 0, &ConversionFailure{
+		From: "scalar set",
+		To:   "duration",
+	}
+}

--- a/function/scalarset.go
+++ b/function/scalarset.go
@@ -29,7 +29,7 @@ type TaggedScalar struct {
 	Value  float64
 }
 
-// TaggedScalar marshals NaN or infinity to null.
+// MarshalJSON for TaggedScalar marshals NaN or infinity to null.
 func (ts TaggedScalar) MarshalJSON() ([]byte, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString(`{"tagset":`)

--- a/function/summary/summary.go
+++ b/function/summary/summary.go
@@ -55,18 +55,29 @@ var Mean = recent(
 	"summarize.mean",
 	func(slice []float64) float64 {
 		sum := 0.0
+		count := 0
 		for i := range slice {
+			if math.IsNaN(slice[i]) {
+				continue
+			}
 			sum += slice[i]
+			count++
 		}
-		return sum / float64(len(slice))
+		return sum / float64(count)
 	},
 )
 
 var Min = recent(
 	"summarize.min",
 	func(slice []float64) float64 {
-		min := math.Inf(1)
+		min := math.NaN()
 		for i := range slice {
+			if math.IsNaN(min) {
+				min = slice[i]
+			}
+			if math.IsNaN(slice[i]) {
+				continue
+			}
 			min = math.Min(min, slice[i])
 		}
 		return min
@@ -76,8 +87,14 @@ var Min = recent(
 var Max = recent(
 	"summarize.max",
 	func(slice []float64) float64 {
-		max := math.Inf(-1)
+		max := math.NaN()
 		for i := range slice {
+			if math.IsNaN(max) {
+				max = slice[i]
+			}
+			if math.IsNaN(slice[i]) {
+				continue
+			}
 			max = math.Max(max, slice[i])
 		}
 		return max

--- a/function/summary/summary.go
+++ b/function/summary/summary.go
@@ -1,0 +1,112 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"math"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/function"
+)
+
+// This file culminates in the definition of `aggregateBy`, which takes a SeriesList and an Aggregator and a list of tags,
+// and produces an aggregated SeriesList with one list per group, each group having been aggregated into it.
+
+var recent = func(name string, summarizer func([]float64) float64) function.MetricFunction {
+	return function.MakeFunction(
+		name,
+		func(list api.SeriesList, optionalDuration *time.Duration, timerange api.Timerange) function.ScalarSet {
+			duration := timerange.Duration()
+			if optionalDuration != nil {
+				duration = *optionalDuration
+			}
+			start := timerange.Slots() - 1 - int(duration/timerange.Resolution())
+			if start < 0 {
+				start = 0
+				// TODO: warn or error?
+			}
+			result := function.ScalarSet{}
+			for i := range list.Series {
+				slice := list.Series[i].Values[start:]
+				result = append(result, function.TaggedScalar{
+					TagSet: list.Series[i].TagSet,
+					Value:  summarizer(slice),
+				})
+			}
+			return result
+		},
+	)
+}
+
+var Mean = recent(
+	"summarize.mean",
+	func(slice []float64) float64 {
+		sum := 0.0
+		for i := range slice {
+			sum += slice[i]
+		}
+		return sum / float64(len(slice))
+	},
+)
+
+var Min = recent(
+	"summarize.min",
+	func(slice []float64) float64 {
+		min := math.Inf(1)
+		for i := range slice {
+			min = math.Min(min, slice[i])
+		}
+		return min
+	},
+)
+
+var Max = recent(
+	"summarize.max",
+	func(slice []float64) float64 {
+		max := math.Inf(-1)
+		for i := range slice {
+			max = math.Max(max, slice[i])
+		}
+		return max
+	},
+)
+
+var LastNotNaN = recent(
+	"summarize.last_not_nan",
+	func(slice []float64) float64 {
+		for i := range slice {
+			if !math.IsNaN(slice[len(slice)-1-i]) {
+				return slice[len(slice)-1-i]
+			}
+		}
+		return math.NaN()
+	},
+)
+
+var Current = function.MakeFunction(
+	"summarize.current",
+	func(list api.SeriesList) function.ScalarSet {
+		result := function.ScalarSet{}
+		for i := range list.Series {
+			values := list.Series[i].Values
+			result = append(result, function.TaggedScalar{
+				TagSet: list.Series[i].TagSet,
+				Value:  values[len(values)-1],
+			})
+		}
+		return result
+	},
+)

--- a/function/value.go
+++ b/function/value.go
@@ -29,6 +29,7 @@ type Value interface {
 	ToSeriesList(api.Timerange) (api.SeriesList, *ConversionFailure)
 	ToString() (string, *ConversionFailure)
 	ToScalar() (float64, *ConversionFailure)
+	ToScalarSet() (ScalarSet, *ConversionFailure)
 	ToDuration() (time.Duration, *ConversionFailure)
 }
 
@@ -61,22 +62,27 @@ func (e ConversionError) Error() string {
 // A SeriesListValue holds a SeriesList.
 type SeriesListValue api.SeriesList
 
-// ToSeriesList is an identity function that allows SeriesList to implement the expression.Value interface.
+// ToSeriesList is an identity function that allows SeriesList to implement the Value interface.
 func (list SeriesListValue) ToSeriesList(time api.Timerange) (api.SeriesList, *ConversionFailure) {
 	return api.SeriesList(list), nil
 }
 
-// ToString is a conversion function to implement the expression.Value interface.
+// ToString is a conversion function to implement the Value interface.
 func (list SeriesListValue) ToString() (string, *ConversionFailure) {
 	return "", &ConversionFailure{"series list", "string"}
 }
 
-// ToScalar is a conversion function to implement the expression.Value interface.
+// ToScalar is a conversion function to implement the Value interface.
 func (list SeriesListValue) ToScalar() (float64, *ConversionFailure) {
 	return 0, &ConversionFailure{"series list", "scalar"}
 }
 
-// ToDuration is a conversion function to implement the expression.Value interface.
+// ToScalarSet is a conversion function to implement the Value interface.
+func (list SeriesListValue) ToScalarSet() (ScalarSet, *ConversionFailure) {
+	return nil, &ConversionFailure{"series list", "scalar set"}
+}
+
+// ToDuration is a conversion function to implement the Value interface.
 func (list SeriesListValue) ToDuration() (time.Duration, *ConversionFailure) {
 	return 0, &ConversionFailure{"series list", "duration"}
 }
@@ -97,6 +103,11 @@ func (value StringValue) ToString() (string, *ConversionFailure) {
 // ToScalar is a conversion function.
 func (value StringValue) ToScalar() (float64, *ConversionFailure) {
 	return 0, &ConversionFailure{"string", "scalar"}
+}
+
+// ToScalarSet is a conversion function.
+func (value StringValue) ToScalarSet() (ScalarSet, *ConversionFailure) {
+	return nil, &ConversionFailure{"string", "scalar set"}
 }
 
 // ToDuration is a conversion function.
@@ -130,6 +141,16 @@ func (value ScalarValue) ToScalar() (float64, *ConversionFailure) {
 	return float64(value), nil
 }
 
+// ToScalarSet is a conversion function.
+func (value ScalarValue) ToScalarSet() (ScalarSet, *ConversionFailure) {
+	return ScalarSet{
+		TaggedScalar{
+			Value:  float64(value),
+			TagSet: api.TagSet{},
+		},
+	}, nil
+}
+
 // ToDuration is a conversion function.
 // Scalars cannot be converted to durations.
 func (value ScalarValue) ToDuration() (time.Duration, *ConversionFailure) {
@@ -160,6 +181,10 @@ func (value DurationValue) ToString() (string, *ConversionFailure) {
 // ToScalar is a conversion function.
 func (value DurationValue) ToScalar() (float64, *ConversionFailure) {
 	return 0, &ConversionFailure{"duration", "scalar"}
+}
+
+func (value DurationValue) ToScalarSet() (ScalarSet, *ConversionFailure) {
+	return nil, &ConversionFailure{"duration", "scalar set"}
 }
 
 // ToDuration is a conversion function.

--- a/main/static/embed.html
+++ b/main/static/embed.html
@@ -30,7 +30,7 @@
   <div class="metrics-link">
     <a ng-show="!hidden.explore" ng-href="{{metricsURL}}" target="_blank">Explore in MQE</a>
   </div>
-  <div class="limit-warning" ng-show="totalResult > maxResult">Embedded view is only rendering {{ maxResult }} results of {{ totalResult }} total.</div>
+  <div class="limit-warning" ng-show="totalSeriesCount > maxResult">Embedded view is only rendering {{ maxResult }} results of {{ totalSeriesCount }} total.</div>
 </div>
 </body>
 </html>

--- a/main/static/index.html
+++ b/main/static/index.html
@@ -56,15 +56,17 @@
 
     <div ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()">
       <div class="col-xs-10">
-        Query took <b>{{ elapsedMs / 1000 | number }}</b> seconds. <b>{{ totalResult }}</b> Series returned.
-        <b ng-show="totalResult > maxResult">UI is only rendering {{ maxResult }} results.</b>
+        Query took <b>{{ elapsedMs / 1000 | number }}</b> seconds.
+        <b>{{ totalSeriesCount }}</b> Series returned.
+        <span ng-show="totalScalarsCount > 0"><b>{{ totalScalarsCount }}</b> scalars returned. <b> At this time the web UI cannot display them.</b></span>
+        <b ng-show="totalSeriesCount > maxResult">UI is only rendering {{ maxResult }} results.</b>
       </div>
       <div class="col-xs-2">
         <a ng-href="{{ embedLink }}" class="btn btn-default" target="_blank">Embed Link</a>
       </div>
     </div>
     <div
-      ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty()"
+      ng-show="screenState() != 'loading' && screenState() != 'error' && queryResult.name === 'select' && !queryResultIsEmpty() && hasSeriesList()"
       class="col-xs-12">
       <google-chart
         class="metric-chart"

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -571,6 +571,7 @@ function convertSelectResponse(object) {
   if (!(object && object.name == "select" &&
         object.body &&
         object.body.length &&
+        object.body[0].type == "series" && // don't display scalar values
         object.body[0].series &&
         object.body[0].series.length &&
         object.body[0].timerange)) {

--- a/main/static/script.js
+++ b/main/static/script.js
@@ -399,6 +399,9 @@ module.controller("commonCtrl", function(
       return false;
     }
     for (var i = 0; i < result.body.length; i++) {
+      if (result.body[i].type == "scalars") {
+        continue;
+      }
       if (result.body[i].series.length == 0) {
         if (result.body.length == 1) {
           $scope.queryEmptyMessage = "the query resulted in 0 series";
@@ -410,6 +413,18 @@ module.controller("commonCtrl", function(
     }
     return false;
   };
+  $scope.hasSeriesList = function() {
+    var result = $scope.queryResult;
+    if (!result || result.name != "select") {
+      return false;
+    }
+    for (var i = 0; i < result.body.length; i++) {
+      if (result.body[i].type == "series") {
+        return true;
+      }
+    }
+    return false;
+  }
   $scope.$watch("inputModel.renderType", function(newValue) {
     if (newValue === "area") {
       $scope.selectOptions.isStacked = true;
@@ -429,12 +444,18 @@ module.controller("commonCtrl", function(
       $scope.selectResult = null;
       $scope.selectOptions.series = null;
     }
-    $scope.totalResult = 0;
+    $scope.totalSeriesCount = 0;
+    $scope.totalScalarsCount = 0;
     $scope.profileResult = convertProfileResponse(queryResult);
-    if ($scope.selectResult) {
+    if (queryResult && queryResult.body) {
       for (var i = 0; i < queryResult.body.length; i++) {
         // Each of these is a list of series
-        $scope.totalResult += queryResult.body[i].series.length;
+        if (queryResult.body[i].type == "series") {
+          $scope.totalSeriesCount += queryResult.body[i].series.length;
+        }
+        if (queryResult.body[i].type == "scalars") {
+          $scope.totalScalarsCount += queryResult.body[i].scalars.length;
+        }
       }
     }
   };

--- a/main/web/web.go
+++ b/main/web/web.go
@@ -49,6 +49,7 @@ func startServer(config web.Config, context command.ExecutionContext) error {
 		WriteTimeout:   time.Duration(config.Timeout) * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
+	fmt.Printf("Listening on port %d.\n", config.Port)
 	return server.ListenAndServe()
 }
 

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -187,7 +187,7 @@ type QueryResult struct {
 	Type  string `json:"type"` // one of "series" or "scalars"
 	// for "series" type
 	Series    []api.Timeseries `json:"series,omitempty"`
-	Timerange api.Timerange    `json:"timerange"`
+	Timerange api.Timerange    `json:"timerange,omitempty"`
 	// for "scalar" type
 	Scalars []function.TaggedScalar `json:"scalars,omitempty"`
 }

--- a/query/tests/command_names_test.go
+++ b/query/tests/command_names_test.go
@@ -172,9 +172,9 @@ func TestQueryNaming(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.Body.([]command.QuerySeriesList)
-		if !ok || len(seriesListList) != 1 {
-			t.Errorf("expected query `%s` to produce []QuerySeriesList; got %+v :: %T", test.query, rawResult.Body, rawResult.Body)
+		seriesListList, ok := rawResult.Body.([]command.QueryResult)
+		if !ok || len(seriesListList) != 1 || seriesListList[0].Type != "series" {
+			t.Errorf("expected query `%s` to produce []QueryResult of series list; got %+v :: %T", test.query, rawResult.Body, rawResult.Body)
 			continue
 		}
 		actualQuery := seriesListList[0].Query

--- a/query/tests/command_select_filter_range_test.go
+++ b/query/tests/command_select_filter_range_test.go
@@ -206,7 +206,7 @@ func TestCommandSelectFilterRange(t *testing.T) {
 			t.Errorf("Error evaluating query %q: %s", test.Query, err.Error())
 			continue
 		}
-		list := rawResult.Body.([]command.QuerySeriesList)[0]
+		list := rawResult.Body.([]command.QueryResult)[0]
 		tags := make([]string, len(list.Series))
 		for i, series := range list.Series {
 			tags[i] = series.TagSet["foo"]

--- a/query/tests/command_select_summary_test.go
+++ b/query/tests/command_select_summary_test.go
@@ -1,0 +1,74 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration test for the query execution.
+package tests
+
+/*
+func TestSelectSummary(t *testing.T) {
+	a := assert.New(t)
+	testTimerange, err := api.NewSnappedTimerange(0, 5*30000, 30000)
+	if err != nil {
+		t.Fatalf("Error creating timerange for test: %s", err.Error())
+	}
+
+	n := math.NaN()
+
+	comboAPI := mocks.NewComboAPI(
+		// timerange
+		testTimerange,
+		// series_a
+		api.Timeseries{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.TagSet{"metric": "series_a", "app": "web", "dc": "west"}},
+		api.Timeseries{Values: []float64{1, 1, 1, 1, 1}, TagSet: api.TagSet{"metric": "series_a", "app": "web", "dc": "east"}},
+		api.Timeseries{Values: []float64{5, 5, 5, 5, 5}, TagSet: api.TagSet{"metric": "series_a", "app": "fun", "dc": "north"}},
+		// series_b
+		api.Timeseries{Values: []float64{3, n, 7, n, n}, TagSet: api.TagSet{"metric": "series_b", "dc": "west"}},
+		api.Timeseries{Values: []float64{n, n, 5, 2, 2}, TagSet: api.TagSet{"metric": "series_b", "dc": "east"}},
+	)
+
+	type test struct {
+		query    string
+		expected map[string]float64
+	}
+
+	tests := []test{
+		{
+			query: "select series_a | summary.mean from 0 to 150000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  3,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  1,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 5,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		a := a.Contextf("Query %s", test.query)
+		context := command.ExecutionContext{
+			TimeseriesStorageAPI: comboAPI,
+			MetricMetadataAPI:    comboAPI,
+			Timerange:            testTimerange,
+		}
+		command, err := parser.Parse(test.query)
+		if err != nil {
+			t.Fatalf("Error parsing command %s: %s", test.query, err.Error())
+		}
+		result, err := command.Execute(context)
+		if err != nil {
+			t.Errorf("Error evaluating %s: %s", test.query, err.Error())
+		}
+		result := result.Body.([]command.QuerySeriesList)[0].Series
+	}
+
+}*/

--- a/query/tests/command_select_summary_test.go
+++ b/query/tests/command_select_summary_test.go
@@ -137,6 +137,22 @@ func TestSelectSummary(t *testing.T) {
 				api.TagSet{"dc": "miss"}.Serialize(): n,
 			},
 		},
+		{
+			query: "select series_b | summarize.current from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"dc": "west"}.Serialize(): n,
+				api.TagSet{"dc": "east"}.Serialize(): 2,
+				api.TagSet{"dc": "miss"}.Serialize(): n,
+			},
+		},
+		{
+			query: "select series_b | summarize.last_not_nan from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"dc": "west"}.Serialize(): 7,
+				api.TagSet{"dc": "east"}.Serialize(): 2,
+				api.TagSet{"dc": "miss"}.Serialize(): n,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/query/tests/command_select_summary_test.go
+++ b/query/tests/command_select_summary_test.go
@@ -15,10 +15,20 @@
 // Integration test for the query execution.
 package tests
 
-/*
+import (
+	"math"
+	"testing"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/query/command"
+	"github.com/square/metrics/query/parser"
+	"github.com/square/metrics/testing_support/assert"
+	"github.com/square/metrics/testing_support/mocks"
+)
+
 func TestSelectSummary(t *testing.T) {
 	a := assert.New(t)
-	testTimerange, err := api.NewSnappedTimerange(0, 5*30000, 30000)
+	testTimerange, err := api.NewSnappedTimerange(0, 4*30000, 30000)
 	if err != nil {
 		t.Fatalf("Error creating timerange for test: %s", err.Error())
 	}
@@ -29,12 +39,13 @@ func TestSelectSummary(t *testing.T) {
 		// timerange
 		testTimerange,
 		// series_a
-		api.Timeseries{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.TagSet{"metric": "series_a", "app": "web", "dc": "west"}},
-		api.Timeseries{Values: []float64{1, 1, 1, 1, 1}, TagSet: api.TagSet{"metric": "series_a", "app": "web", "dc": "east"}},
-		api.Timeseries{Values: []float64{5, 5, 5, 5, 5}, TagSet: api.TagSet{"metric": "series_a", "app": "fun", "dc": "north"}},
+		api.Timeseries{Values: []float64{0, 2, 3, 4, 6}, TagSet: api.TagSet{"metric": "series_a", "app": "web", "dc": "west"}},
+		api.Timeseries{Values: []float64{1, 1, 1, 0, 2}, TagSet: api.TagSet{"metric": "series_a", "app": "web", "dc": "east"}},
+		api.Timeseries{Values: []float64{5, 5, 5, 6, 4}, TagSet: api.TagSet{"metric": "series_a", "app": "fun", "dc": "north"}},
 		// series_b
 		api.Timeseries{Values: []float64{3, n, 7, n, n}, TagSet: api.TagSet{"metric": "series_b", "dc": "west"}},
 		api.Timeseries{Values: []float64{n, n, 5, 2, 2}, TagSet: api.TagSet{"metric": "series_b", "dc": "east"}},
+		api.Timeseries{Values: []float64{n, n, n, n, n}, TagSet: api.TagSet{"metric": "series_b", "dc": "miss"}},
 	)
 
 	type test struct {
@@ -44,11 +55,86 @@ func TestSelectSummary(t *testing.T) {
 
 	tests := []test{
 		{
-			query: "select series_a | summary.mean from 0 to 150000",
+			query: "select series_a | summarize.mean from 0 to 120000",
 			expected: map[string]float64{
 				api.TagSet{"app": "web", "dc": "west"}.Serialize():  3,
 				api.TagSet{"app": "web", "dc": "east"}.Serialize():  1,
 				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 5,
+			},
+		},
+		{
+			query: "select series_a | summarize.min from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  0,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  0,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 4,
+			},
+		},
+
+		{
+			query: "select series_a | summarize.max from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  6,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  2,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 6,
+			},
+		},
+		{
+			query: "select series_a | summarize.current from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  6,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  2,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 4,
+			},
+		},
+		// recent
+		{
+			query: "select series_a | summarize.mean(60s) from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  13.0 / 3,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  1,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 5,
+			},
+		},
+		{
+			query: "select series_a | summarize.min(60s) from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  3,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  0,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 4,
+			},
+		},
+		{
+			query: "select series_a | summarize.max(60s) from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"app": "web", "dc": "west"}.Serialize():  6,
+				api.TagSet{"app": "web", "dc": "east"}.Serialize():  2,
+				api.TagSet{"app": "fun", "dc": "north"}.Serialize(): 6,
+			},
+		},
+		// with NaNs
+		{
+			query: "select series_b | summarize.mean from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"dc": "west"}.Serialize(): 5,
+				api.TagSet{"dc": "east"}.Serialize(): 3,
+				api.TagSet{"dc": "miss"}.Serialize(): n,
+			},
+		},
+		{
+			query: "select series_b | summarize.min from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"dc": "west"}.Serialize(): 3,
+				api.TagSet{"dc": "east"}.Serialize(): 2,
+				api.TagSet{"dc": "miss"}.Serialize(): n,
+			},
+		},
+		{
+			query: "select series_b | summarize.max from 0 to 120000",
+			expected: map[string]float64{
+				api.TagSet{"dc": "west"}.Serialize(): 7,
+				api.TagSet{"dc": "east"}.Serialize(): 5,
+				api.TagSet{"dc": "miss"}.Serialize(): n,
 			},
 		},
 	}
@@ -58,17 +144,27 @@ func TestSelectSummary(t *testing.T) {
 		context := command.ExecutionContext{
 			TimeseriesStorageAPI: comboAPI,
 			MetricMetadataAPI:    comboAPI,
-			Timerange:            testTimerange,
+			FetchLimit:           100,
 		}
-		command, err := parser.Parse(test.query)
+		commandObject, err := parser.Parse(test.query)
 		if err != nil {
 			t.Fatalf("Error parsing command %s: %s", test.query, err.Error())
 		}
-		result, err := command.Execute(context)
+		result, err := commandObject.Execute(context)
 		if err != nil {
 			t.Errorf("Error evaluating %s: %s", test.query, err.Error())
 		}
-		result := result.Body.([]command.QuerySeriesList)[0].Series
+		value := result.Body.([]command.QueryResult)[0]
+		a.Eq(value.Type, "scalars") // Confirm that it's a scalar set.
+		a.Contextf("number of results").Eq(len(value.Scalars), len(test.expected))
+		for i := range value.Scalars {
+			scalar := value.Scalars[i]
+			if correct, ok := test.expected[scalar.TagSet.Serialize()]; ok {
+				a.Contextf("value for %+v", scalar.TagSet).EqFloat(scalar.Value, correct, 1e-10)
+			} else {
+				a.Errorf("Unexpected tag set in result: %+v", scalar)
+			}
+		}
 	}
 
-}*/
+}

--- a/query/tests/command_select_test.go
+++ b/query/tests/command_select_test.go
@@ -333,11 +333,15 @@ func TestCommand_Select(t *testing.T) {
 			}
 		} else {
 			a.CheckError(err)
-			actual := rawResult.Body.([]command.QuerySeriesList)
+			actual := rawResult.Body.([]command.QueryResult)
 			a.EqInt(len(actual), len(expected))
 			if len(actual) == len(expected) {
 				for i := range actual {
 					list := actual[i]
+					if list.Type != "series" {
+						t.Errorf("Should be given series, but was not.")
+						continue
+					}
 					a.EqInt(len(list.Series), len(expected[i].Series))
 					for j := range list.Series {
 						a.Eq(list.Series[j].TagSet, expected[i].Series[j].TagSet)
@@ -392,7 +396,7 @@ func TestCommand_Select(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected success but got %s", err.Error())
 	}
-	queries := result.Body.([]command.QuerySeriesList)[0].Series
+	queries := result.Body.([]command.QueryResult)[0].Series
 
 	assert.New(t).Eq(queries, []api.Timeseries{
 		{
@@ -495,8 +499,8 @@ func TestTag(t *testing.T) {
 			t.Errorf("Unexpected error while execution: %s", err.Error())
 			continue
 		}
-		seriesListList, ok := rawResult.Body.([]command.QuerySeriesList)
-		if !ok || len(seriesListList) != 1 {
+		seriesListList, ok := rawResult.Body.([]command.QueryResult)
+		if !ok || len(seriesListList) != 1 || seriesListList[0].Type != "series" {
 			t.Errorf("expected query `%s` to produce []QuerySeriesList; got %+v :: %T", test.query, rawResult.Body, rawResult.Body)
 			continue
 		}

--- a/testing_support/assert/assert.go
+++ b/testing_support/assert/assert.go
@@ -52,6 +52,7 @@ func (assert Assert) Stack(stack int) Assert {
 // when the line number is not sufficient locator for the test failure:
 // i.e. testing in a loop.
 // returns a new instances of Assert.
+// It will add to the existing context for the Assert object.
 func (assert Assert) Contextf(format string, a ...interface{}) Assert {
 	if assert.context != "" {
 		assert.context += ", "
@@ -123,8 +124,14 @@ func (assert Assert) EqFloatArray(actual, expected []float64, epsilon float64) {
 
 // EqFloat errors the test if two floats aren't equal. NaNs are considered equal.
 func (assert Assert) EqFloat(actual, expected, epsilon float64) {
+	if math.IsNaN(actual) != math.IsNaN(expected) {
+		assert.withCaller("Expected=[%f], actual=[%f]", expected, actual)
+	}
+	if math.IsNaN(expected) {
+		return
+	}
 	delta := math.Abs(actual - expected)
-	if (delta > epsilon && actual != expected) && !(math.IsNaN(actual) && math.IsNaN(expected)) {
+	if delta > epsilon {
 		assert.withCaller("Expected=[%f], actual=[%f]", expected, actual)
 	}
 }

--- a/testing_support/mocks/combo_api.go
+++ b/testing_support/mocks/combo_api.go
@@ -138,10 +138,10 @@ func NewComboAPI(timerange api.Timerange, timeseries ...api.Timeseries) FakeComb
 	}
 	for _, series := range timeseries {
 		if len(series.Values) != timerange.Slots() {
-			panic("NewComboAPI given series with wrong number of values.")
+			panic(fmt.Sprintf("NewComboAPI given series with wrong number of values: timerange has %d slots but series %+v has %d.", timerange.Slots(), series.TagSet, len(series.Values)))
 		}
 		if _, ok := series.TagSet["metric"]; !ok {
-			panic("NewCombiAPI expects that every series has a `metric` tag")
+			panic(fmt.Sprintf("NewCombiAPI expects that every series has a `metric` tag, but tagset is %+v", series.TagSet))
 		}
 		result.metrics[api.MetricKey(series.TagSet["metric"])] = append(result.metrics[api.MetricKey(series.TagSet["metric"])], series)
 		delete(series.TagSet, "metric")

--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -183,17 +183,7 @@ func (b *Blueflood) FetchSingleTimeseries(request timeseries.FetchRequest) (api.
 	if modifiedRange.End().Add(modifiedRange.Resolution()).Before(b.config.TimeSource()) {
 		modifiedRange = modifiedRange.ExtendAfter(modifiedRange.Resolution())
 	}
-<<<<<<< dc32a8b3f4d5aaab4be570a0b83e080c462bb5a4
 	intervals, err := planFetchIntervalsWithOnlyFiner(b.config.Resolutions, b.config.TimeSource(), modifiedRange)
-||||||| merged common ancestors
-
-	rawResults := make([][]byte, 1)
-	parsedResult, rawResult, err := b.fetch(request, queryURL)
-	rawResults[0] = rawResult
-=======
-
-	parsedResult, rawResult, err := b.fetch(request, queryURL)
->>>>>>> update query structure to enable creation of scalars in json
 	if err != nil {
 		return api.Timeseries{}, err
 	}

--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -183,7 +183,17 @@ func (b *Blueflood) FetchSingleTimeseries(request timeseries.FetchRequest) (api.
 	if modifiedRange.End().Add(modifiedRange.Resolution()).Before(b.config.TimeSource()) {
 		modifiedRange = modifiedRange.ExtendAfter(modifiedRange.Resolution())
 	}
+<<<<<<< dc32a8b3f4d5aaab4be570a0b83e080c462bb5a4
 	intervals, err := planFetchIntervalsWithOnlyFiner(b.config.Resolutions, b.config.TimeSource(), modifiedRange)
+||||||| merged common ancestors
+
+	rawResults := make([][]byte, 1)
+	parsedResult, rawResult, err := b.fetch(request, queryURL)
+	rawResults[0] = rawResult
+=======
+
+	parsedResult, rawResult, err := b.fetch(request, queryURL)
+>>>>>>> update query structure to enable creation of scalars in json
 	if err != nil {
 		return api.Timeseries{}, err
 	}


### PR DESCRIPTION
Let's you do summarize timeseries into tagged scalars:

```
select
cpu | summarize.mean
from -1hr to now
```

or,

```
select
cpu | aggregate.sum(group by app) | summarize.mean
from -1hr to now
```

In addition, they play nice with joins, so you can write (for example):

```
select
cpu / (cpu | aggregate.sum(group by app) | summarize.current)
from -1hr to now
```

The UI currently cannot display the results of a scalar or tagged-scalar result.

@drcapulet 