### PR TITLE
Add error details to Blueflood

### DIFF
--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -262,14 +262,14 @@ func (b *Blueflood) performFetch(queryURL *url.URL) (queryResponse, error) {
 	resp, err := b.config.HTTPClient.Get(queryURL.String())
 	if err != nil {
 		// TODO: report the right metric
-		return queryResponse{}, fmt.Errorf("error fetching Blueflood at URL %q: %s", queryURL.String(), err.Error())
+		return queryResponse{}, timeseries.FetchError{Code: 500, Message: fmt.Sprintf("error fetching Blueflood at URL %q: %s", queryURL.String(), err.Error())}
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		// TODO: report the right metric
-		return queryResponse{}, fmt.Errorf("error reading response from Blueflood at URL %q: %s", queryURL.String(), err.Error())
+		return queryResponse{}, timeseries.FetchError{Code: 500, Message: fmt.Sprintf("error reading response from Blueflood at URL %q: %s [[500]]", queryURL.String(), err.Error())}
 	}
 	var parsedJSON queryResponse
 	err = json.Unmarshal(body, &parsedJSON)

--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -262,14 +262,14 @@ func (b *Blueflood) performFetch(queryURL *url.URL) (queryResponse, error) {
 	resp, err := b.config.HTTPClient.Get(queryURL.String())
 	if err != nil {
 		// TODO: report the right metric
-		return queryResponse{}, timeseries.Error{api.TaggedMetric{}, timeseries.FetchIOError, "error while fetching - http connection"}
+		return queryResponse{}, fmt.Errorf("error fetching Blueflood at URL %q: %s", queryURL.String(), err.Error())
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		// TODO: report the right metric
-		return queryResponse{}, timeseries.Error{api.TaggedMetric{}, timeseries.FetchIOError, "error while fetching - reading"}
+		return queryResponse{}, fmt.Errorf("error reading response from Blueflood at URL %q: %s", queryURL.String(), err.Error())
 	}
 	var parsedJSON queryResponse
 	err = json.Unmarshal(body, &parsedJSON)

--- a/timeseries/blueflood/blueflood.go
+++ b/timeseries/blueflood/blueflood.go
@@ -269,7 +269,7 @@ func (b *Blueflood) performFetch(queryURL *url.URL) (queryResponse, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		// TODO: report the right metric
-		return queryResponse{}, timeseries.FetchError{Code: 500, Message: fmt.Sprintf("error reading response from Blueflood at URL %q: %s [[500]]", queryURL.String(), err.Error())}
+		return queryResponse{}, timeseries.FetchError{Code: 500, Message: fmt.Sprintf("error reading response from Blueflood at URL %q: %s", queryURL.String(), err.Error())}
 	}
 	var parsedJSON queryResponse
 	err = json.Unmarshal(body, &parsedJSON)

--- a/timeseries/interface.go
+++ b/timeseries/interface.go
@@ -16,6 +16,7 @@ package timeseries
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/square/metrics/api"
@@ -54,6 +55,25 @@ type UserSpecifiableConfig struct {
 }
 
 type ErrorCode int
+
+// FetchError can return a custom error code
+type FetchError struct {
+	Message string
+	Code    int
+}
+
+// Error returns the message associated with the FetchError.
+func (e FetchError) Error() string {
+	return e.Message
+}
+
+// Error500 indicates that it's a 500-level error.
+func (e FetchError) ErrorCode() int {
+	if e.Code == 0 {
+		return http.StatusBadRequest
+	}
+	return e.Code
+}
 
 const (
 	FetchTimeoutError  ErrorCode = iota + 1 // error while fetching - timeout.


### PR DESCRIPTION
When these errors happen, it's impossible to tell why. Now, details will be reported *and* MQE will respond with 500 instead of 400.

Giving up the structured errors isn't really a loss, since they're not being checked anywhere anyway.



@drcapulet 