### PR TITLE
Inspect query to adjust timerange

### DIFF
--- a/function/builtin/forecast/rolling_function.go
+++ b/function/builtin/forecast/rolling_function.go
@@ -63,6 +63,7 @@ var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 
 		return result, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Argument(5)},
 )
 
 // FunctionRollingSeasonal is a forecasting MetricFunction that performs the rolling seasonal estimation.
@@ -104,6 +105,7 @@ var FunctionRollingSeasonal = function.MakeFunction(
 
 		return result, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Argument(3)},
 )
 
 // FunctionLinear forecasts with a simple linear regression.
@@ -140,4 +142,5 @@ var FunctionLinear = function.MakeFunction(
 
 		return result, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Argument(1)},
 )

--- a/function/builtin/forecast/rolling_function.go
+++ b/function/builtin/forecast/rolling_function.go
@@ -63,7 +63,7 @@ var FunctionRollingMultiplicativeHoltWinters = function.MakeFunction(
 
 		return result, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Argument(5)},
+	function.Option{Name: function.WidenBy, Value: function.Argument(5)},
 )
 
 // FunctionRollingSeasonal is a forecasting MetricFunction that performs the rolling seasonal estimation.
@@ -105,7 +105,7 @@ var FunctionRollingSeasonal = function.MakeFunction(
 
 		return result, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Argument(3)},
+	function.Option{Name: function.WidenBy, Value: function.Argument(3)},
 )
 
 // FunctionLinear forecasts with a simple linear regression.
@@ -142,5 +142,5 @@ var FunctionLinear = function.MakeFunction(
 
 		return result, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Argument(1)},
+	function.Option{Name: function.WidenBy, Value: function.Argument(1)},
 )

--- a/function/builtin/transform/special.go
+++ b/function/builtin/transform/special.go
@@ -29,7 +29,7 @@ var Timeshift = function.MakeFunction(
 		newContext := context.WithTimerange(context.Timerange().Shift(duration))
 		return expression.Evaluate(newContext)
 	},
-	function.Option{Name: "ShiftBy", Value: function.Argument(1)},
+	function.Option{Name: function.ShiftBy, Value: function.Argument(1)},
 )
 
 var MovingAverage = function.MakeFunction(
@@ -85,7 +85,7 @@ var MovingAverage = function.MakeFunction(
 		}
 		return list, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Argument(1)},
+	function.Option{Name: function.WidenBy, Value: function.Argument(1)},
 )
 
 var ExponentialMovingAverage = function.MakeFunction(
@@ -132,7 +132,7 @@ var ExponentialMovingAverage = function.MakeFunction(
 		}
 		return resultList, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Argument(1)},
+	function.Option{Name: function.WidenBy, Value: function.Argument(1)},
 )
 
 // Derivative is special because it needs to get one extra data point to the left
@@ -164,7 +164,7 @@ var Derivative = function.MakeFunction(
 		}
 		return resultList, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Slot(1)},
+	function.Option{Name: function.WidenBy, Value: function.Slot(1)},
 )
 
 // Rate is special because it needs to get one extra data point to the left.
@@ -211,5 +211,5 @@ var Rate = function.MakeFunction(
 		}
 		return resultList, nil
 	},
-	function.Option{Name: "WidenBy", Value: function.Slot(1)},
+	function.Option{Name: function.WidenBy, Value: function.Slot(1)},
 )

--- a/function/builtin/transform/special.go
+++ b/function/builtin/transform/special.go
@@ -29,6 +29,7 @@ var Timeshift = function.MakeFunction(
 		newContext := context.WithTimerange(context.Timerange().Shift(duration))
 		return expression.Evaluate(newContext)
 	},
+	function.Option{Name: "ShiftBy", Value: function.Argument(1)},
 )
 
 var MovingAverage = function.MakeFunction(
@@ -84,6 +85,7 @@ var MovingAverage = function.MakeFunction(
 		}
 		return list, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Argument(1)},
 )
 
 var ExponentialMovingAverage = function.MakeFunction(
@@ -130,6 +132,7 @@ var ExponentialMovingAverage = function.MakeFunction(
 		}
 		return resultList, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Argument(1)},
 )
 
 // Derivative is special because it needs to get one extra data point to the left
@@ -161,6 +164,7 @@ var Derivative = function.MakeFunction(
 		}
 		return resultList, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Slot(1)},
 )
 
 // Rate is special because it needs to get one extra data point to the left.
