### PR TITLE
define tag.copy

### DIFF
--- a/api/tagset.go
+++ b/api/tagset.go
@@ -21,11 +21,23 @@ import (
 )
 
 // TagSet is the set of key-value pairs associated with a given metric.
+// Instances of tag set should generally be treated immutably to avoid
+// accidentally modifying instances belonging to other metrics.
 type TagSet map[string]string
 
 // NewTagSet creates a new instance of TagSet.
 func NewTagSet() TagSet {
 	return make(map[string]string)
+}
+
+// Clone returns a new, identical tag set to the method receiver. It's safe to
+// mutate until you give it away.
+func (tagSet TagSet) Clone() TagSet {
+	result := NewTagSet()
+	for key, value := range tagSet {
+		result[key] = value
+	}
+	return result
 }
 
 // Equals check whether two tags are equal.
@@ -45,10 +57,7 @@ func (tagSet TagSet) Equals(otherTagSet TagSet) bool {
 // Merge two tagsets, and return a new tagset.
 // If keys conflict, the first tag set is preferred.
 func (tagSet TagSet) Merge(other TagSet) TagSet {
-	result := NewTagSet()
-	for key, value := range other {
-		result[key] = value
-	}
+	result := other.Clone()
 	for key, value := range tagSet {
 		result[key] = value
 	}

--- a/function/builtin/tag/tag.go
+++ b/function/builtin/tag/tag.go
@@ -21,12 +21,8 @@ import (
 
 // dropTagSeries returns a copy of the timeseries where the given `dropTag` has been removed from its TagSet.
 func dropTagSeries(series api.Timeseries, dropTag string) api.Timeseries {
-	tagSet := api.NewTagSet()
-	for tag, val := range series.TagSet {
-		if tag != dropTag {
-			tagSet[tag] = val
-		}
-	}
+	tagSet := series.TagSet.Clone()
+	delete(tagSet, dropTag)
 	series.TagSet = tagSet
 	return series
 }
@@ -66,10 +62,8 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 
 // copyTagSeries copies the value of one tag to another.
 func copyTagSeries(series api.Timeseries, target string, source string) api.Timeseries {
-	tagSet := api.NewTagSet()
-	for tag, val := range series.TagSet {
-		tagSet[tag] = val
-	}
+	tagSet := series.TagSet.Clone()
+	// it's okay to mutate tagSet because this reference to it is unique.
 	if val, ok := tagSet[source]; ok {
 		tagSet[target] = val
 	} else {

--- a/function/builtin/tag/tag.go
+++ b/function/builtin/tag/tag.go
@@ -15,6 +15,8 @@
 package tag
 
 import (
+	"fmt"
+
 	"github.com/square/metrics/api"
 	"github.com/square/metrics/function"
 )
@@ -28,14 +30,17 @@ func dropTagSeries(series api.Timeseries, dropTag string) api.Timeseries {
 }
 
 // DropTag returns a copy of the series list where the given `tag` has been removed from all timeseries.
-func DropTag(list api.SeriesList, tag string) api.SeriesList {
+func DropTag(list api.SeriesList, tag string) (api.SeriesList, error) {
+	if tag == "" {
+		return api.SeriesList{}, fmt.Errorf("tag.drop given empty string for tag")
+	}
 	series := make([]api.Timeseries, len(list.Series))
 	for i := range series {
 		series[i] = dropTagSeries(list.Series[i], tag)
 	}
 	return api.SeriesList{
 		series,
-	}
+	}, nil
 }
 
 // setTagSeries returns a copy of the timeseries where the given `newTag` has been set to `newValue`, or added if it wasn't present.
@@ -50,14 +55,20 @@ func setTagSeries(series api.Timeseries, newTag string, newValue string) api.Tim
 }
 
 // SetTag returns a copy of the series list where `tag` has been assigned to `value` for every timeseries in the list.
-func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
+func SetTag(list api.SeriesList, tag string, value string) (api.SeriesList, error) {
+	if tag == "" {
+		return api.SeriesList{}, fmt.Errorf("tag.set given empty string for tag")
+	}
+	if value == "" {
+		return api.SeriesList{}, fmt.Errorf("tag.set given empty string for value")
+	}
 	series := make([]api.Timeseries, len(list.Series))
 	for i := range series {
 		series[i] = setTagSeries(list.Series[i], tag, value)
 	}
 	return api.SeriesList{
 		series,
-	}
+	}, nil
 }
 
 // copyTagSeries copies the value of one tag to another.
@@ -74,14 +85,20 @@ func copyTagSeries(series api.Timeseries, target string, source string) api.Time
 }
 
 // CopyTag returns a copy of the series list where `target` is replaced by `source`'s value in each timeseries in the list.
-func CopyTag(list api.SeriesList, target string, source string) api.SeriesList {
+func CopyTag(list api.SeriesList, target string, source string) (api.SeriesList, error) {
+	if target == "" {
+		return api.SeriesList{}, fmt.Errorf("tag.copy given empty string for target tag")
+	}
+	if source == "" {
+		return api.SeriesList{}, fmt.Errorf("tag.copy given empty string for source tag")
+	}
 	series := make([]api.Timeseries, len(list.Series))
 	for i := range series {
 		series[i] = copyTagSeries(list.Series[i], target, source)
 	}
 	return api.SeriesList{
 		Series: series,
-	}
+	}, nil
 }
 
 // DropFunction wraps up DropTag into a Function called "tag.drop"

--- a/function/builtin/tag/tag.go
+++ b/function/builtin/tag/tag.go
@@ -64,8 +64,37 @@ func SetTag(list api.SeriesList, tag string, value string) api.SeriesList {
 	}
 }
 
+// copyTagSeries copies the value of one tag to another.
+func copyTagSeries(series api.Timeseries, target string, source string) api.Timeseries {
+	tagSet := api.NewTagSet()
+	for tag, val := range series.TagSet {
+		tagSet[tag] = val
+	}
+	if val, ok := tagSet[source]; ok {
+		tagSet[target] = val
+	} else {
+		delete(tagSet, target)
+	}
+	series.TagSet = tagSet
+	return series
+}
+
+// CopyTag returns a copy of the series list where `target` is replaced by `source`'s value in each timeseries in the list.
+func CopyTag(list api.SeriesList, target string, source string) api.SeriesList {
+	series := make([]api.Timeseries, len(list.Series))
+	for i := range series {
+		series[i] = copyTagSeries(list.Series[i], target, source)
+	}
+	return api.SeriesList{
+		Series: series,
+	}
+}
+
 // DropFunction wraps up DropTag into a Function called "tag.drop"
 var DropFunction = function.MakeFunction("tag.drop", DropTag)
 
 // SetFunction wraps up SetTag into a Function called "tag.set"
 var SetFunction = function.MakeFunction("tag.set", SetTag)
+
+// CopyFunction wraps up CopyTag into a Function called "tag.copy"
+var CopyFunction = function.MakeFunction("tag.copy", CopyTag)

--- a/function/builtin/tag/tag_test.go
+++ b/function/builtin/tag/tag_test.go
@@ -141,7 +141,10 @@ func TestDrop(t *testing.T) {
 			},
 		},
 	}
