### PR TITLE
Memoize Function Evaluations

### DIFF
--- a/function/builtin/forecast/anomaly_function.go
+++ b/function/builtin/forecast/anomaly_function.go
@@ -46,7 +46,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err // TODO: add decoration to describe it's coming from the anomaly function
 			}
-			prediction, convErr := predictionValue.ToSeriesList(context.Timerange)
+			prediction, convErr := predictionValue.ToSeriesList(context.Timerange())
 			if convErr != nil {
 				return nil, convErr.WithContext("in anomaly function - model")
 			}
@@ -54,7 +54,7 @@ func FunctionPeriodicAnomalyMaker(name string, model function.MetricFunction) fu
 			if err != nil {
 				return nil, err
 			}
-			periodSlots := int(period / context.Timerange.Resolution())
+			periodSlots := int(period / context.Timerange().Resolution())
 			// Now we need to match up 'original' and 'prediction'
 			// We'll use a hashmap for now.
 			// TODO: clean this up to hog less memory

--- a/function/builtin/forecast/drop_function.go
+++ b/function/builtin/forecast/drop_function.go
@@ -24,8 +24,8 @@ import (
 
 var FunctionDrop = function.MakeFunction(
 	"forecast.drop",
-	func(context function.EvaluationContext, original api.SeriesList, dropTime time.Duration) api.SeriesList {
-		lastValue := float64(context.Timerange.Slots()) - dropTime.Seconds()/context.Timerange.Resolution().Seconds()
+	func(timerange api.Timerange, original api.SeriesList, dropTime time.Duration) api.SeriesList {
+		lastValue := float64(timerange.Slots()) - dropTime.Seconds()/timerange.Resolution().Seconds()
 		result := make([]api.Timeseries, len(original.Series))
 		for i, series := range original.Series {
 			values := make([]float64, len(series.Values))

--- a/function/builtin/forecast/rolling_function.go
+++ b/function/builtin/forecast/rolling_function.go
@@ -38,13 +38,13 @@ var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
-		samples := int(period / context.Timerange.Resolution())
+		samples := int(period / context.Timerange().Resolution())
 		if samples <= 0 {
 			return api.SeriesList{}, fmt.Errorf("forecast.rolling_multiplicative_holt_winters expects the period parameter to mean at least one slot") // TODO: use a structured error
 		}
 
-		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
-		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
+		newContext := context.WithTimerange(context.Timerange().ExtendBefore(extraTrainingTime))
+		extraSlots := newContext.Timerange().Slots() - context.Timerange().Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return api.SeriesList{}, err
@@ -79,13 +79,13 @@ var FunctionRollingSeasonal = function.MakeFunction(
 			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
-		samples := int(period / context.Timerange.Resolution())
+		samples := int(period / context.Timerange().Resolution())
 		if samples <= 0 {
 			return api.SeriesList{}, fmt.Errorf("forecast.rolling_seasonal expects the period parameter to mean at least one slot") // TODO: use a structured error
 		}
 
-		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
-		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
+		newContext := context.WithTimerange(context.Timerange().ExtendBefore(extraTrainingTime))
+		extraSlots := newContext.Timerange().Slots() - context.Timerange().Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return api.SeriesList{}, err
@@ -120,8 +120,8 @@ var FunctionLinear = function.MakeFunction(
 			return api.SeriesList{}, fmt.Errorf("Extra training time must be non-negative, but got %s", extraTrainingTime.String()) // TODO: use structured error
 		}
 
-		newContext := context.WithTimerange(context.Timerange.ExtendBefore(extraTrainingTime))
-		extraSlots := newContext.Timerange.Slots() - context.Timerange.Slots()
+		newContext := context.WithTimerange(context.Timerange().ExtendBefore(extraTrainingTime))
+		extraSlots := newContext.Timerange().Slots() - context.Timerange().Slots()
 		seriesList, err := function.EvaluateToSeriesList(seriesExpression, newContext)
 		if err != nil {
 			return api.SeriesList{}, err

--- a/function/builtin/transform/special.go
+++ b/function/builtin/transform/special.go
@@ -26,7 +26,7 @@ import (
 var Timeshift = function.MakeFunction(
 	"transform.timeshift",
 	func(expression function.Expression, duration time.Duration, context function.EvaluationContext) (function.Value, error) {
-		newContext := context.WithTimerange(context.Timerange.Shift(duration))
+		newContext := context.WithTimerange(context.Timerange().Shift(duration))
 		return expression.Evaluate(newContext)
 	},
 )
@@ -35,15 +35,14 @@ var MovingAverage = function.MakeFunction(
 	"transform.moving_average",
 	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (api.SeriesList, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
-		limit := int(float64(size)/float64(context.Timerange.Resolution()) + 0.5) // Limit is the number of items to include in the average
+		limit := int(float64(size)/float64(context.Timerange().Resolution()) + 0.5) // Limit is the number of items to include in the average
 		if limit < 1 {
 			// At least one value must be included at all times
 			limit = 1
 		}
 
-		timerange := context.Timerange
+		timerange := context.Timerange()
 		newTimerange := timerange.ExtendBefore(time.Duration(limit-1) * timerange.Resolution())
-
 		newContext := context.WithTimerange(newTimerange)
 		// The new context has a timerange which is extended beyond the query's.
 		list, err := function.EvaluateToSeriesList(listExpression, newContext)
@@ -54,7 +53,7 @@ var MovingAverage = function.MakeFunction(
 		// Update each series in the list.
 		for index, series := range list.Series {
 			// The series will be given a (shorter) replaced list of values.
-			results := make([]float64, context.Timerange.Slots())
+			results := make([]float64, context.Timerange().Slots())
 			count := 0
 			sum := 0.0
 			for i := range series.Values {
@@ -88,11 +87,13 @@ var ExponentialMovingAverage = function.MakeFunction(
 	"transform.exponential_moving_average",
 	func(context function.EvaluationContext, listExpression function.Expression, size time.Duration) (api.SeriesList, error) {
 		// Applying a similar trick as did TimeshiftFunction. It fetches data prior to the start of the timerange.
-		limit := int(float64(size)/float64(context.Timerange.Resolution()) + 0.5) // Limit is the number of (additional) items to include in the average
-
-		timerange := context.Timerange
+		limit := int(float64(size)/float64(context.Timerange().Resolution()) + 0.5) // Limit is the number of items to include in the average
+		if limit < 1 {
+			// At least one value must be included at all times
+			limit = 1
+		}
+		timerange := context.Timerange()
 		newTimerange := timerange.ExtendBefore(time.Duration(limit) * timerange.Resolution())
-
 		newContext := context.WithTimerange(newTimerange)
 
 		// The new context has a timerange which is extended beyond the query's.
@@ -101,7 +102,7 @@ var ExponentialMovingAverage = function.MakeFunction(
 			return api.SeriesList{}, err
 		}
 
-		alpha := math.Exp(math.Log(0.5) * context.Timerange.Resolution().Seconds() / size.Seconds())
+		alpha := math.Exp(math.Log(0.5) * context.Timerange().Resolution().Seconds() / size.Seconds())
 
 		resultList := api.SeriesList{
 			Series: make([]api.Timeseries, len(list.Series)),
@@ -128,19 +129,12 @@ var ExponentialMovingAverage = function.MakeFunction(
 	},
 )
 
-// Alias is deprecated.
-// TODO: delete this function
-var Alias = function.MakeFunction("transform.alias", func(seriesList api.SeriesList, message string, context function.EvaluationContext) api.SeriesList {
-	context.EvaluationNotes.AddNote("transform.alias is deprecated")
-	return seriesList
-})
-
 // Derivative is special because it needs to get one extra data point to the left
 // This transform estimates the "change per second" between the two samples (scaled consecutive difference)
 var Derivative = function.MakeFunction(
 	"transform.derivative",
 	func(listExpression function.Expression, context function.EvaluationContext) (api.SeriesList, error) {
-		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
+		newContext := context.WithTimerange(context.Timerange().ExtendBefore(context.Timerange().Resolution()))
 		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
 			return api.SeriesList{}, err
@@ -155,7 +149,7 @@ var Derivative = function.MakeFunction(
 					continue
 				}
 				// Scaled difference
-				newValues[i-1] = (series.Values[i] - series.Values[i-1]) / context.Timerange.Resolution().Seconds()
+				newValues[i-1] = (series.Values[i] - series.Values[i-1]) / context.Timerange().Resolution().Seconds()
 			}
 			resultList.Series[seriesIndex] = api.Timeseries{
 				Values: newValues,
@@ -174,7 +168,7 @@ var Derivative = function.MakeFunction(
 var Rate = function.MakeFunction(
 	"transform.rate",
 	func(listExpression function.Expression, context function.EvaluationContext) (api.SeriesList, error) {
-		newContext := context.WithTimerange(context.Timerange.ExtendBefore(context.Timerange.Resolution()))
+		newContext := context.WithTimerange(context.Timerange().ExtendBefore(context.Timerange().Resolution()))
 		list, err := function.EvaluateToSeriesList(listExpression, newContext)
 		if err != nil {
 			return api.SeriesList{}, err
@@ -189,18 +183,18 @@ var Rate = function.MakeFunction(
 					continue
 				}
 				// Scaled difference
-				newValues[i-1] = (series.Values[i] - series.Values[i-1]) / context.Timerange.Resolution().Seconds()
+				newValues[i-1] = (series.Values[i] - series.Values[i-1]) / context.Timerange().Resolution().Seconds()
 				if newValues[i-1] < 0 {
 					newValues[i-1] = 0
 				}
 				if i+1 < len(series.Values) && series.Values[i-1] > series.Values[i] && series.Values[i] <= series.Values[i+1] {
 					// Downsampling may cause a drop from 1000 to 0 to look like [1000, 500, 0] instead of [1000, 1001, 0].
 					// So we check the next, in addition to the previous.
-					context.EvaluationNotes.AddNote(fmt.Sprintf("Rate(%v): The underlying counter reset between %f, %f\n", series.TagSet, series.Values[i-1], series.Values[i]))
+					context.AddNote(fmt.Sprintf("Rate(%v): The underlying counter reset between %f, %f\n", series.TagSet, series.Values[i-1], series.Values[i]))
 					// values[i] is our best approximatation of the delta between i-1 and i
 					// Why? This should only be used on counters, so if v[i] - v[i-1] < 0 then
 					// the counter has reset, and we know *at least* v[i] increments have happened
-					newValues[i-1] = math.Max(series.Values[i], 0) / context.Timerange.Resolution().Seconds()
+					newValues[i-1] = math.Max(series.Values[i], 0) / context.Timerange().Resolution().Seconds()
 				}
 			}
 			resultList.Series[seriesIndex] = api.Timeseries{

--- a/function/builtin/transform/transformation_test.go
+++ b/function/builtin/transform/transformation_test.go
@@ -628,9 +628,9 @@ func TestTransformIdentity(t *testing.T) {
 					Series: []api.Timeseries{result},
 				}
 				params := []function.Expression{literal{function.SeriesListValue(seriesList)}}
-				aValue, err := fun.Run(ctx, params, function.Groups{})
-				if err != nil {
-					t.Error(err)
+				aValue, runErr := fun.Run(ctx, params, function.Groups{})
+				if runErr != nil {
+					t.Error(runErr)
 					break
 				}
 				a, convErr := aValue.ToSeriesList(ctx.Timerange())

--- a/function/builtin/transform/transformation_test.go
+++ b/function/builtin/transform/transformation_test.go
@@ -199,7 +199,7 @@ func TestApplyTransform(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		ctx := function.EvaluationContextBuilder{Timerange: timerange,Ctx: context.Background()}.Build()
+		ctx := function.EvaluationContextBuilder{Timerange: timerange, Ctx: context.Background()}.Build()
 		resultValue, err := test.transform.Run(ctx, []function.Expression{listExpression}, function.Groups{})
 		if err != nil {
 			t.Error(err)
@@ -622,7 +622,7 @@ func TestTransformIdentity(t *testing.T) {
 		for _, transform := range test.tests {
 			result := series
 			for _, fun := range transform.transforms {
-				ctx := function.EvaluationContextBuilder{Timerange: timerange,Ctx: context.Background()}.Build()
+				ctx := function.EvaluationContextBuilder{Timerange: timerange, Ctx: context.Background()}.Build()
 
 				seriesList := api.SeriesList{
 					Series: []api.Timeseries{result},

--- a/function/context.go
+++ b/function/context.go
@@ -1,0 +1,187 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/inspect"
+	"github.com/square/metrics/metric_metadata"
+	"github.com/square/metrics/query/predicate"
+	"github.com/square/metrics/timeseries"
+
+	"golang.org/x/net/context"
+)
+
+// An EvaluationContextBuilder is used to create an EvaluationContext because
+// the EvaluationContext's fields are private to prevent accidental modification.
+type EvaluationContextBuilder struct {
+	TimeseriesStorageAPI timeseries.StorageAPI   // Backend to fetch data from
+	MetricMetadataAPI    metadata.MetricAPI      // Api to obtain metadata from
+	Timerange            api.Timerange           // Timerange to fetch data from
+	SampleMethod         timeseries.SampleMethod // SampleMethod to use when up/downsampling to match the requested resolution
+	Predicate            predicate.Predicate     // Predicate to apply to TagSets prior to fetching
+	FetchLimit           FetchCounter            // A limit on the number of fetches which may be performed
+	Registry             Registry
+	Profiler             *inspect.Profiler // A profiler pointer
+	EvaluationNotes      *EvaluationNotes  // Debug + numerical notes that can be added during evaluation
+	Ctx                  context.Context
+}
+
+// Build creates an evaluation context from the provided builder.
+func (builder EvaluationContextBuilder) Build() EvaluationContext {
+	return EvaluationContext{
+		private:     builder,
+		memoization: newMemo(),
+	}
+}
+
+// EvaluationContext holds all information relevant to executing a single query.
+type EvaluationContext struct {
+	private     EvaluationContextBuilder // So that it can't be easily modified from outside this package.
+	memoization *memoization
+}
+
+// TimeseriesStorageAPI returns the underlying timeseries.StorageAPI.
+func (context EvaluationContext) TimeseriesStorageAPI() timeseries.StorageAPI {
+	return context.private.TimeseriesStorageAPI
+}
+
+// MetricMetadataAPI returns the underlying metadata.MetricAPI.
+func (context EvaluationContext) MetricMetadataAPI() metadata.MetricAPI {
+	return context.private.MetricMetadataAPI
+}
+
+// Timerange returns the underlying api.Timerange.
+func (context EvaluationContext) Timerange() api.Timerange {
+	return context.private.Timerange
+}
+
+// SampleMethod returns the underlying timeseries.SampleMethod.
+func (context EvaluationContext) SampleMethod() timeseries.SampleMethod {
+	return context.private.SampleMethod
+}
+
+// Predicate returns the underlying predicate.Predicate.
+func (context EvaluationContext) Predicate() predicate.Predicate {
+	return context.private.Predicate
+}
+
+// FetchLimitConsume tries to consume the amount of resources from the limit,
+// returning a non-nil error if this would overdraw the alloted limit.
+func (context EvaluationContext) FetchLimitConsume(n int) error {
+	return context.private.FetchLimit.Consume(n)
+}
+
+// Ctx returns the underlying Context instance for the evaluation.
+func (context EvaluationContext) Ctx() context.Context {
+	return context.private.Ctx
+}
+
+// RegistryGetFunction gets the function of the provided name, return true if
+// the function could be found and false otherwise.
+func (context EvaluationContext) RegistryGetFunction(name string) (Function, bool) {
+	return context.private.Registry.GetFunction(name)
+}
+
+// Profiler returns the underlying inspect.Profiler instance.
+func (context EvaluationContext) Profiler() *inspect.Profiler {
+	return context.private.Profiler
+}
+
+// AddNote adds a note to the evaluation context.
+func (context EvaluationContext) AddNote(note string) {
+	context.private.EvaluationNotes.AddNote(note)
+}
+
+// Notes returns all notes added to the evaluation context.
+func (context EvaluationContext) Notes() []string {
+	return context.private.EvaluationNotes.Notes()
+}
+
+// EvaluationNotes holds notes that were recorded during evaluation.
+type EvaluationNotes struct {
+	mutex sync.Mutex
+	notes []string
+}
+
+// AddNote adds a new note to the collection in a threadsafe manner.
+func (notes *EvaluationNotes) AddNote(note string) {
+	if notes == nil {
+		return
+	}
+	notes.mutex.Lock()
+	defer notes.mutex.Unlock()
+	notes.notes = append(notes.notes, note)
+}
+
+// Notes returns the current collection of notes in a threadsafe manner.
+func (notes *EvaluationNotes) Notes() []string {
+	if notes == nil {
+		return nil
+	}
+	notes.mutex.Lock()
+	defer notes.mutex.Unlock()
+	return notes.notes
+}
+
+// WithTimerange duplicates the EvaluationContext but with a new timerange.
+func (context EvaluationContext) WithTimerange(t api.Timerange) EvaluationContext {
+	context.private.Timerange = t
+	context.memoization = newMemo()
+	return context
+}
+
+func (context EvaluationContext) EvaluateMemoized(expression ActualExpression) (Value, error) {
+	return context.memoization.evaluate(expression, context)
+}
+
+// FetchCounter is used to count the number of fetches remaining in a thread-safe manner.
+type FetchCounter struct {
+	count *int32
+	limit int
+}
+
+// NewFetchCounter creates a FetchCounter with n as the limit.
+func NewFetchCounter(n int) FetchCounter {
+	n32 := int32(n)
+	return FetchCounter{
+		count: &n32,
+		limit: n,
+	}
+}
+
+// Limit returns the max # of fetches allowed by this counter.
+func (c FetchCounter) Limit() int {
+	return c.limit
+}
+
+// Current returns the current number of fetches remaining for the counter.
+func (c FetchCounter) Current() int {
+	return c.limit - int(atomic.LoadInt32(c.count))
+}
+
+// Consume decrements the internal counter and returns whether the result is at least 0.
+// It does so in a threadsafe manner.
+func (c FetchCounter) Consume(n int) error {
+	remaining := atomic.AddInt32(c.count, -int32(n))
+	if remaining < 0 {
+		return fmt.Errorf("performing fetch of %d additional series brings the total to %d, which exceeds the specified limit %d", n, c.limit-int(remaining), c.limit)
+	}
+	return nil
+}

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,177 +15,10 @@
 package function
 
 import (
-	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/square/metrics/api"
-	"github.com/square/metrics/inspect"
-	"github.com/square/metrics/metric_metadata"
-	"github.com/square/metrics/query/predicate"
-	"github.com/square/metrics/timeseries"
-
-	"golang.org/x/net/context"
 )
-
-// An EvaluationContextBuilder is used to create an EvaluationContext because
-// the EvaluationContext's fields are private to prevent accidental modification.
-type EvaluationContextBuilder struct {
-	TimeseriesStorageAPI timeseries.StorageAPI   // Backend to fetch data from
-	MetricMetadataAPI    metadata.MetricAPI      // Api to obtain metadata from
-	Timerange            api.Timerange           // Timerange to fetch data from
-	SampleMethod         timeseries.SampleMethod // SampleMethod to use when up/downsampling to match the requested resolution
-	Predicate            predicate.Predicate     // Predicate to apply to TagSets prior to fetching
-	FetchLimit           FetchCounter            // A limit on the number of fetches which may be performed
-	Registry             Registry
-	Profiler             *inspect.Profiler // A profiler pointer
-	EvaluationNotes      *EvaluationNotes  // Debug + numerical notes that can be added during evaluation
-	Ctx                  context.Context
-}
-
-// Build creates an evaluation context from the provided builder.
-func (builder EvaluationContextBuilder) Build() EvaluationContext {
-	return EvaluationContext{
-		private:     builder,
-		memoization: newMemo(),
-	}
-}
-
-// EvaluationContext holds all information relevant to executing a single query.
-type EvaluationContext struct {
-	private     EvaluationContextBuilder // So that it can't be easily modified from outside this package.
-	memoization *memoization
-}
-
-// TimeseriesStorageAPI returns the underlying timeseries.StorageAPI.
-func (context EvaluationContext) TimeseriesStorageAPI() timeseries.StorageAPI {
-	return context.private.TimeseriesStorageAPI
-}
-
-// MetricMetadataAPI returns the underlying metadata.MetricAPI.
-func (context EvaluationContext) MetricMetadataAPI() metadata.MetricAPI {
-	return context.private.MetricMetadataAPI
-}
-
-// Timerange returns the underlying api.Timerange.
-func (context EvaluationContext) Timerange() api.Timerange {
-	return context.private.Timerange
-}
-
-// SampleMethod returns the underlying timeseries.SampleMethod.
-func (context EvaluationContext) SampleMethod() timeseries.SampleMethod {
-	return context.private.SampleMethod
-}
-
-// Predicate returns the underlying predicate.Predicate.
-func (context EvaluationContext) Predicate() predicate.Predicate {
-	return context.private.Predicate
-}
-
-// FetchLimitConsume tries to consume the amount of resources from the limit,
-// returning a non-nil error if this would overdraw the alloted limit.
-func (context EvaluationContext) FetchLimitConsume(n int) error {
-	return context.private.FetchLimit.Consume(n)
-}
-
-// Ctx returns the underlying Context instance for the evaluation.
-func (context EvaluationContext) Ctx() context.Context {
-	return context.private.Ctx
-}
-
-// RegistryGetFunction gets the function of the provided name, return true if
-// the function could be found and false otherwise.
-func (context EvaluationContext) RegistryGetFunction(name string) (Function, bool) {
-	return context.private.Registry.GetFunction(name)
-}
-
-// Profiler returns the underlying inspect.Profiler instance.
-func (context EvaluationContext) Profiler() *inspect.Profiler {
-	return context.private.Profiler
-}
-
-// AddNote adds a note to the evaluation context.
-func (context EvaluationContext) AddNote(note string) {
-	context.private.EvaluationNotes.AddNote(note)
-}
-
-// Notes returns all notes added to the evaluation context.
-func (context EvaluationContext) Notes() []string {
-	return context.private.EvaluationNotes.Notes()
-}
-
-// EvaluationNotes holds notes that were recorded during evaluation.
-type EvaluationNotes struct {
-	mutex sync.Mutex
-	notes []string
-}
-
-// AddNote adds a new note to the collection in a threadsafe manner.
-func (notes *EvaluationNotes) AddNote(note string) {
-	if notes == nil {
-		return
-	}
-	notes.mutex.Lock()
-	defer notes.mutex.Unlock()
-	notes.notes = append(notes.notes, note)
-}
-
-// Notes returns the current collection of notes in a threadsafe manner.
-func (notes *EvaluationNotes) Notes() []string {
-	if notes == nil {
-		return nil
-	}
-	notes.mutex.Lock()
-	defer notes.mutex.Unlock()
-	return notes.notes
-}
-
-// WithTimerange duplicates the EvaluationContext but with a new timerange.
-func (context EvaluationContext) WithTimerange(t api.Timerange) EvaluationContext {
-	context.private.Timerange = t
-	context.memoization = newMemo()
-	return context
-}
-
-func (context EvaluationContext) EvaluateMemoized(expression ActualExpression) (Value, error) {
-	return context.memoization.evaluate(expression, context)
-}
-
-// FetchCounter is used to count the number of fetches remaining in a thread-safe manner.
-type FetchCounter struct {
-	count *int32
-	limit int
-}
-
-// NewFetchCounter creates a FetchCounter with n as the limit.
-func NewFetchCounter(n int) FetchCounter {
-	n32 := int32(n)
-	return FetchCounter{
-		count: &n32,
-		limit: n,
-	}
-}
-
-// Limit returns the max # of fetches allowed by this counter.
-func (c FetchCounter) Limit() int {
-	return c.limit
-}
-
-// Current returns the current number of fetches remaining for the counter.
-func (c FetchCounter) Current() int {
-	return c.limit - int(atomic.LoadInt32(c.count))
-}
-
-// Consume decrements the internal counter and returns whether the result is at least 0.
-// It does so in a threadsafe manner.
-func (c FetchCounter) Consume(n int) error {
-	remaining := atomic.AddInt32(c.count, -int32(n))
-	if remaining < 0 {
-		return fmt.Errorf("performing fetch of %d additional series brings the total to %d, which exceeds the specified limit %d", n, c.limit-int(remaining), c.limit)
-	}
-	return nil
-}
 
 // Expression is a piece of code, which can be evaluated in a given
 // EvaluationContext. EvaluationContext must never be changed in an Evaluate().
@@ -198,8 +31,7 @@ type Expression interface {
 }
 
 // An ActualExpression is how expressions are internally implemented by the
-// library, but not how they should be consumed. ActualExpressions don't
-// benefit from memoization, but can
+// library, but not how they should be consumed.
 type ActualExpression interface {
 	// Evaluate the given expression.
 	ActualEvaluate(context EvaluationContext) (Value, error)

--- a/function/make.go
+++ b/function/make.go
@@ -144,7 +144,7 @@ func MakeFunction(name string, function interface{}) MetricFunction {
 				case contextType:
 					argumentFuncs[i] = provideValue(context)
 				case timerangeType:
-					argumentFuncs[i] = provideValue(context.Timerange)
+					argumentFuncs[i] = provideValue(context.Timerange())
 				case groupsType:
 					argumentFuncs[i] = provideValue(groups)
 				case stringType, scalarType, scalarSetType, durationType, timeseriesType, valueType, expressionType:

--- a/function/memoize.go
+++ b/function/memoize.go
@@ -1,0 +1,91 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import "sync"
+
+// memoized is a synchronized container for the results of an evaluation.
+// In order to use it, acquire the lock and then check whether "done" is true.
+type memoized struct {
+	sync.Mutex
+	done  bool
+	value Value
+	err   error
+}
+
+// compute uses the given expression and context to assign the value and err of
+// the memoized object, unless they've already been set, or are currently being
+// set, in which case it waits for them to complete and then returns the same
+// value without re-computing.
+func (m *memoized) compute(e ActualExpression, context EvaluationContext) (Value, error) {
+	m.Lock()
+	defer m.Unlock()
+	if m.done {
+		return m.value, m.err
+	}
+	m.value, m.err = e.ActualEvaluate(context)
+	m.done = true
+	return m.value, m.err
+}
+
+type memoization struct {
+	sync.Mutex
+	memoized map[string]*memoized
+}
+
+// evaluate uses the expression's StringMemoization to look it up in the internal
+// map. If
+func (m *memoization) evaluate(e ActualExpression, context EvaluationContext) (Value, error) {
+	if m == nil || m.memoized == nil {
+		// if uninitialized, it will always compute the given expressions.
+		return e.ActualEvaluate(context)
+	}
+	m.Lock()
+	memoIdentity := e.ExpressionString(StringMemoization)
+	ptr, ok := m.memoized[memoIdentity]
+	if !ok {
+		ptr = new(memoized)
+		m.memoized[memoIdentity] = ptr
+	}
+	m.Unlock()
+	return ptr.compute(e, context)
+}
+
+func newMemo() *memoization {
+	return &memoization{
+		memoized: make(map[string]*memoized),
+	}
+}
+
+// A memoizedExpression wraps an expression such that Evaluate is automatically
+// memoized.
+type memoizedExpression struct {
+	Expression ActualExpression
+}
+
+// Memoize takes an ordinary actual expression and turns it into a memoized expression.
+func Memoize(expression ActualExpression) Expression {
+	return memoizedExpression{Expression: expression}
+}
+
+// Evaluate calls EvaluateMemoized on the underlying expression.
+func (m memoizedExpression) Evaluate(context EvaluationContext) (Value, error) {
+	return context.EvaluateMemoized(m.Expression)
+}
+
+// ExpressionString behaves identically to the underlying expression
+func (m memoizedExpression) ExpressionString(mode DescriptionMode) string {
+	return m.Expression.ExpressionString(mode)
+}

--- a/function/registry/registry.go
+++ b/function/registry/registry.go
@@ -73,7 +73,6 @@ func init() {
 	MustRegister(NewFilterThreshold("filter.min_below", aggregate.Min, true))
 
 	// Weird ones
-	MustRegister(transform.Alias)
 	MustRegister(transform.Derivative)
 	MustRegister(transform.MovingAverage)
 	MustRegister(transform.ExponentialMovingAverage)

--- a/query/parser/language.peg
+++ b/query/parser/language.peg
@@ -66,7 +66,7 @@ matchClause <- _ "match" KEY literalString { p.addMatchClause() }
 describeMetrics <- _ "metrics" KEY _ "where" KEY tagName _ "=" literalString { p.makeDescribeMetrics() }
 
 describeSingleStmt <-
-  _ <METRIC_NAME> { p.pushNode(unescapeLiteral(buffer[begin:end])) }
+  _ <METRIC_NAME> { p.pushString(unescapeLiteral(buffer[begin:end])) }
   optionalPredicateClause
   { p.makeDescribe() }
 
@@ -112,7 +112,7 @@ expression_product <-
 add_one_pipe <-
   _ OP_PIPE
   _ <IDENTIFIER>
-  { p.pushNode(unescapeLiteral(buffer[begin:end])) }
+  { p.pushString(unescapeLiteral(buffer[begin:end])) }
   (
     (
     _ PAREN_OPEN
@@ -156,7 +156,7 @@ expression_function  <-
   # func(expr_a, expr_b, expr_c group by column_a, column_b, column_c)
   # a single optional group-by clause.
   _ <IDENTIFIER> {
-    p.pushNode(unescapeLiteral(buffer[begin:end]))
+    p.pushString(unescapeLiteral(buffer[begin:end]))
   }
   _ PAREN_OPEN
     expressionList optionalGroupBy
@@ -166,7 +166,7 @@ expression_function  <-
 
 expression_metric <-
   _ <IDENTIFIER> {
-    p.pushNode(unescapeLiteral(buffer[begin:end]))
+    p.pushString(unescapeLiteral(buffer[begin:end]))
   }
   (_ "[" predicate_1 _ "]" / { p.addNullPredicate() })? {
     p.addMetricExpression()
@@ -227,7 +227,7 @@ tagMatcher <-
   }
 
 literalString <- _ STRING {
-  p.pushNode(unescapeLiteral(buffer[begin:end]))
+  p.pushString(unescapeLiteral(buffer[begin:end]))
 }
 
 literalList <- { p.addLiteralList() }

--- a/query/parser/language.peg.go
+++ b/query/parser/language.peg.go
@@ -705,7 +705,7 @@ func (p *Parser) Execute() {
 		case ruleAction4:
 			p.makeDescribeMetrics()
 		case ruleAction5:
-			p.pushNode(unescapeLiteral(buffer[begin:end]))
+			p.pushString(unescapeLiteral(buffer[begin:end]))
 		case ruleAction6:
 			p.makeDescribe()
 		case ruleAction7:
@@ -739,7 +739,7 @@ func (p *Parser) Execute() {
 		case ruleAction21:
 			p.addOperatorFunction()
 		case ruleAction22:
-			p.pushNode(unescapeLiteral(buffer[begin:end]))
+			p.pushString(unescapeLiteral(buffer[begin:end]))
 		case ruleAction23:
 			p.addExpressionList()
 		case ruleAction24:
@@ -761,7 +761,7 @@ func (p *Parser) Execute() {
 			p.addGroupBy()
 		case ruleAction31:
 
-			p.pushNode(unescapeLiteral(buffer[begin:end]))
+			p.pushString(unescapeLiteral(buffer[begin:end]))
 
 		case ruleAction32:
 
@@ -769,7 +769,7 @@ func (p *Parser) Execute() {
 
 		case ruleAction33:
 
-			p.pushNode(unescapeLiteral(buffer[begin:end]))
+			p.pushString(unescapeLiteral(buffer[begin:end]))
 
 		case ruleAction34:
 			p.addNullPredicate()
@@ -816,7 +816,7 @@ func (p *Parser) Execute() {
 
 		case ruleAction47:
 
-			p.pushNode(unescapeLiteral(buffer[begin:end]))
+			p.pushString(unescapeLiteral(buffer[begin:end]))
 
 		case ruleAction48:
 			p.addLiteralList()
@@ -5663,7 +5663,7 @@ func (p *Parser) Init() {
 		/* 77 Action4 <- <{ p.makeDescribeMetrics() }> */
 		nil,
 		nil,
-		/* 79 Action5 <- <{ p.pushNode(unescapeLiteral(buffer[begin:end])) }> */
+		/* 79 Action5 <- <{ p.pushString(unescapeLiteral(buffer[begin:end])) }> */
 		nil,
 		/* 80 Action6 <- <{ p.makeDescribe() }> */
 		nil,
@@ -5697,7 +5697,7 @@ func (p *Parser) Init() {
 		nil,
 		/* 95 Action21 <- <{ p.addOperatorFunction() }> */
 		nil,
-		/* 96 Action22 <- <{ p.pushNode(unescapeLiteral(buffer[begin:end])) }> */
+		/* 96 Action22 <- <{ p.pushString(unescapeLiteral(buffer[begin:end])) }> */
 		nil,
 		/* 97 Action23 <- <{p.addExpressionList()}> */
 		nil,
@@ -5719,7 +5719,7 @@ func (p *Parser) Init() {
 		/* 104 Action30 <- <{ p.addGroupBy() }> */
 		nil,
 		/* 105 Action31 <- <{
-		   p.pushNode(unescapeLiteral(buffer[begin:end]))
+		   p.pushString(unescapeLiteral(buffer[begin:end]))
 		 }> */
 		nil,
 		/* 106 Action32 <- <{
@@ -5727,7 +5727,7 @@ func (p *Parser) Init() {
 		 }> */
 		nil,
 		/* 107 Action33 <- <{
-		   p.pushNode(unescapeLiteral(buffer[begin:end]))
+		   p.pushString(unescapeLiteral(buffer[begin:end]))
 		 }> */
 		nil,
 		/* 108 Action34 <- <{ p.addNullPredicate() }> */
@@ -5774,7 +5774,7 @@ func (p *Parser) Init() {
 		 }> */
 		nil,
 		/* 121 Action47 <- <{
-		  p.pushNode(unescapeLiteral(buffer[begin:end]))
+		  p.pushString(unescapeLiteral(buffer[begin:end]))
 		}> */
 		nil,
 		/* 122 Action48 <- <{ p.addLiteralList() }> */

--- a/query/tests/command_error_test.go
+++ b/query/tests/command_error_test.go
@@ -49,13 +49,13 @@ func TestCommandError(t *testing.T) {
 		Timeout:              100 * time.Millisecond,
 		Ctx:                  context.Background(),
 	}
-	command, err := parser.Parse(`select testmetric + testmetric + testmetric from 0 to 120 resolution 30ms`)
+	command, err := parser.Parse(`select testmetric + testmetric[host != "foo"] + testmetric[host != "bar"] from 0 to 120 resolution 30ms`)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 	_, err = command.Execute(context)
 	if err == nil {
-		t.Fatalf("expected error")
+		t.Fatalf("expected error due to exceeding fetch limits")
 	}
 	t.Logf("Message :: %s", err.Error())
 	if !strings.Contains(err.Error(), "brings the total to 18") {

--- a/query/tests/inspect_test.go
+++ b/query/tests/inspect_test.go
@@ -89,6 +89,15 @@ func TestProfilerIntegration(t *testing.T) {
 			query: "select A+A from 0 to 0",
 			expected: map[string]int{
 				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 1,
+				"Mock GetAllTags":              1,
+				"Mock FetchSingleTimeseries":   3,
+			},
+		},
+		{
+			query: `select A+A[foo != "blah"] from 0 to 0`,
+			expected: map[string]int{
+				"select.Execute":               1,
 				"Mock FetchMultipleTimeseries": 2,
 				"Mock GetAllTags":              2,
 				"Mock FetchSingleTimeseries":   6,


### PR DESCRIPTION
`function.EvaluationContext` is made immutable (by virtue of keeping its fields private) so that it can be reliably left untouched by metric functions. This introduces some boilerplate, but it's mostly just getter-methods for the `EvaluationContext` type.

`QueryString() string` and `Name() string` for the `Expression` interface have been replaced by `ExpressionString(DescriptionMode) string` that handles both of these *and* memoization.

There are now two kinds of expressions: `Expression` and `ActualExpression`.

The first is the kind that's used in evaluation (for example, functions should expect their arguments to be `Expression`):
```
type Expression interface {
    Evaluate(EvaluationContext) (Value, error)
    ExpressionString(DescriptionMode) string
}
```

The second is what expressions should (generally) be implemented as:
```
type ActualExpression interface {
     ActualEvaluate(EvaluationContext) (Value, error)
     ExpressionString(DescriptionMode) string
}
```

To convert an `ActualExpression` to an `Expression`, use `function.Memoize(ActualExpression) Expression`.

Memoization **relies on `StringExpression` being implemented correctly.** Distinct expressions **must** have distinct names, or they will be erroneously conflated during evaluation.

## `transform.alias` is now fully deprecated

Renaming functions by introspecting their arguments is not pleasant; this functionality has been removed instead of making things complicated.

The function remains defined and is a no-operations (other than adding a note indicating that it's deprecated). It no longer has any affect on metric names.

## Limitations

The main limitation of this memoization is that it doesn't apply to different subcontexts that are actually identical. The most obvious issue is in an expression like

```
select
transform.timeshift(cpu, -1w) + transform.timeshift(cpu, -1w)
from -30m to now
```

where the two fetches happen in distinct subcontexts and hence cannot be shared (even though they happen to be the same).