@@ -207,4 +211,5 @@ var Rate = function.MakeFunction(
 		}
 		return resultList, nil
 	},
+	function.Option{Name: "WidenBy", Value: function.Slot(1)},
 )

--- a/function/builtin/transform/transformation_test.go
+++ b/function/builtin/transform/transformation_test.go
@@ -31,7 +31,7 @@ type literal struct {
 }
 
 func (lit literal) ExpressionDescription(mode function.DescriptionMode) string {
-	if mode == function.StringMemoization {
+	if mode == function.StringMemoization() {
 		return fmt.Sprintf("%#v", lit)
 	}
 	return "<literal>"

--- a/function/builtin/transform/transformation_test.go
+++ b/function/builtin/transform/transformation_test.go
@@ -30,7 +30,7 @@ type literal struct {
 	value function.Value
 }
 
-func (lit literal) ExpressionString(mode function.DescriptionMode) string {
+func (lit literal) ExpressionDescription(mode function.DescriptionMode) string {
 	if mode == function.StringMemoization {
 		return fmt.Sprintf("%#v", lit)
 	}

--- a/function/expression.go
+++ b/function/expression.go
@@ -60,12 +60,12 @@ type WidestMode struct {
 	Current    time.Time
 	Earliest   *time.Time
 	Resolution time.Duration
-	mutex      sync.Mutex
+	Mutex      *sync.Mutex
 }
 
 func (w *WidestMode) AddTime(t time.Time) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
+	w.Mutex.Lock()
+	defer w.Mutex.Unlock()
 	if w.Earliest.After(t) {
 		*w.Earliest = t
 	}

--- a/function/expression.go
+++ b/function/expression.go
@@ -71,12 +71,20 @@ func (w *WidestMode) AddTime(t time.Time) {
 	}
 }
 
-var (
-	// TODO: These should be constants
-	StringName        = StringNameMode{}        // StringName is for human readability and respects aliases
-	StringQuery       = StringQueryMode{}       // StringQuery is for humans but ignores aliases, presenting the query as written
-	StringMemoization = StringMemoizationMode{} // StringMemoization is not for humans and intended to give a unique name to every expression
-)
+// StringName is for human readability and respects aliases
+func StringName() DescriptionMode {
+	return StringNameMode{}
+}
+
+// StringQuery is for humans but ignores aliases, presenting the query as written
+func StringQuery() DescriptionMode {
+	return StringQueryMode{}
+}
+
+// StringMemoization is not for humans and intended to give a unique name to every expression
+func StringMemoization() DescriptionMode {
+	return StringMemoizationMode{}
+}
 
 // EvaluateToScalar is a helper function that takes an Expression and makes it a scalar.
 func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) {

--- a/function/expression.go
+++ b/function/expression.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"sync"
 	"time"
 
 	"github.com/square/metrics/api"
@@ -27,7 +28,14 @@ import (
 // timerange exactly.
 type Expression interface {
 	Evaluate(context EvaluationContext) (Value, error)
-	ExpressionString(DescriptionMode) string
+	ExpressionDescription(DescriptionMode) string
+}
+
+// A LiteralExpression is an expression that holds a literal value.
+// Returning `nil` indicates that your particular instance doesn't actually
+// hold any literal value.
+type LiteralExpression interface {
+	Literal() interface{}
 }
 
 // An ActualExpression is how expressions are internally implemented by the
@@ -35,16 +43,39 @@ type Expression interface {
 type ActualExpression interface {
 	// Evaluate the given expression.
 	ActualEvaluate(context EvaluationContext) (Value, error)
-	ExpressionString(DescriptionMode) string
+	ExpressionDescription(DescriptionMode) string
 }
 
 // DescriptionMode indicates how the expression should be evaluated.
-type DescriptionMode int
+type DescriptionMode interface{}
 
-const (
-	StringName        DescriptionMode = iota // StringName is for human readability and respects aliases
-	StringQuery                              // StringQuery is for humans but ignores aliases, presenting the query as written
-	StringMemoization                        // StringMemoization is not for humans and intended to give a unique name to every expression
+type StringNameMode struct{}
+
+type StringQueryMode struct{}
+
+type StringMemoizationMode struct{}
+
+type WidestMode struct {
+	Registry   Registry
+	Current    time.Time
+	Earliest   *time.Time
+	Resolution time.Duration
+	mutex      sync.Mutex
+}
+
+func (w *WidestMode) AddTime(t time.Time) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	if w.Earliest.After(t) {
+		*w.Earliest = t
+	}
+}
+
+var (
+	// TODO: These should be constants
+	StringName        = StringNameMode{}        // StringName is for human readability and respects aliases
+	StringQuery       = StringQueryMode{}       // StringQuery is for humans but ignores aliases, presenting the query as written
+	StringMemoization = StringMemoizationMode{} // StringMemoization is not for humans and intended to give a unique name to every expression
 )
 
 // EvaluateToScalar is a helper function that takes an Expression and makes it a scalar.
@@ -55,7 +86,7 @@ func EvaluateToScalar(e Expression, context EvaluationContext) (float64, error) 
 	}
 	value, convErr := scalarValue.ToScalar()
 	if convErr != nil {
-		return 0, convErr.WithContext(e.ExpressionString(StringQuery))
+		return 0, convErr.WithContext(e.ExpressionDescription(StringQuery))
 	}
 	return value, nil
 }
@@ -68,7 +99,7 @@ func EvaluateToScalarSet(e Expression, context EvaluationContext) (ScalarSet, er
 	}
 	value, convErr := scalarValue.ToScalarSet()
 	if convErr != nil {
-		return nil, convErr.WithContext(e.ExpressionString(StringQuery))
+		return nil, convErr.WithContext(e.ExpressionDescription(StringQuery))
 	}
 	return value, nil
 }
@@ -81,7 +112,7 @@ func EvaluateToDuration(e Expression, context EvaluationContext) (time.Duration,
 	}
 	value, convErr := durationValue.ToDuration()
 	if convErr != nil {
-		return 0, convErr.WithContext(e.ExpressionString(StringQuery))
+		return 0, convErr.WithContext(e.ExpressionDescription(StringQuery))
 	}
 	return value, nil
 }
@@ -94,7 +125,7 @@ func EvaluateToSeriesList(e Expression, context EvaluationContext) (api.SeriesLi
 	}
 	value, convErr := seriesValue.ToSeriesList(context.private.Timerange)
 	if convErr != nil {
-		return api.SeriesList{}, convErr.WithContext(e.ExpressionString(StringQuery))
+		return api.SeriesList{}, convErr.WithContext(e.ExpressionDescription(StringQuery))
 	}
 	return value, nil
 }
