### PR TITLE
Change blueflood planning error condition

### DIFF
--- a/timeseries/blueflood/blueflood_test.go
+++ b/timeseries/blueflood/blueflood_test.go
@@ -168,6 +168,17 @@ func TestPlanFetchIntervals(t *testing.T) {
 			lowerBound:  0,
 			error:       true,
 		},
+		{
+			// -1hr to +36hr (future) (30s, 5m, 60m)
+			// should error
+			resolutions: testResolutions[:3],
+			requested:   makeInterval(1*time.Hour, -36*time.Hour),
+			lowerBound:  0,
+			expected: map[Resolution]api.Interval{
+				// use only full resolution
+				resolutionFull: makeInterval(1*time.Hour, 0),
+			},
+		},
 	}
 	for i, test := range testcases {
 		a := a.Contextf("test #%d (input %+v)", i+1, test.requested)


### PR DESCRIPTION
This changes how Blueflood plans fetching. It has the following impacts:

* requesting data into the future is never a problem (Blueflood won't try to actually fetch the data, though)
* if the specified resolutions don't have monotonic (increasing) TTLs, then you'll unexpected get errors with queries. Skip resolutions with non-monotonic TTLs.

@drcapulet 