### PR TITLE
Clarify error message

### DIFF
--- a/query/parser/language.peg.go
+++ b/query/parser/language.peg.go
@@ -9,7 +9,7 @@ import (
 	"github.com/square/metrics/query/command"
 )
 
-const end_symbol rune = 1114112
+const endSymbol rune = 1114112
 
 /* The rule types inferred from the grammar are below. */
 type pegRule uint8
@@ -141,9 +141,9 @@ const (
 	ruleAction49
 	ruleAction50
 
-	rulePre_
-	rule_In_
-	rule_Suf
+	rulePre
+	ruleIn
+	ruleSuf
 )
 
 var rul3s = [...]string{
@@ -308,8 +308,8 @@ func (node *node32) print(depth int, buffer string) {
 	}
 }
 
-func (ast *node32) Print(buffer string) {
-	ast.print(0, buffer)
+func (node *node32) Print(buffer string) {
+	node.print(0, buffer)
 }
 
 type element struct {
@@ -417,7 +417,7 @@ func (t *tokens32) PreOrder() (<-chan state32, [][]token32) {
 	s, ordered := make(chan state32, 6), t.Order()
 	go func() {
 		var states [8]state32
-		for i, _ := range states {
+		for i := range states {
 			states[i].depths = make([]int32, len(ordered))
 		}
 		depths, state, depth := make([]int32, len(ordered)), 0, 1
@@ -439,14 +439,14 @@ func (t *tokens32) PreOrder() (<-chan state32, [][]token32) {
 					if c, j := ordered[depth][i-1], depths[depth-1]; a.isParentOf(c) &&
 						(j < 2 || !ordered[depth-1][j-2].isParentOf(c)) {
 						if c.end != b.begin {
-							write(token32{pegRule: rule_In_, begin: c.end, end: b.begin}, true)
+							write(token32{pegRule: ruleIn, begin: c.end, end: b.begin}, true)
 						}
 						break
 					}
 				}
 
 				if a.begin < b.begin {
-					write(token32{pegRule: rulePre_, begin: a.begin, end: b.begin}, true)
+					write(token32{pegRule: rulePre, begin: a.begin, end: b.begin}, true)
 				}
 				break
 			}
@@ -467,7 +467,7 @@ func (t *tokens32) PreOrder() (<-chan state32, [][]token32) {
 					b = c
 					continue depthFirstSearch
 				} else if parent && b.end != a.end {
-					write(token32{pegRule: rule_Suf, begin: b.end, end: a.end}, true)
+					write(token32{pegRule: ruleSuf, begin: b.end, end: a.end}, true)
 				}
 
 				depth--
@@ -556,7 +556,7 @@ func (t *tokens32) Error() []token32 {
 	ordered := t.Order()
 	length := len(ordered)
 	tokens, length := make([]token32, length), length-1
-	for i, _ := range tokens {
+	for i := range tokens {
 		o := ordered[length-i]
 		if len(o) > 1 {
 			tokens[i] = o[len(o)-2].getToken32()
@@ -834,8 +834,8 @@ func (p *Parser) Execute() {
 
 func (p *Parser) Init() {
 	p.buffer = []rune(p.Buffer)
-	if len(p.buffer) == 0 || p.buffer[len(p.buffer)-1] != end_symbol {
-		p.buffer = append(p.buffer, end_symbol)
+	if len(p.buffer) == 0 || p.buffer[len(p.buffer)-1] != endSymbol {
+		p.buffer = append(p.buffer, endSymbol)
 	}
 
 	var tree tokenTree = &tokens32{tree: make([]token32, math.MaxInt16)}
@@ -872,7 +872,7 @@ func (p *Parser) Init() {
 	}
 
 	matchDot := func() bool {
-		if buffer[position] != end_symbol {
+		if buffer[position] != endSymbol {
 			position++
 			return true
 		}

--- a/query/tests/command_error_test.go
+++ b/query/tests/command_error_test.go
@@ -1,0 +1,67 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration test for the query execution.
+package tests
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/query/command"
+	"github.com/square/metrics/query/parser"
+	"github.com/square/metrics/testing_support/mocks"
+)
+
+func TestCommandError(t *testing.T) {
+	testTimerange, err := api.NewTimerange(0, 120, 30)
+	if err != nil {
+		t.Fatalf("Error creating timerange for test: %s", err.Error())
+	}
+	comboAPI := mocks.NewComboAPI(testTimerange,
+		api.Timeseries{Values: []float64{1, 2, 3, 4, 5}, TagSet: api.TagSet{"metric": "testmetric", "host": "h1"}},
+		api.Timeseries{Values: []float64{5, 4, 3, 4, 5}, TagSet: api.TagSet{"metric": "testmetric", "host": "h2"}},
+		api.Timeseries{Values: []float64{1, 7, 7, 7, 5}, TagSet: api.TagSet{"metric": "testmetric", "host": "h3"}},
+		api.Timeseries{Values: []float64{3, 3, 3, 3, 3}, TagSet: api.TagSet{"metric": "testmetric", "host": "h4"}},
+		api.Timeseries{Values: []float64{1, 2, 0, 0, 5}, TagSet: api.TagSet{"metric": "testmetric", "host": "h5"}},
+		api.Timeseries{Values: []float64{0, 2, 0, 0, 0}, TagSet: api.TagSet{"metric": "testmetric", "host": "h6"}},
+	)
+
+	context := command.ExecutionContext{
+		TimeseriesStorageAPI: comboAPI,
+		MetricMetadataAPI:    comboAPI,
+		FetchLimit:           13,
+		Timeout:              100 * time.Millisecond,
+	}
+	command, err := parser.Parse(`select testmetric + testmetric + testmetric from 0 to 120 resolution 30ms`)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	_, err = command.Execute(context)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	t.Logf("Message :: %s", err.Error())
+	if !strings.Contains(err.Error(), "brings the total to 18") {
+		t.Errorf(`"brings the total to 18" expected in error message %s`, err.Error())
+	}
+	if !strings.Contains(err.Error(), "specified limit 13") {
+		t.Errorf(`"specified limit 13" expected in error message %s`, err.Error())
+	}
+	if !strings.Contains(err.Error(), "6 additional series") {
+		t.Errorf(`"6 additional series" expected in error message %s`, err.Error())
+	}
+}


### PR DESCRIPTION
Previously, it could sometimes say the (highly misleading):

```
fetch limit exceeded: too many series to fetch (actual=4857 limit=5000)
```

it will now report the (much more helpful)

```
performing fetch of 4857 additional series brings the total to 9714, which exceeds specified limit 5000
```

@drcapulet 