@@ -107,7 +138,7 @@ func EvaluateToString(e Expression, context EvaluationContext) (string, error) {
 	}
 	value, convErr := stringValue.ToString()
 	if convErr != nil {
-		return "", convErr.WithContext(e.ExpressionString(StringQuery))
+		return "", convErr.WithContext(e.ExpressionDescription(StringQuery))
 	}
 	return value, nil
 }

--- a/function/function.go
+++ b/function/function.go
@@ -14,7 +14,10 @@
 
 package function
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // The Function interface defines a metric function.
 // It is given several (unevaluated) expressions as input, and evaluates to a Value.
@@ -43,6 +46,7 @@ type MetricFunction struct {
 	MaxArguments  int    // MaxArguments is the maximum number of arguments the function allows. -1 indicates an unlimited number.
 	AllowsGroupBy bool   // Whether the function allows a 'group by' clause.
 	Compute       func(EvaluationContext, []Expression, Groups) (Value, error)
+	Widen         func(WidestMode, []Expression) time.Time // Optional; returns new Earliest
 }
 
 // Name returns the MetricFunction's name.

--- a/function/make.go
+++ b/function/make.go
@@ -28,8 +28,8 @@ type OptionName int
 
 const (
 	InvalidOption OptionName = iota // InvalidOption represents an invalid option
-	WidenBy                         // WidenBy indicates that the given duration Argument index, or the number of Slots should be used to extend the timerange in the query
-	ShiftBy                         // ShiftBy acts as WidenBy, but with opposite sign
+	WidenBy                         // WidenBy indicates that the given duration Argument index, or the number of Slots should be used to extend the timerange in the query into the past by the given amount.
+	ShiftBy                         // ShiftBy indicates that the given duration Argument index, or the number of Slots should be used to shift the timerange in the query (positive is forward in time into the future, negative is backward in time to the past)
 )
 
 // String makes the option name human-readable.

