### PR TITLE
When fetching into present, don't error for being able to reach it.

### DIFF
--- a/demo/example-config.yaml
+++ b/demo/example-config.yaml
@@ -14,7 +14,7 @@ blueflood:
 
 cassandra:
   hosts:
-    - localhost:9160                            # the IP addresses/hostnames for the Cassandra nodes (9160 is the default port, and can be omitted)
+    - localhost:9042                            # the IP addresses/hostnames for the Cassandra nodes (9042 is the default port, and can be omitted)
   keyspace: metrics_indexer                     # the keyspace for MQE indexing
 
 web:


### PR DESCRIPTION
I'm not sure if this is the best solution.

Rounding from the user's request can query slightly into the future, which is rejected.

An alternative solution is to say that `FULL` is first available at `-2m`, for example.