-	result := DropTag(list, "host")
+	result, err := DropTag(list, "host")
+	if err != nil {
+		t.Fatalf("unexpected error calling DropTag: %s", err.Error())
+	}
 	expect := api.SeriesList{
 		Series: []api.Timeseries{
 			{
@@ -323,7 +326,10 @@ func TestSet(t *testing.T) {
 			},
 		},
 	}
-	result := SetTag(list, "dc", newValue)
+	result, err := SetTag(list, "dc", newValue)
+	if err != nil {
+		t.Fatalf("expected error from SetTag: %s", err.Error())
+	}
 	expect := api.SeriesList{
 		Series: []api.Timeseries{
 			{
@@ -416,7 +422,10 @@ func TestCopy(t *testing.T) {
 			},
 		},
 	}
-	result := CopyTag(list, "dc", "host")
+	result, err := CopyTag(list, "dc", "host")
+	if err != nil {
+		t.Fatalf("unpexected error from CopyTag: %s", err.Error())
+	}
 	expect := api.SeriesList{
 		Series: []api.Timeseries{
 			{

--- a/function/builtin/tag/tag_test.go
+++ b/function/builtin/tag/tag_test.go
@@ -373,3 +373,102 @@ func TestSet(t *testing.T) {
 		}
 	}
 }
+
+func TestCopy(t *testing.T) {
+	list := api.SeriesList{
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4},
+				TagSet: api.TagSet{
+					"name": "A",
+					"host": "q12",
+				},
+			},
+			{
+				Values: []float64{6, 7, 3, 1},
+				TagSet: api.TagSet{
+					"name": "B",
+					"host": "r2",
+				},
+			},
+			{
+				Values: []float64{2, 4, 6, 8},
+				TagSet: api.TagSet{
+					"name": "C",
+					"host": "q13",
+					"dc":   "south",
+				},
+			},
+			{
+				Values: []float64{5, math.NaN(), 2, math.NaN()},
+				TagSet: api.TagSet{
+					"name": "D",
+					"host": "q16",
+					"dc":   "south",
+				},
+			},
+			{
+				Values: []float64{4, 3, 2, 1},
+				TagSet: api.TagSet{
+					"name": "E",
+					"dc":   "south",
+				},
+			},
+		},
+	}
+	result := CopyTag(list, "dc", "host")
+	expect := api.SeriesList{
+		Series: []api.Timeseries{
+			{
+				Values: []float64{1, 2, 3, 4},
+				TagSet: api.TagSet{
+					"name": "A",
+					"host": "q12",
+					"dc":   "q12",
+				},
+			},
+			{
+				Values: []float64{6, 7, 3, 1},
+				TagSet: api.TagSet{
+					"name": "B",
+					"host": "r2",
+					"dc":   "r2",
+				},
+			},
+			{
+				Values: []float64{2, 4, 6, 8},
+				TagSet: api.TagSet{
+					"name": "C",
+					"host": "q13",
+					"dc":   "q13",
+				},
+			},
+			{
+				Values: []float64{5, math.NaN(), 2, math.NaN()},
+				TagSet: api.TagSet{
+					"name": "D",
+					"host": "q16",
+					"dc":   "q16",
+				},
+			},
+			{
+				Values: []float64{4, 3, 2, 1},
+				TagSet: api.TagSet{
+					"name": "E",
+				},
+			},
+		},
+	}
+	// Verify that result == expect
+	a := assert.New(t)
+	a.EqInt(len(result.Series), len(expect.Series))
+	for i := range result.Series {
+		// Verify that the two are equal
+		seriesResult := result.Series[i]
+		seriesExpect := expect.Series[i]
+		a.EqFloatArray(seriesResult.Values, seriesExpect.Values, 1e-7)
+		if !seriesResult.TagSet.Equals(seriesExpect.TagSet) {
+			t.Errorf("Expected series %+v, but got %+v", seriesExpect, seriesResult)
+		}
+	}
+}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -83,6 +83,7 @@ func init() {
 	// Tags
 	MustRegister(tag.DropFunction)
 	MustRegister(tag.SetFunction)
+	MustRegister(tag.CopyFunction)
 
 	// Forecasting
 	MustRegister(forecast.FunctionRollingMultiplicativeHoltWinters)


### PR DESCRIPTION
Defines the `tag.copy` function that behaves thusly:

```
tag.copy(series, target, source)
```
will return a clone of `series` where the tag `target` will have the value of `source` for each series. For example,

Input:
* Series
  * [1,2,3,4] `app:mqe` `host:server1`
  * [5,6,7,8] `app:mqe` `host:server2`
  * [1,2,4,8] `app:indexer` `host:server3`
  * [2,3,5,7] `app:indexer` `host:server4`
* Target: `service`
* Source: `app`

Output:
* [1,2,3,4] `app:mqe` `host:server1` `service:mqe`
* [5,6,7,8] `app:mqe` `host:server2` `service:mqe`
* [1,2,4,8] `app:indexer` `host:server3` `service:indexer`
* [2,3,5,7] `app:indexer` `host:server4` `service:indexer`

It can be used to improve agreement for joins like `-` or `/`, as well as to improve display (by renaming a tag, via `... | tag.copy(new, old) | tag.drop(old)`.

If the `source` tag is absent in the original, `target` will be deleted (not just set to `""`) (even if present). Is this the best behavior? Other possible behaviors would be to set it to `""`, to leave it alone, or to throw an error.

@drcapulet 