--- a/function/memoize.go
+++ b/function/memoize.go
@@ -53,7 +53,7 @@ func (m *memoization) evaluate(e ActualExpression, context EvaluationContext) (V
 		return e.ActualEvaluate(context)
 	}
 	m.Lock()
-	memoIdentity := e.ExpressionString(StringMemoization)
+	memoIdentity := e.ExpressionDescription(StringMemoization)
 	ptr, ok := m.memoized[memoIdentity]
 	if !ok {
 		ptr = new(memoized)
@@ -80,14 +80,23 @@ func Memoize(expression ActualExpression) Expression {
 	return memoizedExpression{Expression: expression}
 }
 
+// Literal exposes the underlying Expression's literal
+func (m memoizedExpression) Literal() interface{} {
+	literalExpression, ok := m.Expression.(LiteralExpression)
+	if !ok {
+		return nil
+	}
+	return literalExpression.Literal()
+}
+
 // Evaluate calls EvaluateMemoized on the underlying expression.
 func (m memoizedExpression) Evaluate(context EvaluationContext) (Value, error) {
 	return context.EvaluateMemoized(m.Expression)
 }
 
-// ExpressionString behaves identically to the underlying expression
-func (m memoizedExpression) ExpressionString(mode DescriptionMode) string {
-	return m.Expression.ExpressionString(mode)
+// ExpressionDescription behaves identically to the underlying expression
+func (m memoizedExpression) ExpressionDescription(mode DescriptionMode) string {
+	return m.Expression.ExpressionDescription(mode)
 }
 
 // memoization map holds a collection of memoization points.

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/square/metrics/api"
@@ -222,6 +223,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 		Current:    userTimerange.Start(),
 		Earliest:   earliest,
 		Resolution: userTimerange.Resolution(),
+		Mutex:      &sync.Mutex{},
 	}
 	if context.Registry == nil {
 		widening.Registry = registry.Default()

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -214,8 +214,30 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 	// so
 	// res >= (end - start) / (slots - 2)
 
+	earliest := new(time.Time)
+	*earliest = userTimerange.Start()
+
+	widening := function.WidestMode{
+		Registry:   context.Registry,
+		Current:    userTimerange.Start(),
+		Earliest:   earliest,
+		Resolution: userTimerange.Resolution(),
+	}
+	if context.Registry == nil {
+		widening.Registry = registry.Default()
+	}
+	for _, expression := range cmd.Expressions {
+		_ = expression.ExpressionDescription(widening) // widen by each expression
+	}
+
+	widenedTimerange, err := api.NewSnappedTimerange(earliest.UnixNano()/1e6, userTimerange.EndMillis(), userTimerange.ResolutionMillis())
+
+	if err != nil {
+		widenedTimerange = userTimerange // TODO: anything else?
+	}
+
 	// Update the timerange by applying the insights of the storage API:
-	chosenResolution, err := context.TimeseriesStorageAPI.ChooseResolution(userTimerange, smallestResolution)
+	chosenResolution, err := context.TimeseriesStorageAPI.ChooseResolution(widenedTimerange, smallestResolution)
 	if err != nil {
 		return Result{}, err
 	}
@@ -312,8 +334,8 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 		for i := range body {
 			if list, ok := result[i].(function.SeriesListValue); ok {
 				body[i] = QueryResult{
-					Query:     cmd.Expressions[i].ExpressionString(function.StringQuery),
-					Name:      cmd.Expressions[i].ExpressionString(function.StringName),
+					Query:     cmd.Expressions[i].ExpressionDescription(function.StringQuery),
+					Name:      cmd.Expressions[i].ExpressionDescription(function.StringName),
 					Type:      "series",
 					Series:    list.Series,
 					Timerange: chosenTimerange,
@@ -322,14 +344,14 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 			}
 			if scalars, err := result[i].ToScalarSet(); err == nil {
 				body[i] = QueryResult{
-					Query:   cmd.Expressions[i].ExpressionString(function.StringQuery),
-					Name:    cmd.Expressions[i].ExpressionString(function.StringName),
+					Query:   cmd.Expressions[i].ExpressionDescription(function.StringQuery),
+					Name:    cmd.Expressions[i].ExpressionDescription(function.StringName),
 					Type:    "scalars",
 					Scalars: scalars,
 				}
 				continue
 			}
-			return Result{}, fmt.Errorf("query %s does not result in a timeseries or scalar.", cmd.Expressions[i].ExpressionString(function.StringQuery))
+			return Result{}, fmt.Errorf("query %s does not result in a timeseries or scalar.", cmd.Expressions[i].ExpressionDescription(function.StringQuery))
 		}
 
 		return Result{
@@ -337,6 +359,7 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 			Metadata: map[string]interface{}{
 				"description": description,
 				"notes":       evaluationContext.Notes(),
+				"resolution":  chosenResolution,
 			},
 		}, nil
 	}

--- a/query/command/command.go
+++ b/query/command/command.go
@@ -233,7 +233,9 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 	widenedTimerange, err := api.NewSnappedTimerange(earliest.UnixNano()/1e6, userTimerange.EndMillis(), userTimerange.ResolutionMillis())
 
 	if err != nil {
-		widenedTimerange = userTimerange // TODO: anything else?
+		// If the timerange is invalid, just fall back on the user's.
+		// It's unlikely that this can actually occur; but just to be safe, it's an easy fallback.
+		widenedTimerange = userTimerange
 	}
 
 	// Update the timerange by applying the insights of the storage API:
@@ -334,8 +336,8 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 		for i := range body {
 			if list, ok := result[i].(function.SeriesListValue); ok {
 				body[i] = QueryResult{
-					Query:     cmd.Expressions[i].ExpressionDescription(function.StringQuery),
-					Name:      cmd.Expressions[i].ExpressionDescription(function.StringName),
+					Query:     cmd.Expressions[i].ExpressionDescription(function.StringQuery()),
+					Name:      cmd.Expressions[i].ExpressionDescription(function.StringName()),
 					Type:      "series",
 					Series:    list.Series,
 					Timerange: chosenTimerange,
@@ -344,8 +346,8 @@ func (cmd *SelectCommand) Execute(context ExecutionContext) (Result, error) {
 			}
 			if scalars, err := result[i].ToScalarSet(); err == nil {
 				body[i] = QueryResult{
-					Query:   cmd.Expressions[i].ExpressionDescription(function.StringQuery),
-					Name:    cmd.Expressions[i].ExpressionDescription(function.StringName),
+					Query:   cmd.Expressions[i].ExpressionDescription(function.StringQuery()),
+					Name:    cmd.Expressions[i].ExpressionDescription(function.StringName()),
 					Type:    "scalars",
 					Scalars: scalars,
 				}

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -44,7 +44,7 @@ func (expr Duration) ActualEvaluate(context function.EvaluationContext) (functio
 }
 
 func (expr Duration) ExpressionDescription(mode function.DescriptionMode) string {
-	if mode == function.StringMemoization {
+	if mode == function.StringMemoization() {
 		return fmt.Sprintf("%#v", expr)
 	}
 	return expr.Source
@@ -63,7 +63,7 @@ func (expr Scalar) ActualEvaluate(context function.EvaluationContext) (function.
 }
 
 func (expr Scalar) ExpressionDescription(mode function.DescriptionMode) string {
-	if mode == function.StringMemoization {
+	if mode == function.StringMemoization() {
 		return fmt.Sprintf("%#v", expr)
 	}
 	return fmt.Sprintf("%+v", expr.Value)
@@ -82,7 +82,7 @@ func (expr String) ActualEvaluate(context function.EvaluationContext) (function.
 }
 
 func (expr String) ExpressionDescription(mode function.DescriptionMode) string {
-	if mode == function.StringMemoization {
+	if mode == function.StringMemoization() {
 		return fmt.Sprintf("%#v", expr)
 	}
 	return fmt.Sprintf("%q", expr.Value)
@@ -133,7 +133,7 @@ func (expr *MetricFetchExpression) ActualEvaluate(context function.EvaluationCon
 }
 
 func (expr *MetricFetchExpression) ExpressionDescription(mode function.DescriptionMode) string {
-	if mode == function.StringMemoization {
+	if mode == function.StringMemoization() {
 		return fmt.Sprintf("fetch[%q][%s]", expr.MetricName, expr.Predicate.Query())
 	}
 	if expr.Predicate.Query() == "true" {
@@ -225,10 +225,10 @@ func (expr *AnnotationExpression) Evaluate(context function.EvaluationContext) (
 }
 
 func (expr *AnnotationExpression) ExpressionDescription(mode function.DescriptionMode) string {
-	if mode == function.StringName {
+	if mode == function.StringName() {
 		return expr.Annotation
 	}
-	if mode == function.StringMemoization {
+	if mode == function.StringMemoization() {
 		return expr.Expression.ExpressionDescription(mode) // annotations can be ignored for memoization purposes since they don't modify their input
 	}
 	return fmt.Sprintf("%s {%s}", expr.Expression.ExpressionDescription(mode), expr.Annotation)

--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -31,30 +31,38 @@ import (
 // ===============
 
 type Duration struct {
-	Literal  string
+	Source   string
 	Duration time.Duration
 }
 
-func (expr Duration) ActualEvaluate(context function.EvaluationContext) (function.Value, error) {
-	return function.NewDurationValue(expr.Literal, expr.Duration), nil
+func (expr Duration) Literal() interface{} {
+	return expr.Duration
 }
 
-func (expr Duration) ExpressionString(mode function.DescriptionMode) string {
+func (expr Duration) ActualEvaluate(context function.EvaluationContext) (function.Value, error) {
+	return function.NewDurationValue(expr.Source, expr.Duration), nil
+}
+
+func (expr Duration) ExpressionDescription(mode function.DescriptionMode) string {
 	if mode == function.StringMemoization {
 		return fmt.Sprintf("%#v", expr)
 	}
-	return expr.Literal
+	return expr.Source
 }
 
 type Scalar struct {
 	Value float64
 }
 
+func (expr Scalar) Literal() interface{} {
+	return expr.Value
+}
+
 func (expr Scalar) ActualEvaluate(context function.EvaluationContext) (function.Value, error) {
 	return function.ScalarValue(expr.Value), nil
 }
 
-func (expr Scalar) ExpressionString(mode function.DescriptionMode) string {
+func (expr Scalar) ExpressionDescription(mode function.DescriptionMode) string {
 	if mode == function.StringMemoization {
 		return fmt.Sprintf("%#v", expr)
 	}
@@ -65,11 +73,15 @@ type String struct {
 	Value string
 }
 
+func (expr String) Literal() interface{} {
+	return expr.Value
+}
+
 func (expr String) ActualEvaluate(context function.EvaluationContext) (function.Value, error) {
 	return function.StringValue(expr.Value), nil
 }
 
-func (expr String) ExpressionString(mode function.DescriptionMode) string {
+func (expr String) ExpressionDescription(mode function.DescriptionMode) string {
 	if mode == function.StringMemoization {
 		return fmt.Sprintf("%#v", expr)
 	}
@@ -120,7 +132,7 @@ func (expr *MetricFetchExpression) ActualEvaluate(context function.EvaluationCon
 	return function.SeriesListValue(seriesList), nil
 }
 
-func (expr *MetricFetchExpression) ExpressionString(mode function.DescriptionMode) string {
+func (expr *MetricFetchExpression) ExpressionDescription(mode function.DescriptionMode) string {
 	if mode == function.StringMemoization {
 		return fmt.Sprintf("fetch[%q][%s]", expr.MetricName, expr.Predicate.Query())
 	}
@@ -171,10 +183,24 @@ func functionFormatString(argumentStrings []string, f FunctionExpression) string
 	return fmt.Sprintf("%s(%s%s)", f.FunctionName, argumentString, groupString)
 }
 
-func (expr *FunctionExpression) ExpressionString(mode function.DescriptionMode) string {
+func (expr *FunctionExpression) ExpressionDescription(mode function.DescriptionMode) string {
+	if widest, ok := mode.(function.WidestMode); ok {
+		// Handle "widening" here
+		if registered, ok := widest.Registry.GetFunction(expr.FunctionName); ok {
+			if metricFunction, ok := registered.(function.MetricFunction); ok {
+				if metricFunction.Widen != nil {
+					widest.Current = metricFunction.Widen(widest, expr.Arguments)
+				}
+			}
+		}
+		for _, argument := range expr.Arguments {
+			argument.ExpressionDescription(widest)
+		}
+		return ""
+	}
 	argumentStrings := []string{}
 	for i := range expr.Arguments {
-		argumentStrings = append(argumentStrings, expr.Arguments[i].ExpressionString(mode))
+		argumentStrings = append(argumentStrings, expr.Arguments[i].ExpressionDescription(mode))
 	}
 	return functionFormatString(argumentStrings, *expr)
 }
@@ -184,20 +210,28 @@ type AnnotationExpression struct {
 	Annotation string
 }
 
+func (expr *AnnotationExpression) Literal() interface{} {
+	literalExpression, ok := expr.Expression.(function.LiteralExpression)
+	if !ok {
+		return nil
+	}
+	return literalExpression.Literal()
+}
+
 // Evaluate evalutes the underlying expression without memoization, since its
 // child expression should handle memoization itself.
 func (expr *AnnotationExpression) Evaluate(context function.EvaluationContext) (function.Value, error) {
 	return expr.Expression.Evaluate(context)
 }
 
-func (expr *AnnotationExpression) ExpressionString(mode function.DescriptionMode) string {
+func (expr *AnnotationExpression) ExpressionDescription(mode function.DescriptionMode) string {
 	if mode == function.StringName {
 		return expr.Annotation
 	}
 	if mode == function.StringMemoization {
-		return expr.Expression.ExpressionString(mode) // annotations can be ignored for memoization purposes since they don't modify their input
+		return expr.Expression.ExpressionDescription(mode) // annotations can be ignored for memoization purposes since they don't modify their input
 	}
-	return fmt.Sprintf("%s {%s}", expr.Expression.ExpressionString(mode), expr.Annotation)
+	return fmt.Sprintf("%s {%s}", expr.Expression.ExpressionDescription(mode), expr.Annotation)
 }
 
 // Auxiliary functions

--- a/query/parser/parser.go
+++ b/query/parser/parser.go
@@ -589,7 +589,7 @@ func (p *Parser) addAndPredicate() {
 
 func (p *Parser) addDurationNode(value string) {
 	duration, err := function.StringToDuration(value)
-	p.pushExpression(function.Memoize(expression.Duration{Literal: value, Duration: duration}))
+	p.pushExpression(function.Memoize(expression.Duration{Source: value, Duration: duration}))
 	if err != nil {
 		p.flagSyntaxError(SyntaxError{
 			token:   value,

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -38,7 +38,7 @@ type LiteralExpression struct {
 
 func (le LiteralExpression) ExpressionDescription(mode function.DescriptionMode) string {
 	switch mode {
-	case function.StringName:
+	case function.StringName():
 		return "<literal expression>"
 	}
 	return fmt.Sprintf("%+v", le)
@@ -59,7 +59,7 @@ type LiteralSeriesExpression struct {
 
 func (lse LiteralSeriesExpression) ExpressionDescription(mode function.DescriptionMode) string {
 	switch mode {
-	case function.StringName:
+	case function.StringName():
 		return "<literal series expression>"
 	}
 	return fmt.Sprintf("%+v", lse)

--- a/query/tests/expression_test.go
+++ b/query/tests/expression_test.go
@@ -36,7 +36,7 @@ type LiteralExpression struct {
 	Values []float64
 }
 
-func (le LiteralExpression) ExpressionString(mode function.DescriptionMode) string {
+func (le LiteralExpression) ExpressionDescription(mode function.DescriptionMode) string {
 	switch mode {
 	case function.StringName:
 		return "<literal expression>"
@@ -57,7 +57,7 @@ type LiteralSeriesExpression struct {
 	list api.SeriesList
 }
 
-func (lse LiteralSeriesExpression) ExpressionString(mode function.DescriptionMode) string {
+func (lse LiteralSeriesExpression) ExpressionDescription(mode function.DescriptionMode) string {
 	switch mode {
 	case function.StringName:
 		return "<literal series expression>"

--- a/query/tests/resolution_edge_test.go
+++ b/query/tests/resolution_edge_test.go
@@ -1,0 +1,112 @@
+// Copyright 2015 - 2016 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/square/metrics/api"
+	"github.com/square/metrics/query/command"
+	"github.com/square/metrics/query/parser"
+	"github.com/square/metrics/testing_support/mocks"
+	"github.com/square/metrics/timeseries"
+)
+
+var fixedNow = time.Now().Round(30 * time.Second)
+var fullResolutionCutoff = fixedNow.Add(-24 * time.Hour)
+
+type testResolutionStorage struct {
+}
+
+func (t testResolutionStorage) ChooseResolution(requested api.Timerange, lowerBound time.Duration) (time.Duration, error) {
+	if requested.Start().Before(fullResolutionCutoff) {
+		return 5 * time.Minute, nil
+	}
+	return 30 * time.Second, nil
+}
+func (t testResolutionStorage) FetchSingleTimeseries(request timeseries.FetchRequest) (api.Timeseries, error) {
+	if request.Timerange.Resolution() == 30*time.Second && request.Timerange.Start().Before(fullResolutionCutoff) {
+		return api.Timeseries{}, fmt.Errorf("querying 30s resolution data prior to 24h ago (over by %v)", fullResolutionCutoff.Sub(request.Timerange.Start()))
+	}
+	return api.Timeseries{
+		Values: make([]float64, request.Timerange.Slots()),
+	}, nil
+}
+func (t testResolutionStorage) FetchMultipleTimeseries(request timeseries.FetchMultipleRequest) (api.SeriesList, error) {
+	requests := request.ToSingle()
+	series := make([]api.Timeseries, len(requests))
+	for i := range requests {
+		result, err := t.FetchSingleTimeseries(requests[i])
+		if err != nil {
+			return api.SeriesList{}, err
+		}
+		series[i] = result
+	}
+	return api.SeriesList{
+		Series: series,
+	}, nil
+}
+
+func (t testResolutionStorage) CheckHealthy() error {
+	return nil
+}
+
+func relative(format string, durations ...time.Duration) string {
+	args := make([]interface{}, len(durations))
+	for i := range durations {
+		args[i] = fixedNow.Add(durations[i]).Format(time.UnixDate)
+	}
+	return fmt.Sprintf(format, args...)
+}
+
+func TestResolutionEdge(t *testing.T) {
+	queries := []string{
+		relative(`select foo from '%s' to '%s'`, -24*time.Hour, 0),
+		relative(`select foo from '%s' to '%s'`, -24*time.Hour-time.Minute, 0),
+		`select foo | transform.timeshift(-5m) from -1d to now`,
+		`select foo | transform.moving_average(5m) from -1d to now`,
+		`select foo | forecast.linear(5m) from -1d to now`,
+	}
+	timerange, err := api.NewSnappedTimerange(300000000, 300000000, 30000)
+	if err != nil {
+		t.Fatalf("Error creating test timerange: %s", err.Error())
+	}
+	combo := mocks.NewComboAPI(
+		timerange,
+		api.Timeseries{TagSet: api.TagSet{"metric": "foo"}, Values: []float64{math.NaN()}},
+	)
+	for _, query := range queries {
+		parsed, err := parser.Parse(query)
+		if err != nil {
+			t.Errorf("parsing error for query %q: %s", query, err.Error())
+			continue
+		}
+		_, err = parsed.Execute(command.ExecutionContext{
+			TimeseriesStorageAPI: testResolutionStorage{},
+			MetricMetadataAPI:    combo,
+			FetchLimit:           1000,
+			SlotLimit:            1000000, // want this to not be a concern
+			Ctx:                  context.Background(),
+		})
+		if err != nil {
+			t.Errorf("unexpected error executing query %q: %s", query, err.Error())
+		}
+	}
+}

--- a/query/tests/transformation_test.go
+++ b/query/tests/transformation_test.go
@@ -72,7 +72,7 @@ func TestMovingAverage(t *testing.T) {
 		GroupBy:      []string{},
 		Arguments: []function.Expression{
 			function.Memoize(&expression.MetricFetchExpression{MetricName: "series", Predicate: predicate.TruePredicate{}}),
-			function.Memoize(expression.Duration{Literal: "300ms", Duration: 300 * time.Millisecond}),
+			function.Memoize(expression.Duration{Source: "300ms", Duration: 300 * time.Millisecond}),
 		},
 	})
 


### PR DESCRIPTION
When doing a query like

```
select
transform.moving_average(foo, 5m)
from -1d to now
```

when the edge of availability of full resolution data is at `-1d`, since you'd fetch data beyond that point with the moving average, the query would suddenly error.

Now, by inspecting the query (using annotations on the registered functions) it's possible to automatically adjust the query's resolution, increased to (say) `5m`, so that no error occurs.

It's intelligent enough to recognize that

```
select
transform.moving_average(foo, 5m) | transform.moving_average(12m)
from -1d to now
```

extends by a total of 17m, and that

```
select
transform.moving_average(foo, 5m) | transform.timeshift(-7m)
from -1d to now
```

doesn't extend it at all.

@drcapulet 
