### PR TITLE
With context and better sharing for memoization

### DIFF
--- a/function/memoize.go
+++ b/function/memoize.go
@@ -89,3 +89,24 @@ func (m memoizedExpression) Evaluate(context EvaluationContext) (Value, error) {
 func (m memoizedExpression) ExpressionString(mode DescriptionMode) string {
 	return m.Expression.ExpressionString(mode)
 }
+
+////////
+
+type memoizationMap struct {
+	sync.Mutex
+	Map map[contextIdentity]*memoization
+}
+
+func (m *memoizationMap) get(i contextIdentity) *memoization {
+	m.Lock()
+	defer m.Unlock()
+	_, ok := m.Map[i]
+	if !ok {
+		m.Map[i] = newMemo()
+	}
+	return m.Map[i]
+}
+
+func newMemoMap() *memoizationMap {
+	return &memoizationMap{Map: map[contextIdentity]*memoization{}}
+}

--- a/function/memoize.go
+++ b/function/memoize.go
@@ -99,8 +99,7 @@ type memoizationMap struct {
 func (m *memoizationMap) get(i contextIdentity) *memoization {
 	m.Lock()
 	defer m.Unlock()
-	_, ok := m.Map[i]
-	if !ok {
+	if _, ok := m.Map[i]; !ok {
 		m.Map[i] = newMemo()
 	}
 	return m.Map[i]

--- a/function/memoize.go
+++ b/function/memoize.go
@@ -90,8 +90,7 @@ func (m memoizedExpression) ExpressionString(mode DescriptionMode) string {
 	return m.Expression.ExpressionString(mode)
 }
 
-////////
-
+// memoization map holds a collection of memoization points.
 type memoizationMap struct {
 	sync.Mutex
 	Map map[contextIdentity]*memoization

--- a/query/tests/inspect_test.go
+++ b/query/tests/inspect_test.go
@@ -142,6 +142,24 @@ func TestProfilerIntegration(t *testing.T) {
 				"Mock GetAllMetrics":   1,
 			},
 		},
+		{
+			query: "select transform.timeshift(A, -5m) + transform.timeshift(A, -5m) from 0 to 0",
+			expected: map[string]int{
+				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 1,
+				"Mock GetAllTags":              1,
+				"Mock FetchSingleTimeseries":   3,
+			},
+		},
+		{
+			query: "select transform.timeshift(A | transform.timeshift(-3m), -2m) + transform.timeshift(A, -5m) from 0 to 0",
+			expected: map[string]int{
+				"select.Execute":               1,
+				"Mock FetchMultipleTimeseries": 1,
+				"Mock GetAllTags":              1,
+				"Mock FetchSingleTimeseries":   3,
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -177,6 +195,7 @@ func TestProfilerIntegration(t *testing.T) {
 
 		for name, count := range test.expected {
 			if counts[name] != count {
+				t.Errorf("Unexpected problem in query '%s'", test.query)
 				t.Errorf("Expected `%s` to have %d occurrences, but had %d\n", name, count, counts[name])
 				t.Errorf("Expected: %+v\nBut got: %+v\n", test.expected, counts)
 				break


### PR DESCRIPTION
Add a `WithAdditionalConstraint(predicate.Predicate)` method to `EvaluationContext` that plays nice with memoization.

Also, add a `memoizationMap` to the `EvaluationContext` which can be used to look up already-existing `memoization`s within the same query, which makes the following query much more efficient, by performing the fetch for `cpu` only once instead of twice:

```
transform.timeshift(cpu, -1w) + transform.timeshift(cpu, -1)
from -30m to now
```

